### PR TITLE
chore(ci): guard claude-ready label with maintainer allowlist

### DIFF
--- a/.github/workflows/guard-claude-ready.yml
+++ b/.github/workflows/guard-claude-ready.yml
@@ -1,0 +1,39 @@
+name: Guard claude-ready label
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  guard:
+    if: github.event.label.name == 'claude-ready'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce guardian allowlist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          GUARDIANS: ${{ vars.CLAUDE_READY_GUARDIANS }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          allowed=$(printf '%s' "${GUARDIANS:-}" | tr ',' '\n' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]' | grep -v '^$' | sort -u || true)
+          actor_lc=$(printf '%s' "$ACTOR" | tr '[:upper:]' '[:lower:]')
+
+          if [ -n "$allowed" ] && printf '%s\n' "$allowed" | grep -qx "$actor_lc"; then
+            echo "Actor $ACTOR is a guardian; claude-ready allowed."
+            exit 0
+          fi
+
+          if [ -z "$allowed" ]; then
+            reason="the \`CLAUDE_READY_GUARDIANS\` allowlist is not configured"
+          else
+            reason="\`$ACTOR\` is not in the maintainer allowlist"
+          fi
+
+          gh issue edit "$ISSUE" --repo "$REPO" --remove-label "claude-ready"
+          gh issue comment "$ISSUE" --repo "$REPO" --body "Removed \`claude-ready\`: $reason. A maintainer will review and re-label if appropriate."


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/guard-claude-ready.yml` that fires on every issue label event.
- If the label is `claude-ready` and the actor isn't in the `CLAUDE_READY_GUARDIANS` repo variable, the workflow removes the label and posts an explanatory comment.
- Repo variable already seeded with `HussienH`. Add maintainers later with: `gh variable set CLAUDE_READY_GUARDIANS --repo finlynq/finlynq --body "HussienH,other-user"`.

## Why
Defense in depth on top of GitHub's native triage-role permission. The agent loop (`drain-claude-ready` skill) picks up any issue with `claude-ready` — this guarantees the queue only ever contains issues a maintainer has explicitly flagged, even if a triage role is granted in the future.

## Behavior
- Maintainer applies `claude-ready` → label stays, no comment.
- Anyone else (including future bots / triagers) applies it → label is removed within seconds + a comment explains why.
- If the variable is unset, the workflow fails closed (removes the label) — no silent allow-all state.

## Test plan
- [ ] Merge, then on a throwaway issue have a non-guardian apply `claude-ready` and confirm it gets stripped.
- [ ] Apply `claude-ready` as `HussienH` and confirm it sticks.
- [ ] Confirm the `review-plans-to-issues` skill (runs as `HussienH` via `gh`) still labels successfully.