### PR TITLE
fix(security): make CSRF gate proxy-aware (closes #176)

### DIFF
--- a/src/lib/request-origins.ts
+++ b/src/lib/request-origins.ts
@@ -1,0 +1,61 @@
+/**
+ * Resolve the set of origins that should be treated as "same as us" when
+ * deciding whether to allow a state-changing cookie-auth request through
+ * the CSRF gate.
+ *
+ * Behind a reverse proxy (Caddy / nginx / Cloudflare) the Next.js process
+ * binds on `http://localhost:<port>` while the public URL is on `https`.
+ * `NextRequest.nextUrl.origin` is reconstructed from the inbound URL and
+ * does not consult `X-Forwarded-Proto`, so it returns `http://...` even
+ * though the browser sees `https://...`. The browser sends the public
+ * `Origin: https://...` and the membership check fails — every same-origin
+ * cookie POST 403s, including legitimate ones (issue #176).
+ *
+ * Fix: include the proxy-reported origin (built from `X-Forwarded-Proto`
+ * + the inbound `Host`) alongside the URL-derived origin in the allow
+ * list. Self-hosted users on a single-process binding (no proxy, no
+ * `X-Forwarded-Proto` header) keep the previous behavior with no env
+ * var to set.
+ *
+ * Threat model: CSRF is a browser-side concern. A browser cannot spoof
+ * `X-Forwarded-Proto` — that header is set by the trusted reverse proxy.
+ * An attacker bypassing the proxy and hitting the backend directly is a
+ * different threat and is not what the CSRF gate defends against. Even
+ * so, we whitelist the protocol value to "http" / "https" and reuse the
+ * URL-derived host (NOT `X-Forwarded-Host`, which IS spoofable end-to-
+ * end), so a malicious header from inside the LAN cannot construct
+ * arbitrary origins.
+ */
+
+export interface OriginRequestParts {
+  /** What `NextRequest.nextUrl.origin` would return — scheme://host[:port] */
+  fallbackOrigin: string;
+  /** What `NextRequest.nextUrl.host` would return — host[:port] (no scheme) */
+  fallbackHost: string;
+  /** Header lookup. Case-insensitive in real `Headers`; we lowercase here too. */
+  getHeader: (name: string) => string | null;
+}
+
+/**
+ * Returns the set of origins that count as "us" for this request, in
+ * canonical `scheme://host[:port]` form. Always includes the URL-derived
+ * fallback. May add a proxy-derived origin if `X-Forwarded-Proto` is
+ * present and differs from the fallback's scheme.
+ */
+export function getRequestOrigins(parts: OriginRequestParts): string[] {
+  const { fallbackOrigin, fallbackHost, getHeader } = parts;
+  const origins = new Set<string>([fallbackOrigin]);
+
+  const fwdProto = getHeader("x-forwarded-proto");
+  if (fwdProto === "https" || fwdProto === "http") {
+    // Use the existing host (browser's Host header — same as what
+    // nextUrl.host already reflects). We deliberately do NOT trust
+    // X-Forwarded-Host; an upstream proxy hop or a misconfigured edge
+    // could inject an arbitrary host there.
+    if (fallbackHost) {
+      origins.add(`${fwdProto}://${fallbackHost}`);
+    }
+  }
+
+  return Array.from(origins);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import { getRequestOrigins } from "@/lib/request-origins";
 
 /**
  * Allowed origins for managed (hosted) mode.
@@ -67,6 +68,21 @@ function getCorsHeaders(request: NextRequest): Record<string, string> {
   return {};
 }
 
+/**
+ * Resolve the origins that count as "us" for this request — both the
+ * URL-derived `nextUrl.origin` AND, if the request arrived via a reverse
+ * proxy, the proxy-reported origin reconstructed from `X-Forwarded-Proto`
+ * + the inbound Host. See [src/lib/request-origins.ts] for the full
+ * threat-model rationale (issue #176).
+ */
+function getOwnOriginsFor(request: NextRequest): string[] {
+  return getRequestOrigins({
+    fallbackOrigin: request.nextUrl.origin,
+    fallbackHost: request.nextUrl.host,
+    getHeader: (name) => request.headers.get(name),
+  });
+}
+
 const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 const AUTH_COOKIE = "pf_session";
 
@@ -112,8 +128,15 @@ function csrfCheck(request: NextRequest): NextResponse | null {
   const sessionCookie = request.cookies.get(AUTH_COOKIE);
   if (!sessionCookie) return null;
 
-  const ownOrigin = request.nextUrl.origin;
-  const allowed = new Set<string>([ownOrigin, ...MANAGED_ALLOWED_ORIGINS]);
+  // Includes both the URL-derived origin AND the proxy-reported origin
+  // when behind Caddy/nginx (X-Forwarded-Proto). See issue #176 — without
+  // the proxy-derived entry, every same-origin POST 403s because Next.js
+  // sees the binding as `http://localhost:<port>` while the browser sends
+  // `Origin: https://...`.
+  const allowed = new Set<string>([
+    ...getOwnOriginsFor(request),
+    ...MANAGED_ALLOWED_ORIGINS,
+  ]);
 
   const origin = request.headers.get("origin");
   if (origin) {

--- a/tests/request-origins.test.ts
+++ b/tests/request-origins.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for getRequestOrigins (issue #176).
+ *
+ * The helper resolves the set of origins that count as "us" for a CSRF
+ * gate / CORS check. It must (a) always include the URL-derived fallback
+ * origin so single-process self-hosted setups keep working, and (b) when
+ * an `X-Forwarded-Proto` header is present, also include the proxy-
+ * reported origin so deployments behind Caddy / nginx don't 403 every
+ * same-origin request.
+ */
+import { describe, it, expect } from "vitest";
+import { getRequestOrigins } from "@/lib/request-origins";
+
+function makeHeaders(input: Record<string, string>): (n: string) => string | null {
+  const lookup = new Map(Object.entries(input).map(([k, v]) => [k.toLowerCase(), v]));
+  return (name: string) => lookup.get(name.toLowerCase()) ?? null;
+}
+
+describe("getRequestOrigins", () => {
+  it("returns only the fallback origin when no X-Forwarded-Proto is present", () => {
+    const origins = getRequestOrigins({
+      fallbackOrigin: "http://localhost:3000",
+      fallbackHost: "localhost:3000",
+      getHeader: makeHeaders({}),
+    });
+    expect(origins).toEqual(["http://localhost:3000"]);
+  });
+
+  it("adds the proxy-reported origin behind a TLS-terminating reverse proxy (the #176 case)", () => {
+    // Backend bound on http://dev.finlynq.com (Next.js's nextUrl.origin
+    // because Caddy passes the Host header through). Browser sees https.
+    const origins = getRequestOrigins({
+      fallbackOrigin: "http://dev.finlynq.com",
+      fallbackHost: "dev.finlynq.com",
+      getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
+    });
+    expect(origins).toContain("http://dev.finlynq.com"); // fallback preserved
+    expect(origins).toContain("https://dev.finlynq.com"); // proxy-reported added
+  });
+
+  it("dedupes when X-Forwarded-Proto matches the fallback scheme", () => {
+    const origins = getRequestOrigins({
+      fallbackOrigin: "https://app.example.com",
+      fallbackHost: "app.example.com",
+      getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
+    });
+    expect(origins).toEqual(["https://app.example.com"]);
+  });
+
+  it("ignores X-Forwarded-Proto values that aren't 'http' or 'https'", () => {
+    // Reject "javascript", arbitrary schemes, comma-separated lists, etc.
+    for (const bad of ["javascript", "ftp", "https,http", "HTTPS", " https", ""]) {
+      const origins = getRequestOrigins({
+        fallbackOrigin: "http://app.example.com",
+        fallbackHost: "app.example.com",
+        getHeader: makeHeaders({ "X-Forwarded-Proto": bad }),
+      });
+      expect(origins).toEqual(["http://app.example.com"]);
+    }
+  });
+
+  it("does NOT trust X-Forwarded-Host even when it differs from the fallback host", () => {
+    // X-Forwarded-Host is forgeable end-to-end (any forward proxy or a
+    // misconfigured edge can inject it). The CSRF allowlist only uses
+    // the request's actual Host (already reflected in fallbackHost).
+    const origins = getRequestOrigins({
+      fallbackOrigin: "http://app.example.com",
+      fallbackHost: "app.example.com",
+      getHeader: makeHeaders({
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "attacker.example.com",
+      }),
+    });
+    expect(origins).toContain("https://app.example.com");
+    expect(origins).not.toContain("https://attacker.example.com");
+    expect(origins).not.toContain("http://attacker.example.com");
+  });
+
+  it("preserves the port in the proxy-reported origin", () => {
+    const origins = getRequestOrigins({
+      fallbackOrigin: "http://app.example.com:8443",
+      fallbackHost: "app.example.com:8443",
+      getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
+    });
+    expect(origins).toContain("https://app.example.com:8443");
+  });
+
+  it("does nothing when fallbackHost is empty (defense-in-depth)", () => {
+    const origins = getRequestOrigins({
+      fallbackOrigin: "http://app.example.com",
+      fallbackHost: "",
+      getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
+    });
+    expect(origins).toEqual(["http://app.example.com"]);
+  });
+});


### PR DESCRIPTION
Closes #176.

## Summary

Behind a TLS-terminating reverse proxy, `NextRequest.nextUrl.origin` returns `http://dev.finlynq.com` because the Next.js process binds on `localhost:<port>`. The browser sends `Origin: https://dev.finlynq.com`. They don't match → every same-origin cookie POST 403s.

This breaks logout, MFA setup, transaction edits, account creation, and **functionally disables H-5 JWT revocation** — confirmed in a real Chrome session against dev: logout returned 403, JWT never entered `revoked_jtis`, captured cookie still authenticated `/api/auth/session` 200.

## What changed

- Extracted a pure `getRequestOrigins()` helper into `src/lib/request-origins.ts`. It always includes the URL-derived fallback (preserves single-process self-hosted behavior with no env var) and **adds** a proxy-reported origin if `X-Forwarded-Proto` is `http` / `https`.
- Wired it into `csrfCheck` in `src/middleware.ts`.
- 7 unit tests in `tests/request-origins.test.ts` covering: no-proxy fallback, the #176 proxy case, dedup when scheme matches, garbage-proto rejection (including `javascript`, `https,http`, leading whitespace), explicit `X-Forwarded-Host` non-trust, port preservation, empty-host defense.

## Why this is safe

- `X-Forwarded-Proto` is set by the trusted reverse proxy. Browsers cannot spoof it across a same-origin fetch — that's the primary CSRF threat model.
- Whitelist of `"http"` / `"https"` only — exact-match, no comma-lists, no case fuzz.
- Reuse the URL-derived host (already populated from the inbound `Host` header). We deliberately do NOT trust `X-Forwarded-Host` because an upstream forward proxy or misconfigured edge could inject an arbitrary one. The dedicated test `does NOT trust X-Forwarded-Host` pins this invariant.
- An attacker bypassing the reverse proxy and hitting the backend directly is a LAN-level threat that CSRF doesn't defend against.

## Threat-model walk

| Sender | `Origin` | `X-Forwarded-Proto` | Behavior |
|---|---|---|---|
| Browser on `https://dev.finlynq.com` | `https://dev.finlynq.com` | set by Caddy = `https` | allowed origins now include `https://dev.finlynq.com` → ✅ pass |
| Attacker page on `https://attacker.com` | `https://attacker.com` | set by Caddy = `https` | not in allowed set → ❌ 403 csrf-rejected (preserved) |
| Direct localhost hit (LAN attacker) | anything | `https` (forged) | allowed includes `https://<their-Host-header>` only — they'd need to forge Host AND have a valid cookie. CSRF isn't the relevant control here. |

## Test plan

- [x] `npx vitest run tests/request-origins.test.ts` — 7/7 pass locally.
- [x] `npx tsc --noEmit` — clean.
- [ ] CI: typecheck + build
- [ ] After merge + deploy: re-run the runtime tests blocked by #176 (logout actually revokes JWT in `revoked_jtis`, dashboard state-changes succeed, attacker-Origin still 403s).

## Related

- Original review: PR #167 (B5 — middleware CSRF/CSP/CORS validator).
- Knock-on impact: PR #170 H-5 JWT revocation effectively re-enabled.
- Issue: #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)