### PR TITLE
fix(security): restore B7 getDEK signature + fix B6/B7 test type errors

### DIFF
--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -75,7 +75,7 @@ export async function GET(request: NextRequest) {
   const auth = await requireAuth(request);
   if (!auth.authenticated) return auth.response;
   const { userId, sessionId } = auth.context;
-  const dek = sessionId ? getDEK(sessionId) : null;
+  const dek = sessionId ? getDEK(sessionId, userId) : null;
 
   const params = request.nextUrl.searchParams;
   const search = params.get("search") ?? undefined;

--- a/tests/auth/security-b6.test.ts
+++ b/tests/auth/security-b6.test.ts
@@ -80,15 +80,15 @@ describe("getTransport prod refusal (M-17)", () => {
   });
 
   afterEach(() => {
-    if (originalEnv === undefined) delete process.env.NODE_ENV;
-    else process.env.NODE_ENV = originalEnv;
-    if (originalSmtp === undefined) delete process.env.SMTP_HOST;
-    else process.env.SMTP_HOST = originalSmtp;
+    vi.unstubAllEnvs();
+    if (originalSmtp === undefined) vi.stubEnv("SMTP_HOST", "");
+    else vi.stubEnv("SMTP_HOST", originalSmtp);
+    if (originalEnv !== undefined) vi.stubEnv("NODE_ENV", originalEnv);
   });
 
   it("sendEmail throws in production when SMTP_HOST is unset", async () => {
-    delete process.env.SMTP_HOST;
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("SMTP_HOST", "");
+    vi.stubEnv("NODE_ENV", "production");
     // Re-import to bypass any prior module cache that closed over a different env.
     vi.resetModules();
     const { sendEmail } = await import("@/lib/email");
@@ -98,8 +98,8 @@ describe("getTransport prod refusal (M-17)", () => {
   });
 
   it("sendEmail falls back to console in development when SMTP_HOST is unset", async () => {
-    delete process.env.SMTP_HOST;
-    process.env.NODE_ENV = "development";
+    vi.stubEnv("SMTP_HOST", "");
+    vi.stubEnv("NODE_ENV", "development");
     vi.resetModules();
     const { sendEmail } = await import("@/lib/email");
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/tests/auth/wipe-clears-mfa.test.ts
+++ b/tests/auth/wipe-clears-mfa.test.ts
@@ -38,7 +38,13 @@ vi.mock("@/db", () => {
     return c;
   };
 
-  const tx = {
+  type TxStub = {
+    select: () => unknown;
+    delete: () => unknown;
+    update: () => unknown;
+    insert: () => unknown;
+  };
+  const tx: TxStub = {
     select: () => makeChain([]),
     delete: () => makeChain([]),
     update: () => makeChain([]),
@@ -46,7 +52,7 @@ vi.mock("@/db", () => {
   };
   return {
     db: {
-      transaction: async (fn: (tx: typeof tx) => Promise<unknown>) =>
+      transaction: async (fn: (tx: TxStub) => Promise<unknown>) =>
         fn(tx),
       // Outer pre-tx select for mcpUploads
       select: () => makeChain([]),


### PR DESCRIPTION
Three minimal fixes to unblock the remaining security PRs (B5/B8/B9/B10) which all fail CI on dev's current state. See commit message for the per-fix rationale.