### PR TITLE
fix(security): use Host header (not nextUrl.host) for proxy-aware CSRF — finishes #176

### DIFF
--- a/src/lib/request-origins.ts
+++ b/src/lib/request-origins.ts
@@ -3,57 +3,78 @@
  * deciding whether to allow a state-changing cookie-auth request through
  * the CSRF gate.
  *
- * Behind a reverse proxy (Caddy / nginx / Cloudflare) the Next.js process
- * binds on `http://localhost:<port>` while the public URL is on `https`.
- * `NextRequest.nextUrl.origin` is reconstructed from the inbound URL and
- * does not consult `X-Forwarded-Proto`, so it returns `http://...` even
- * though the browser sees `https://...`. The browser sends the public
- * `Origin: https://...` and the membership check fails — every same-origin
- * cookie POST 403s, including legitimate ones (issue #176).
+ * Behind a reverse proxy, neither `NextRequest.nextUrl.origin` nor
+ * `nextUrl.host` is reliable:
  *
- * Fix: include the proxy-reported origin (built from `X-Forwarded-Proto`
- * + the inbound `Host`) alongside the URL-derived origin in the allow
- * list. Self-hosted users on a single-process binding (no proxy, no
- * `X-Forwarded-Proto` header) keep the previous behavior with no env
- * var to set.
+ *  1. The Next.js standalone server reads `process.env.HOSTNAME` (typically
+ *     `0.0.0.0` when bound to all interfaces) and reflects it in
+ *     `nextUrl.host`. So even when the browser sends `Host: dev.example.com`,
+ *     `nextUrl.host` returns `0.0.0.0:3000` — useless for origin matching.
+ *  2. The protocol the browser saw (https when behind a TLS-terminating
+ *     proxy) is not reflected in the internal binding (which is plain http).
+ *     Next.js partially compensates by reading `X-Forwarded-Proto` for
+ *     `nextUrl.protocol`, but the host bug above defeats that anyway.
  *
- * Threat model: CSRF is a browser-side concern. A browser cannot spoof
- * `X-Forwarded-Proto` — that header is set by the trusted reverse proxy.
- * An attacker bypassing the proxy and hitting the backend directly is a
- * different threat and is not what the CSRF gate defends against. Even
- * so, we whitelist the protocol value to "http" / "https" and reuse the
- * URL-derived host (NOT `X-Forwarded-Host`, which IS spoofable end-to-
- * end), so a malicious header from inside the LAN cannot construct
- * arbitrary origins.
+ * Fix: derive the public origin from the inbound `Host` header (which the
+ * proxy passes through unchanged from the browser) and the scheme from
+ * `X-Forwarded-Proto` (set by the proxy) — falling back to `nextUrl.protocol`
+ * for self-hosted single-process setups with no proxy.
+ *
+ * Threat model: CSRF defends against a logged-in browser visiting an
+ * attacker page. Browsers always set `Host` to the URL they're hitting
+ * and `Origin` to their page's origin — they cannot mismatch the two
+ * across a same-origin fetch. An attacker bypassing the proxy and hitting
+ * the backend directly is a different (LAN-level) threat that CSRF does
+ * not defend against.
+ *
+ * Defense-in-depth:
+ *  - Whitelist `X-Forwarded-Proto` to "http" or "https" exactly.
+ *  - Sanitize Host header to `[A-Za-z0-9.-]+(:port)?` only — rejects any
+ *    embedded `,` `;` ` ` etc. that would let a misconfigured upstream
+ *    inject a bogus origin.
+ *  - We deliberately do NOT trust `X-Forwarded-Host` because that one IS
+ *    forgeable end-to-end (any forward proxy or misconfigured edge can
+ *    inject it).
  */
 
 export interface OriginRequestParts {
-  /** What `NextRequest.nextUrl.origin` would return — scheme://host[:port] */
+  /** What `NextRequest.nextUrl.origin` returns — kept as a fallback for
+   *  self-hosted setups that don't go through a proxy. */
   fallbackOrigin: string;
-  /** What `NextRequest.nextUrl.host` would return — host[:port] (no scheme) */
-  fallbackHost: string;
-  /** Header lookup. Case-insensitive in real `Headers`; we lowercase here too. */
+  /** What `NextRequest.nextUrl.protocol` returns — `"http:"` or `"https:"`.
+   *  Used to choose a scheme when no `X-Forwarded-Proto` is present. */
+  fallbackProtocol: string;
+  /** The inbound `Host` header (browser's view; proxy passes it through). */
+  hostHeader: string | null;
+  /** Header lookup. Case-insensitive in real `Headers`; pass `(name) =>
+   *  request.headers.get(name)`. */
   getHeader: (name: string) => string | null;
 }
+
+const HOST_RE = /^[A-Za-z0-9.-]+(:\d+)?$/;
 
 /**
  * Returns the set of origins that count as "us" for this request, in
  * canonical `scheme://host[:port]` form. Always includes the URL-derived
- * fallback. May add a proxy-derived origin if `X-Forwarded-Proto` is
- * present and differs from the fallback's scheme.
+ * fallback. Adds a Host-header-derived origin when the Host is well-formed,
+ * using `X-Forwarded-Proto` if present, otherwise the fallback protocol.
  */
 export function getRequestOrigins(parts: OriginRequestParts): string[] {
-  const { fallbackOrigin, fallbackHost, getHeader } = parts;
+  const { fallbackOrigin, fallbackProtocol, hostHeader, getHeader } = parts;
   const origins = new Set<string>([fallbackOrigin]);
 
-  const fwdProto = getHeader("x-forwarded-proto");
-  if (fwdProto === "https" || fwdProto === "http") {
-    // Use the existing host (browser's Host header — same as what
-    // nextUrl.host already reflects). We deliberately do NOT trust
-    // X-Forwarded-Host; an upstream proxy hop or a misconfigured edge
-    // could inject an arbitrary host there.
-    if (fallbackHost) {
-      origins.add(`${fwdProto}://${fallbackHost}`);
+  if (hostHeader && HOST_RE.test(hostHeader)) {
+    const fwdProto = getHeader("x-forwarded-proto");
+    let proto: "http" | "https" | null = null;
+    if (fwdProto === "https" || fwdProto === "http") {
+      proto = fwdProto;
+    } else if (fallbackProtocol === "https:") {
+      proto = "https";
+    } else if (fallbackProtocol === "http:") {
+      proto = "http";
+    }
+    if (proto) {
+      origins.add(`${proto}://${hostHeader}`);
     }
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -69,16 +69,18 @@ function getCorsHeaders(request: NextRequest): Record<string, string> {
 }
 
 /**
- * Resolve the origins that count as "us" for this request — both the
- * URL-derived `nextUrl.origin` AND, if the request arrived via a reverse
- * proxy, the proxy-reported origin reconstructed from `X-Forwarded-Proto`
- * + the inbound Host. See [src/lib/request-origins.ts] for the full
- * threat-model rationale (issue #176).
+ * Resolve the origins that count as "us" for this request. Combines the
+ * URL-derived fallback with a Host-header + X-Forwarded-Proto-derived
+ * origin when the request came in via a reverse proxy. See
+ * [src/lib/request-origins.ts] for the full threat-model rationale and
+ * why `nextUrl.host` alone is unreliable (it reflects HOSTNAME=0.0.0.0
+ * from the systemd unit, not the public hostname). Issue #176.
  */
 function getOwnOriginsFor(request: NextRequest): string[] {
   return getRequestOrigins({
     fallbackOrigin: request.nextUrl.origin,
-    fallbackHost: request.nextUrl.host,
+    fallbackProtocol: request.nextUrl.protocol,
+    hostHeader: request.headers.get("host"),
     getHeader: (name) => request.headers.get(name),
   });
 }

--- a/tests/request-origins.test.ts
+++ b/tests/request-origins.test.ts
@@ -2,11 +2,15 @@
  * Unit tests for getRequestOrigins (issue #176).
  *
  * The helper resolves the set of origins that count as "us" for a CSRF
- * gate / CORS check. It must (a) always include the URL-derived fallback
- * origin so single-process self-hosted setups keep working, and (b) when
- * an `X-Forwarded-Proto` header is present, also include the proxy-
- * reported origin so deployments behind Caddy / nginx don't 403 every
- * same-origin request.
+ * gate / CORS check. It must:
+ *  (a) always include the URL-derived fallback origin so single-process
+ *      self-hosted setups keep working,
+ *  (b) when the `Host` header is well-formed, also include a derived
+ *      origin built from Host + X-Forwarded-Proto (or fallbackProtocol if
+ *      no proxy header), so deployments behind Caddy / nginx don't 403
+ *      every same-origin request,
+ *  (c) NOT trust X-Forwarded-Host (forgeable),
+ *  (d) reject malformed Host header values (header injection guard).
  */
 import { describe, it, expect } from "vitest";
 import { getRequestOrigins } from "@/lib/request-origins";
@@ -17,55 +21,72 @@ function makeHeaders(input: Record<string, string>): (n: string) => string | nul
 }
 
 describe("getRequestOrigins", () => {
-  it("returns only the fallback origin when no X-Forwarded-Proto is present", () => {
+  it("returns only the fallback origin when no Host header is present", () => {
     const origins = getRequestOrigins({
       fallbackOrigin: "http://localhost:3000",
-      fallbackHost: "localhost:3000",
+      fallbackProtocol: "http:",
+      hostHeader: null,
       getHeader: makeHeaders({}),
     });
     expect(origins).toEqual(["http://localhost:3000"]);
   });
 
-  it("adds the proxy-reported origin behind a TLS-terminating reverse proxy (the #176 case)", () => {
-    // Backend bound on http://dev.finlynq.com (Next.js's nextUrl.origin
-    // because Caddy passes the Host header through). Browser sees https.
+  it("derives the public origin from Host header (Next.js standalone HOSTNAME=0.0.0.0 case — the #176 root cause)", () => {
+    // Backend bound on http://0.0.0.0:3458 (Next.js's nextUrl.host returns
+    // the bind address, NOT the inbound Host). Caddy passes Host through
+    // and adds X-Forwarded-Proto.
     const origins = getRequestOrigins({
-      fallbackOrigin: "http://dev.finlynq.com",
-      fallbackHost: "dev.finlynq.com",
+      fallbackOrigin: "https://0.0.0.0:3458",
+      fallbackProtocol: "https:",
+      hostHeader: "dev.finlynq.com",
       getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
     });
-    expect(origins).toContain("http://dev.finlynq.com"); // fallback preserved
-    expect(origins).toContain("https://dev.finlynq.com"); // proxy-reported added
+    expect(origins).toContain("https://0.0.0.0:3458"); // fallback preserved
+    expect(origins).toContain("https://dev.finlynq.com"); // Host-header-derived added
   });
 
-  it("dedupes when X-Forwarded-Proto matches the fallback scheme", () => {
+  it("uses fallback protocol when no X-Forwarded-Proto is set (single-process self-hosted)", () => {
+    // No proxy in front. Browser hits localhost:3000 directly. Host header
+    // is "localhost:3000", protocol is http.
+    const origins = getRequestOrigins({
+      fallbackOrigin: "http://localhost:3000",
+      fallbackProtocol: "http:",
+      hostHeader: "localhost:3000",
+      getHeader: makeHeaders({}),
+    });
+    expect(origins).toContain("http://localhost:3000");
+  });
+
+  it("dedupes when Host-derived origin equals fallback", () => {
     const origins = getRequestOrigins({
       fallbackOrigin: "https://app.example.com",
-      fallbackHost: "app.example.com",
+      fallbackProtocol: "https:",
+      hostHeader: "app.example.com",
       getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
     });
     expect(origins).toEqual(["https://app.example.com"]);
   });
 
-  it("ignores X-Forwarded-Proto values that aren't 'http' or 'https'", () => {
-    // Reject "javascript", arbitrary schemes, comma-separated lists, etc.
-    for (const bad of ["javascript", "ftp", "https,http", "HTTPS", " https", ""]) {
+  it("ignores X-Forwarded-Proto values that aren't 'http' or 'https' and falls back to fallbackProtocol", () => {
+    for (const bad of ["javascript", "ftp", "https,http", "HTTPS", " https"]) {
       const origins = getRequestOrigins({
-        fallbackOrigin: "http://app.example.com",
-        fallbackHost: "app.example.com",
+        fallbackOrigin: "http://0.0.0.0:3000",
+        fallbackProtocol: "http:",
+        hostHeader: "app.example.com",
         getHeader: makeHeaders({ "X-Forwarded-Proto": bad }),
       });
-      expect(origins).toEqual(["http://app.example.com"]);
+      // Bad XFP rejected, falls back to fallbackProtocol (http) for the
+      // Host-derived origin.
+      expect(origins).toContain("http://app.example.com");
+      expect(origins).not.toContain("https://app.example.com");
     }
   });
 
-  it("does NOT trust X-Forwarded-Host even when it differs from the fallback host", () => {
-    // X-Forwarded-Host is forgeable end-to-end (any forward proxy or a
-    // misconfigured edge can inject it). The CSRF allowlist only uses
-    // the request's actual Host (already reflected in fallbackHost).
+  it("does NOT trust X-Forwarded-Host even when it differs from the Host header", () => {
     const origins = getRequestOrigins({
-      fallbackOrigin: "http://app.example.com",
-      fallbackHost: "app.example.com",
+      fallbackOrigin: "http://0.0.0.0:3000",
+      fallbackProtocol: "https:",
+      hostHeader: "app.example.com",
       getHeader: makeHeaders({
         "X-Forwarded-Proto": "https",
         "X-Forwarded-Host": "attacker.example.com",
@@ -76,21 +97,46 @@ describe("getRequestOrigins", () => {
     expect(origins).not.toContain("http://attacker.example.com");
   });
 
-  it("preserves the port in the proxy-reported origin", () => {
+  it("preserves the port in the Host-derived origin", () => {
     const origins = getRequestOrigins({
-      fallbackOrigin: "http://app.example.com:8443",
-      fallbackHost: "app.example.com:8443",
+      fallbackOrigin: "http://0.0.0.0:8443",
+      fallbackProtocol: "https:",
+      hostHeader: "app.example.com:8443",
       getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
     });
     expect(origins).toContain("https://app.example.com:8443");
   });
 
-  it("does nothing when fallbackHost is empty (defense-in-depth)", () => {
+  it("rejects malformed Host header values (header-injection guard)", () => {
+    // A misconfigured upstream could inject Host: "evil.com,good.com" or
+    // "evil.com /a=b" or other shenanigans. Reject anything that isn't
+    // strict [A-Za-z0-9.-] + optional :port.
+    for (const bad of [
+      "evil.com,good.com",
+      "evil.com:80,good.com",
+      "evil.com /path",
+      "evil.com\r\nX-Header: poison",
+      "evil.com'>script",
+      "evil.com:abc",
+      "",
+    ]) {
+      const origins = getRequestOrigins({
+        fallbackOrigin: "http://0.0.0.0:3000",
+        fallbackProtocol: "https:",
+        hostHeader: bad,
+        getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
+      });
+      expect(origins).toEqual(["http://0.0.0.0:3000"]); // ONLY the fallback
+    }
+  });
+
+  it("returns only the fallback when neither X-Forwarded-Proto nor a recognizable fallbackProtocol is present", () => {
     const origins = getRequestOrigins({
-      fallbackOrigin: "http://app.example.com",
-      fallbackHost: "",
-      getHeader: makeHeaders({ "X-Forwarded-Proto": "https" }),
+      fallbackOrigin: "weirdscheme://app.example.com",
+      fallbackProtocol: "weirdscheme:",
+      hostHeader: "app.example.com",
+      getHeader: makeHeaders({}),
     });
-    expect(origins).toEqual(["http://app.example.com"]);
+    expect(origins).toEqual(["weirdscheme://app.example.com"]);
   });
 });


### PR DESCRIPTION
Follow-up to #177. Closes #176 properly.

## What happened

PR #177 shipped a "proxy-aware" CSRF allowed-origin helper but used `request.nextUrl.host` for the host portion. On the dev systemd unit, `HOSTNAME=0.0.0.0` is set (Next.js standalone bind). Next.js reads that env var and reflects it in `nextUrl.host`, so the helper produced \`https://0.0.0.0:3458\` instead of \`https://dev.finlynq.com\`. Same-origin POSTs continued to 403.

## Diagnosis

Restored on a debug bundle patch (in-place via SSH, reverted immediately after):

\`\`\`json
{
  \"nextUrlOrigin\": \"https://0.0.0.0:3458\",  // useless
  \"nextUrlHost\":   \"0.0.0.0:3458\",          // useless
  \"host\":          \"dev.finlynq.com\",       // correct (Host header)
  \"fwdProto\":      \"https\",                  // correct (Caddy)
  \"fwdHost\":       \"dev.finlynq.com\",       // correct but DON'T trust
  \"origin\":        \"https://dev.finlynq.com\"
}
\`\`\`

The Host header is reaching the backend correctly. We just have to use it.

## What changed

- \`getRequestOrigins()\` now takes \`hostHeader\` + \`fallbackProtocol\` instead of \`fallbackHost\`. It derives the public origin from \`hostHeader + (X-Forwarded-Proto || fallbackProtocol)\`. Strict \`[A-Za-z0-9.-]+(:port)?\` regex rejects malformed Host values (header-injection guard).
- \`middleware.ts\` passes \`request.headers.get(\"host\")\` and \`request.nextUrl.protocol\` instead of \`request.nextUrl.host\`.
- 9 unit tests covering: #176 root-cause scenario, no-proxy self-hosted, garbage-XFP fallback, X-Forwarded-Host non-trust, port preservation, header-injection guard, unknown-scheme handling.

## Why this is safe

- \`Host\` header is set by the browser to the URL it's hitting. A real browser cannot forge it across a same-origin fetch.
- Strict regex on Host rejects \`,\` \`;\` \` \` \`/\` \`\r\n\` etc. — any embedded delimiter that would let a misconfigured upstream proxy inject a bogus origin.
- Continue NOT trusting \`X-Forwarded-Host\` (forgeable end-to-end).
- \`X-Forwarded-Proto\` whitelist is exact \`\"http\"\` / \`\"https\"\`.
- Bundle-patch verified on dev: hardcoded \`https://dev.finlynq.com\` makes same-origin pass and attacker-origin still 403. The corrected logic builds the same string at runtime.

## Test plan

- [x] \`npx vitest run tests/request-origins.test.ts\` — 9/9 pass.
- [x] \`npx tsc --noEmit\` — clean.
- [ ] CI typecheck + build.
- [ ] After merge + deploy: verify on dev that same-origin POST /api/auth/logout returns 200, attacker origin still 403, captured cookie returns 401 after logout.
- [ ] Then re-run the Tier-2 tests blocked by #176 (H-1 verifyOwnership 404, H-5 JWT revocation end-to-end, H-6 MFA setup hardening, H-7 wipe-account).

## Related

- #177 (the partial fix this completes)
- #176 (original P0 issue — this PR closes it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)