### PR TITLE
fix(deploy): repair migration-runner SQL bug blocking all dev deploys

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -177,20 +177,22 @@ if [ -d "$MIGRATIONS_DIR" ]; then
   shopt -s nullglob
   for file in "$MIGRATIONS_DIR"/*.sql; do
     version="$(basename "$file" .sql)"
-    # Filename gate: only [A-Za-z0-9_-]. Defense-in-depth — the SQL below
-    # uses psql's `:'ver'` parameter-binding to quote the value, so a
-    # malicious filename couldn't escape the literal even without this
-    # check. Keeping the regex anyway to fail fast on obviously-wrong files.
+    # Filename gate: only [A-Za-z0-9_-]. This is the sole barrier against
+    # SQL injection from a hostile migration filename — the SQL below
+    # interpolates $version directly because psql's `:'ver'` parameter
+    # substitution is a psql-script-only feature and is NOT processed by
+    # the server when passed via -c. The regex permits no quote, semicolon,
+    # backslash, or whitespace, so direct interpolation is safe.
     if ! [[ "$version" =~ ^[A-Za-z0-9_-]+$ ]]; then
       echo "==> ERROR: migration filename '$version' contains unsafe characters; rename to [A-Za-z0-9_-] only."
       exit 1
     fi
-    exists=$(psql "$DB_URL" -tA -v ver="$version" -c "SELECT 1 FROM schema_migrations WHERE version = :'ver';")
+    exists=$(psql "$DB_URL" -tA -c "SELECT 1 FROM schema_migrations WHERE version = '$version';")
     if [ "$exists" = "1" ]; then continue; fi
     echo "==> Applying migration: $version"
-    psql "$DB_URL" -v ON_ERROR_STOP=1 -v ver="$version" --single-transaction \
+    psql "$DB_URL" -v ON_ERROR_STOP=1 --single-transaction \
       -f "$file" \
-      -c "INSERT INTO schema_migrations (version) VALUES (:'ver');"
+      -c "INSERT INTO schema_migrations (version) VALUES ('$version');"
     APPLIED_COUNT=$((APPLIED_COUNT + 1))
   done
   shopt -u nullglob


### PR DESCRIPTION
## Summary

- `deploy.sh` migration runner uses `psql -c \"... :'ver' ...\"` for version bookkeeping, but `psql -c` is **server-only** and does not process psql's client-side variable substitution. The literal `:'ver'` string was being sent to postgres, which rejected it with `syntax error at or near \":\"`.
- Every dev deploy since B1 (#164) merged has crashed in the migration step. **None of the 11 security PRs (#164, #165, #166, #167, #168, #169, #170, #171, #172, #173, #174) are actually live on dev** — dev is still running the build from 2026-05-06 18:22 UTC (commit c708138c).
- Prod hasn't tried to deploy this code path yet (last prod deploy 2026-05-06), but would have hit the same bug on the next merge from dev.

## What changed

- `deploy.sh`: replace `:'ver'` with direct shell interpolation `'$version'`. The `version` value is gated immediately above by `^[A-Za-z0-9_-]+$`, which permits no quote, semicolon, backslash, or whitespace — so no SQL-injection vector remains. Updated the comment to document this is the sole barrier (not defense-in-depth).
- One file changed, 9 insertions / 7 deletions.

## Why this is safe

- No new code paths; same SQL operations, same regex gate.
- `version` regex `^[A-Za-z0-9_-]+$` is unchanged. It already matches the filename charset documented in CLAUDE.md and `docs/migrations.md`.
- The rejected characters (single quote, semicolon, backslash, NUL, whitespace) are exactly the ones that would let a malicious filename break out of the SQL literal.

## Test plan

- [x] Diff inspected; only `deploy.sh` modified.
- [ ] CI typecheck + build pass (no app code touched, should be no-ops).
- [ ] After merge: confirm Deploy Dev workflow goes green.
- [ ] After deploy: confirm `revoked_jtis` table exists in dev DB (it's the only pending migration in `pf-app/scripts/migrations/`).
- [ ] After deploy: re-run security verification against dev, which has been blocked on this fix.

## Related

- Original bug introduced in #164 (B1 — Docker / deps / CI).
- Blocks verification of #164–#174 on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)