### PR TITLE
DRAFT: marketing + analytics consent + public MCP guide (preserved from working tree)

### DIFF
--- a/mcp-server/auto-annotations.ts
+++ b/mcp-server/auto-annotations.ts
@@ -1,0 +1,175 @@
+/**
+ * Auto-annotation helper for MCP tools.
+ *
+ * The Anthropic Connectors Directory submission requires every tool to expose
+ * `title` and either `readOnlyHint` or `destructiveHint` annotations. We have
+ * 90 HTTP / 86 stdio tools across four registration files; rather than touch
+ * every callsite, we monkey-patch `server.tool()` once per server instance to
+ * inject inferred annotations from the tool name.
+ *
+ * Annotations are HINTS to clients per the MCP spec; the underlying handler
+ * is unchanged. Confirmation-token / preview-execute safety is enforced
+ * server-side regardless of the client's interpretation of these hints.
+ *
+ * Inference rules (by name prefix / contained token):
+ *   read-only        get_  list_  find_  search_  analyze_  preview_  test_
+ *                    trace_  detect_  convert_  suggest_  describe_  read_
+ *                    finlynq_help  *_help
+ *   destructive      delete_*   *_delete   reject_*
+ *   idempotent       set_*  update_*  replace_*  delete_*  reject_*  + read tools
+ *   open-world       false (Finlynq operates only on the user's own DB)
+ *
+ * Reorder, cancel, approve, link, apply, execute (non-delete), record, add,
+ * create, bulk_*, enqueue_* default to {readOnly:false, destructive:false}.
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+type ToolAnnotations = {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+};
+
+const READ_PREFIXES = [
+  "get_",
+  "list_",
+  "find_",
+  "search_",
+  "analyze_",
+  "preview_",
+  "test_",
+  "trace_",
+  "detect_",
+  "convert_",
+  "suggest_",
+  "describe_",
+  "read_",
+];
+
+const IDEMPOTENT_WRITE_PREFIXES = ["set_", "update_", "replace_"];
+
+export function inferAnnotations(name: string): ToolAnnotations {
+  const isReadOnly =
+    READ_PREFIXES.some((p) => name.startsWith(p)) ||
+    name === "finlynq_help" ||
+    name.endsWith("_help");
+
+  const isDestructive =
+    name.startsWith("delete_") ||
+    /_delete(_|$)/.test(name) ||
+    name.startsWith("reject_");
+
+  const isIdempotent =
+    isReadOnly ||
+    isDestructive ||
+    IDEMPOTENT_WRITE_PREFIXES.some((p) => name.startsWith(p));
+
+  return {
+    title: toTitle(name),
+    readOnlyHint: isReadOnly,
+    destructiveHint: isDestructive,
+    idempotentHint: isIdempotent,
+    openWorldHint: false,
+  };
+}
+
+function toTitle(snake: string): string {
+  return snake
+    .split("_")
+    .map((w) => (w.length === 0 ? w : w[0].toUpperCase() + w.slice(1)))
+    .join(" ");
+}
+
+const PATCHED = Symbol.for("finlynq.autoAnnotated");
+
+/**
+ * Patch a McpServer instance so that every subsequent `server.tool(...)` call
+ * gets inferred annotations injected before the handler. Idempotent — calling
+ * twice on the same server is a no-op.
+ *
+ * Supported existing call shapes (the SDK exposes more overloads, but only
+ * these are used in this codebase):
+ *   tool(name, description, schema, callback)            -> 4-arg form
+ *   tool(name, description, callback)                    -> 3-arg form
+ *
+ * The patched call rewrites these to:
+ *   tool(name, description, schema, annotations, callback)
+ *   tool(name, description, annotations, callback)
+ *
+ * Both new shapes are valid SDK overloads.
+ */
+export function withAutoAnnotations(server: McpServer): McpServer {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const s = server as any;
+  if (s[PATCHED]) return server;
+  s[PATCHED] = true;
+
+  const original = s.tool.bind(server);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  s.tool = function patchedTool(...args: any[]) {
+    if (args.length < 2 || typeof args[0] !== "string") {
+      return original(...args);
+    }
+
+    const name = args[0] as string;
+    const last = args[args.length - 1];
+    if (typeof last !== "function") {
+      return original(...args);
+    }
+
+    // Detect existing annotations: position N-2 is an object with at least
+    // one annotation key. Skip injection if already present.
+    if (args.length >= 4) {
+      const candidate = args[args.length - 2];
+      if (looksLikeAnnotations(candidate)) {
+        return original(...args);
+      }
+    }
+
+    const annotations = inferAnnotations(name);
+
+    // tool(name, description, schema, callback)
+    if (
+      args.length === 4 &&
+      typeof args[1] === "string" &&
+      args[2] !== null &&
+      typeof args[2] === "object"
+    ) {
+      return original(args[0], args[1], args[2], annotations, args[3]);
+    }
+
+    // tool(name, description, callback)
+    if (args.length === 3 && typeof args[1] === "string") {
+      return original(args[0], args[1], annotations, args[2]);
+    }
+
+    // tool(name, schema, callback) — used by some libraries; insert annotations after schema
+    if (
+      args.length === 3 &&
+      args[1] !== null &&
+      typeof args[1] === "object"
+    ) {
+      return original(args[0], args[1], annotations, args[2]);
+    }
+
+    // Fallback: don't risk breaking unknown shapes.
+    return original(...args);
+  };
+
+  return server;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function looksLikeAnnotations(o: any): boolean {
+  if (!o || typeof o !== "object") return false;
+  return (
+    "readOnlyHint" in o ||
+    "destructiveHint" in o ||
+    "idempotentHint" in o ||
+    "openWorldHint" in o ||
+    ("title" in o && typeof o.title === "string" && Object.keys(o).length <= 5)
+  );
+}

--- a/src/app/mcp-guide/page.tsx
+++ b/src/app/mcp-guide/page.tsx
@@ -1,0 +1,912 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { CheckCircle2, XCircle, Copy, Check, Terminal, Zap, Bot, Key, Eye, EyeOff, Globe, Plus, Shield, Upload, Wand2, Radar, Landmark, Globe2, Scissors, Scale, Lightbulb, Briefcase } from "lucide-react";
+
+type ClientTab = "claude-desktop" | "claude-web" | "cursor" | "cline" | "windsurf" | "custom";
+type StatusState = "checking" | "connected" | "disconnected";
+
+const examplePrompts = [
+  { category: "Spending", prompt: "How much did I spend on groceries last month?" },
+  { category: "Spending", prompt: "What were my top 5 spending categories this year?" },
+  { category: "Budget", prompt: "Am I on track with my budget this month?" },
+  { category: "Budget", prompt: "Which budget categories am I over or under?" },
+  { category: "Net Worth", prompt: "What is my current net worth?" },
+  { category: "Net Worth", prompt: "How has my net worth changed over the last 6 months?" },
+  { category: "Goals", prompt: "How close am I to reaching my emergency fund goal?" },
+  { category: "Goals", prompt: "What goals should I prioritize this month?" },
+  { category: "Investments", prompt: "What is my portfolio return this year?" },
+  { category: "Insights", prompt: "Are there any unusual transactions I should review?" },
+  { category: "Insights", prompt: "What subscriptions might I want to reconsider?" },
+  { category: "Cash Flow", prompt: "What bills are due in the next 30 days?" },
+];
+
+type ToolGroupIcon =
+  | typeof Upload
+  | typeof Wand2
+  | typeof Radar
+  | typeof Landmark
+  | typeof Globe2
+  | typeof Scissors
+  | typeof Scale
+  | typeof Lightbulb
+  | typeof Briefcase
+  | typeof Bot;
+
+const toolGroups: {
+  title: string;
+  icon: ToolGroupIcon;
+  blurb: string;
+  example: string;
+  tools: string[];
+}[] = [
+  {
+    title: "Import transactions (CSV / OFX)",
+    icon: Upload,
+    blurb:
+      "Drop a CSV or OFX into Finlynq with the Upload button, then ask Claude to take it from there. Claude lists pending uploads, shows you a preview with duplicate detection, and only commits after you confirm.",
+    example: "Preview my pending CSV import and show me the duplicates before you commit.",
+    tools: ["list_pending_uploads", "preview_import", "execute_import", "cancel_import"],
+  },
+  {
+    title: "Bulk cleanup",
+    icon: Wand2,
+    blurb:
+      "Recategorize, retag, or delete many transactions at once. Every bulk operation is two steps: a preview that returns a sample and a signed confirmation token, then an execute call that commits. Claude can't skip the confirmation — the token is scoped to the exact payload.",
+    example: "Recategorize every Starbucks transaction from the last 90 days as Coffee.",
+    tools: [
+      "preview_bulk_update",
+      "execute_bulk_update",
+      "preview_bulk_delete",
+      "execute_bulk_delete",
+      "preview_bulk_categorize",
+      "execute_bulk_categorize",
+    ],
+  },
+  {
+    title: "Find and manage subscriptions",
+    icon: Radar,
+    blurb:
+      "Detect recurring charges from your transaction history, then add, update (pause/resume/cancel via status), or delete subscriptions without leaving the chat.",
+    example: "Find my subscriptions and add the ones you're confident about.",
+    tools: [
+      "list_subscriptions",
+      "detect_subscriptions",
+      "bulk_add_subscriptions",
+      "add_subscription",
+      "update_subscription",
+      "delete_subscription",
+      "get_subscription_summary",
+    ],
+  },
+  {
+    title: "Manage loans and plan payoff",
+    icon: Landmark,
+    blurb:
+      "Track balances, generate amortization schedules, and compare avalanche vs. snowball payoff plans across all your loans.",
+    example: "Show me an avalanche payoff plan with an extra $300 a month.",
+    tools: [
+      "list_loans",
+      "add_loan",
+      "update_loan",
+      "delete_loan",
+      "get_loan_amortization",
+      "get_debt_payoff_plan",
+    ],
+  },
+  {
+    title: "Currency conversion",
+    icon: Globe2,
+    blurb:
+      "Ask for live or historical FX rates, convert amounts between currencies, or pin your own rate overrides for bookkeeping.",
+    example: "What's 1,200 USD in CAD on the day of my last paycheck?",
+    tools: [
+      "get_fx_rate",
+      "convert_amount",
+      "list_fx_overrides",
+      "set_fx_override",
+      "delete_fx_override",
+    ],
+  },
+  {
+    title: "Split transactions",
+    icon: Scissors,
+    blurb:
+      "Split a single transaction across multiple categories — useful for $200 grocery runs that include household goods, or Costco trips that mix food and electronics.",
+    example: "Split my last Costco run: $120 groceries, $60 household, $40 electronics.",
+    tools: ["list_splits", "add_split", "update_split", "delete_split", "replace_splits"],
+  },
+  {
+    title: "Rule management",
+    icon: Scale,
+    blurb:
+      "Create, list, reorder, test, and delete auto-categorization rules. Dry-run any rule against your history before you apply it.",
+    example: "Create a rule that categorizes anything containing 'SHELL' as Fuel, and show me what it would match first.",
+    tools: [
+      "list_rules",
+      "create_rule",
+      "update_rule",
+      "delete_rule",
+      "test_rule",
+      "reorder_rules",
+      "apply_rules_to_uncategorized",
+    ],
+  },
+  {
+    title: "Portfolio holdings",
+    icon: Briefcase,
+    blurb:
+      "Manually create, rename, move, or delete portfolio positions (the import pipeline auto-creates them from CSV/ZIP, but for one-offs use these). Plus the read tools for portfolio metrics, performance, deep-dive on a single position, and rebalancing/benchmark insights. Renames cascade to all transactions automatically; deletes leave the transactions in place with the holding link cleared.",
+    example: "Add 'VEQT.TO' as a new holding under my RRSP, then move my Apple position to my TFSA.",
+    tools: [
+      "add_portfolio_holding",
+      "update_portfolio_holding",
+      "delete_portfolio_holding",
+      "get_portfolio_analysis",
+      "get_portfolio_performance",
+      "analyze_holding",
+      "trace_holding_quantity",
+      "get_investment_insights",
+    ],
+  },
+  {
+    title: "Accounts and aliases",
+    icon: Landmark,
+    blurb:
+      "Add or update accounts, including a short alias (e.g. last 4 digits of a card, or a receipt label) so Claude can match a transaction even when the source document doesn't use the canonical name. The account parameter on every write tool fuzzy-matches your account names and exact-matches aliases — pass either.",
+    example: "When I send you receipts that say 'Visa ending 4242', file them under my Chase Sapphire account — set its alias to '4242'.",
+    tools: ["add_account", "update_account", "delete_account", "get_account_balances"],
+  },
+  {
+    title: "Suggest payee / category",
+    icon: Lightbulb,
+    blurb:
+      "Before recording a transaction, ask Claude to guess the right category and tags based on your rules and history.",
+    example: "I'm about to enter a charge from 'TIM HORTONS #4412' for $7.40 — what category should it be?",
+    tools: ["suggest_transaction_details"],
+  },
+  {
+    title: "Reads & dashboards",
+    icon: Bot,
+    blurb:
+      "Balances, net worth, budgets, goals, spending trends, income statements, health score, spotlight alerts, weekly recap, cash flow forecast, anomalies — all the dashboards, queryable in natural language. Portfolio metrics live in the Portfolio holdings card above.",
+    example: "Summarize my week: spending, net worth change, and anything unusual.",
+    tools: [
+      "get_account_balances",
+      "get_net_worth",
+      "search_transactions",
+      "get_budget_summary",
+      "get_spending_trends",
+      "get_income_statement",
+      "get_goals",
+      "get_cash_flow_forecast",
+      "get_recurring_transactions",
+      "get_spotlight_items",
+      "get_weekly_recap",
+      "get_spending_anomalies",
+      "get_financial_health_score",
+      "get_categories",
+      "finlynq_help",
+    ],
+  },
+];
+
+const workedExamples: { title: string; prompt: string; flow: string }[] = [
+  {
+    title: "Import a month of transactions from a CSV",
+    prompt:
+      "I just uploaded my December BMO statement. Preview it, flag the duplicates, and once it looks clean go ahead and import it.",
+    flow: "list_pending_uploads → preview_import → (you confirm) → execute_import",
+  },
+  {
+    title: "Find and add subscriptions in one shot",
+    prompt:
+      "Scan my transactions for recurring charges I might be missing from my subscription list. Show me the candidates with confidence scores and add the ones you're at least 80% sure about.",
+    flow: "detect_subscriptions → (you confirm) → bulk_add_subscriptions",
+  },
+  {
+    title: "Refinance plan across every loan",
+    prompt:
+      "Pull my loans, then compare an avalanche vs. snowball payoff plan assuming I can put an extra $500 a month toward debt. Which gets me debt-free first?",
+    flow: "list_loans → get_debt_payoff_plan × 2 (one per strategy)",
+  },
+  {
+    title: "Clean up a year of Uber charges",
+    prompt:
+      "Every Uber charge before last month should be categorized as Transit instead of Dining. Preview it first and tell me how many rows would change.",
+    flow: "preview_bulk_categorize → (you confirm) → execute_bulk_categorize",
+  },
+];
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+      className="absolute right-2 top-2 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-white/10 transition-colors"
+      title="Copy to clipboard"
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-400" /> : <Copy className="h-3.5 w-3.5" />}
+    </button>
+  );
+}
+
+export default function McpGuidePage() {
+  const [activeTab, setActiveTab] = useState<ClientTab>("claude-desktop");
+  const [status, setStatus] = useState<StatusState>("checking");
+  const [serverUrl, setServerUrl] = useState("http://localhost:3000");
+  const [apiKey, setApiKey] = useState<string | null>(null);
+  const [apiKeyVisible, setApiKeyVisible] = useState(false);
+  const [apiKeyCopied, setApiKeyCopied] = useState(false);
+
+  useEffect(() => {
+    setServerUrl(window.location.origin);
+    fetch("/api/healthz")
+      .then((r) => setStatus(r.ok ? "connected" : "disconnected"))
+      .catch(() => setStatus("disconnected"));
+    // Load API key so config snippets are ready to paste
+    fetch("/api/settings/api-key")
+      .then((r) => r.json())
+      .then((d) => { if (d.apiKey) setApiKey(d.apiKey); })
+      .catch(() => {});
+  }, []);
+
+  const mcpUrl = `${serverUrl}/api/mcp`;
+  const displayKey = apiKey ?? "YOUR_API_KEY";
+
+  // Config snippets always use a placeholder — users copy their actual key from the section above
+  const httpConfig = JSON.stringify(
+    {
+      mcpServers: {
+        "finlynq": {
+          type: "streamable-http",
+          url: mcpUrl,
+          headers: {
+            "Authorization": "Bearer YOUR_API_KEY",
+          },
+        },
+      },
+    },
+    null,
+    2
+  );
+
+  const claudeConfig = httpConfig;
+  const cursorConfig = httpConfig;
+  const windsurfConfig = httpConfig;
+
+  const stdioConfig = JSON.stringify(
+    {
+      mcpServers: {
+        "finlynq": {
+          command: "node",
+          args: ["/path/to/pf-app/mcp-server/dist/index.js"],
+          env: {
+            DATABASE_URL: "postgresql://user:pass@localhost:5432/pf",
+            PF_USER_ID: "your-user-uuid-from-users-table",
+            PF_PASSPHRASE: "your-passphrase",
+          },
+        },
+      },
+    },
+    null,
+    2
+  );
+
+  const tabs: { id: ClientTab; label: string; icon: string }[] = [
+    { id: "claude-desktop", label: "Claude Desktop", icon: "🤖" },
+    { id: "claude-web", label: "Claude Web / Mobile", icon: "🌐" },
+    { id: "cursor", label: "Cursor", icon: "⚡" },
+    { id: "cline", label: "Cline (VS Code)", icon: "🔌" },
+    { id: "windsurf", label: "Windsurf", icon: "🌊" },
+    { id: "custom", label: "Custom / Local LLMs", icon: "🛠️" },
+  ];
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-4xl px-6 py-10">
+        {/* Header */}
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 shadow-lg shadow-indigo-500/30">
+              <Bot className="h-5 w-5 text-white" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight text-foreground">Connect Your AI</h1>
+              <p className="text-sm text-muted-foreground">Ask Claude, Cursor, Windsurf, or any MCP client about your finances</p>
+            </div>
+          </div>
+
+          {/* Connection Status */}
+          <div
+            className={`inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-medium border ${
+              status === "connected"
+                ? "bg-emerald-500/10 border-emerald-500/20 text-emerald-400"
+                : status === "disconnected"
+                  ? "bg-rose-500/10 border-rose-500/20 text-rose-400"
+                  : "bg-muted border-border text-muted-foreground"
+            }`}
+          >
+            {status === "checking" && (
+              <div className="h-2 w-2 rounded-full bg-muted-foreground animate-pulse" />
+            )}
+            {status === "connected" && <CheckCircle2 className="h-4 w-4" />}
+            {status === "disconnected" && <XCircle className="h-4 w-4" />}
+            {status === "checking" && "Checking MCP server…"}
+            {status === "connected" && "MCP server is running — ready to connect"}
+            {status === "disconnected" && "MCP server not reachable — is the app running?"}
+          </div>
+        </div>
+
+        {/* API Key */}
+        <section className="mb-8">
+          <h2 className="mb-3 text-lg font-semibold text-foreground">Your API Key</h2>
+          <div className="rounded-xl border border-indigo-500/20 bg-indigo-500/5 p-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <Key className="h-4 w-4 text-indigo-400 shrink-0" />
+              <span className="text-sm text-muted-foreground">
+                Use this key in the config snippets below to authenticate with the MCP server.
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 font-mono text-sm bg-background/60 border border-border rounded-lg px-3 py-2 text-foreground truncate">
+                {apiKey
+                  ? (apiKeyVisible ? apiKey : `${apiKey.slice(0, 6)}${"•".repeat(20)}${apiKey.slice(-4)}`)
+                  : "Hidden — regenerate from Settings to view"}
+              </code>
+              <button
+                onClick={() => setApiKeyVisible(!apiKeyVisible)}
+                className="p-2 rounded-lg border border-border bg-background/60 text-muted-foreground hover:text-foreground hover:bg-white/10 transition-colors"
+                title={apiKeyVisible ? "Hide key" : "Show key"}
+                disabled={!apiKey}
+              >
+                {apiKeyVisible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+              <button
+                onClick={() => {
+                  if (!apiKey) return;
+                  navigator.clipboard.writeText(apiKey);
+                  setApiKeyCopied(true);
+                  setTimeout(() => setApiKeyCopied(false), 2000);
+                }}
+                className="p-2 rounded-lg border border-border bg-background/60 text-muted-foreground hover:text-foreground hover:bg-white/10 transition-colors"
+                title="Copy key"
+                disabled={!apiKey}
+              >
+                {apiKeyCopied ? <Check className="h-4 w-4 text-emerald-400" /> : <Copy className="h-4 w-4" />}
+              </button>
+            </div>
+            {!apiKey && (
+              <p className="text-xs text-muted-foreground">
+                Sign in at <a href="/cloud" className="underline underline-offset-2 hover:text-foreground">finlynq.com/cloud</a> (free), then visit <a href="/settings/account" className="underline underline-offset-2 hover:text-foreground">Settings → API Key</a> to generate one. We only store a hash — the raw key is shown to you once at creation and cannot be re-shown. Self-hosters: same flow on your own deployment.
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* Setup Instructions */}
+        <section className="mb-10">
+          <h2 className="mb-4 text-lg font-semibold text-foreground">Setup Instructions</h2>
+
+          {/* Tab bar */}
+          <div className="flex gap-1 mb-4 rounded-xl border border-border bg-muted p-1 overflow-x-auto">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex-shrink-0 flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                  activeTab === tab.id
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                <span>{tab.icon}</span>
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="rounded-xl border border-border bg-card p-6 space-y-4">
+            {activeTab === "claude-desktop" && (
+              <ol className="space-y-5 text-sm text-foreground">
+                <p className="text-sm text-muted-foreground">
+                  Claude Desktop natively supports MCP. Add Finlynq to your config file and restart Claude.
+                </p>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    1
+                  </span>
+                  <div>
+                    <p className="font-medium mb-1">Open Claude Desktop settings</p>
+                    <p className="text-muted-foreground">
+                      Go to Claude menu → Settings → Developer → Edit Config
+                    </p>
+                    <code className="mt-1.5 block text-xs text-muted-foreground leading-relaxed">
+                      Mac: ~/Library/Application Support/Claude/claude_desktop_config.json
+                      <br />
+                      Windows: %APPDATA%\Claude\claude_desktop_config.json
+                    </code>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    2
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium mb-2">Add this to your config file</p>
+                    <div className="relative">
+                      <pre className="text-xs bg-muted rounded-lg p-4 overflow-x-auto text-muted-foreground leading-relaxed pr-10">
+                        {claudeConfig}
+                      </pre>
+                      <CopyButton text={claudeConfig} />
+                    </div>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    3
+                  </span>
+                  <div>
+                    <p className="font-medium mb-1">Restart Claude Desktop</p>
+                    <p className="text-muted-foreground">
+                      Finlynq tools will appear in Claude&apos;s tool panel (hammer icon). Make sure
+                      Finlynq is running at{" "}
+                      <code className="text-xs bg-muted px-1 py-0.5 rounded">{serverUrl}</code>.
+                    </p>
+                  </div>
+                </li>
+              </ol>
+            )}
+
+            {activeTab === "claude-web" && (
+              <div className="space-y-5 text-sm text-foreground">
+                {/* Easy-mode callout */}
+                <div className="flex items-start gap-3 rounded-xl border border-indigo-500/25 bg-indigo-500/8 p-4">
+                  <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-indigo-500/15">
+                    <Globe className="h-4 w-4 text-indigo-400" />
+                  </div>
+                  <div>
+                    <p className="font-semibold text-foreground mb-0.5">Easiest way to connect</p>
+                    <p className="text-xs text-muted-foreground">
+                      No config files, no API keys to paste. Just click, log in, and authorize — done in under
+                      a minute. Works on claude.ai in any browser, and on the Claude iOS / Android app.
+                    </p>
+                  </div>
+                </div>
+
+                <ol className="space-y-5">
+                  <li className="flex gap-3">
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                      1
+                    </span>
+                    <div>
+                      <p className="font-medium mb-1">Open Claude on the web or mobile</p>
+                      <p className="text-muted-foreground">
+                        Go to <strong>claude.ai</strong> or open the Claude app on your phone. Start a new
+                        conversation or open any existing one.
+                      </p>
+                    </div>
+                  </li>
+
+                  <li className="flex gap-3">
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                      2
+                    </span>
+                    <div>
+                      <p className="font-medium mb-1">
+                        Click the{" "}
+                        <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+                          <Plus className="h-3 w-3" /> plus
+                        </span>{" "}
+                        icon in the chat input
+                      </p>
+                      <p className="text-muted-foreground">
+                        Or go to <strong>Settings → Integrations</strong> and click{" "}
+                        <strong>Add custom integration</strong>.
+                      </p>
+                    </div>
+                  </li>
+
+                  <li className="flex gap-3">
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                      3
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium mb-2">Fill in the connector details</p>
+                      <div className="rounded-lg border border-border bg-muted/40 divide-y divide-border/50 text-xs overflow-hidden">
+                        <div className="flex items-center gap-3 px-3 py-2">
+                          <span className="w-28 shrink-0 text-muted-foreground">Name</span>
+                          <code className="text-foreground font-mono">Finlynq</code>
+                        </div>
+                        <div className="flex items-center gap-3 px-3 py-2">
+                          <span className="w-28 shrink-0 text-muted-foreground">Server URL</span>
+                          <div className="relative flex-1 min-w-0">
+                            <code className="text-foreground font-mono break-all">{mcpUrl}</code>
+                          </div>
+                          <CopyButton text={mcpUrl} />
+                        </div>
+                        <div className="flex items-center gap-3 px-3 py-2">
+                          <span className="w-28 shrink-0 text-muted-foreground">Advanced</span>
+                          <span className="text-muted-foreground italic">Leave collapsed — OAuth handles auth</span>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+
+                  <li className="flex gap-3">
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                      4
+                    </span>
+                    <div>
+                      <p className="font-medium mb-1">Click <strong>Add</strong>, then <strong>Connect</strong></p>
+                      <p className="text-muted-foreground">
+                        Claude will open a Finlynq authorization page. Log in if prompted, then click{" "}
+                        <strong>Allow</strong> to grant access.
+                      </p>
+                    </div>
+                  </li>
+
+                  <li className="flex gap-3">
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500/20 text-[11px] font-bold text-emerald-500 mt-0.5">
+                      ✓
+                    </span>
+                    <div>
+                      <p className="font-medium mb-1 text-emerald-500">You&apos;re connected!</p>
+                      <p className="text-muted-foreground mb-3">
+                        The Finlynq tools are now available in every Claude conversation. Try one of these:
+                      </p>
+                      <div className="space-y-1.5">
+                        {[
+                          "What's my current net worth?",
+                          "How much did I spend on groceries last month?",
+                          "Show me my investment portfolio performance",
+                          "Record a $45 Starbucks transaction from yesterday",
+                        ].map((prompt) => (
+                          <button
+                            key={prompt}
+                            onClick={() => navigator.clipboard.writeText(prompt)}
+                            className="flex w-full items-center gap-2 rounded-lg border border-border/50 bg-card px-3 py-2 text-left text-xs text-muted-foreground hover:border-primary/30 hover:text-foreground transition-colors"
+                            title="Click to copy"
+                          >
+                            <Copy className="h-3 w-3 shrink-0 opacity-40" />
+                            {prompt}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </li>
+                </ol>
+
+                <div className="flex items-start gap-2 rounded-lg bg-amber-500/5 border border-amber-500/20 p-3">
+                  <Shield className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
+                  <p className="text-xs text-muted-foreground">
+                    <strong className="text-foreground">Privacy note:</strong> Claude Web uses OAuth 2.1 — your
+                    Finlynq passphrase and financial data are never shared with Anthropic. Only the tool
+                    responses (query results) pass through Claude&apos;s servers.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {activeTab === "cursor" && (
+              <ol className="space-y-5 text-sm text-foreground">
+                <p className="text-sm text-muted-foreground">
+                  Cursor supports MCP through its settings. Add Finlynq as an MCP server.
+                </p>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    1
+                  </span>
+                  <div>
+                    <p className="font-medium mb-1">Open Cursor Settings</p>
+                    <p className="text-muted-foreground">
+                      Go to Cursor → Settings → Cursor Settings → MCP
+                    </p>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    2
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium mb-2">
+                      Add to{" "}
+                      <code className="text-xs bg-muted px-1 py-0.5 rounded">~/.cursor/mcp.json</code>
+                    </p>
+                    <div className="relative">
+                      <pre className="text-xs bg-muted rounded-lg p-4 overflow-x-auto text-muted-foreground leading-relaxed pr-10">
+                        {cursorConfig}
+                      </pre>
+                      <CopyButton text={cursorConfig} />
+                    </div>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    3
+                  </span>
+                  <div>
+                    <p className="font-medium mb-1">Enable the server</p>
+                    <p className="text-muted-foreground">
+                      Toggle &quot;finlynq&quot; on in Cursor&apos;s MCP settings panel and reload the window.
+                    </p>
+                  </div>
+                </li>
+              </ol>
+            )}
+
+            {activeTab === "cline" && (
+              <ol className="space-y-5 text-sm text-foreground">
+                <p className="text-sm text-muted-foreground">
+                  Cline is a VS Code extension that supports MCP servers. Works with Claude, GPT-4, and local
+                  models.
+                </p>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    1
+                  </span>
+                  <div>
+                    <p className="font-medium mb-1">Install Cline from VS Code Marketplace</p>
+                    <p className="text-muted-foreground">
+                      Search &quot;Cline&quot; in the VS Code extensions panel and install it.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    2
+                  </span>
+                  <div>
+                    <p className="font-medium mb-1">Open Cline&apos;s MCP Servers panel</p>
+                    <p className="text-muted-foreground">
+                      Click the Cline icon in the sidebar → &quot;MCP Servers&quot; → &quot;Add Server&quot;.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    3
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium mb-2">Enter this URL for the HTTP transport</p>
+                    <div className="relative">
+                      <pre className="text-xs bg-muted rounded-lg p-4 overflow-x-auto text-muted-foreground pr-10">
+                        {mcpUrl}
+                      </pre>
+                      <CopyButton text={mcpUrl} />
+                    </div>
+                  </div>
+                </li>
+              </ol>
+            )}
+
+            {activeTab === "windsurf" && (
+              <ol className="space-y-5 text-sm text-foreground">
+                <p className="text-sm text-muted-foreground">
+                  Windsurf (by Codeium) supports MCP servers via its config file. Add Finlynq to start
+                  querying your finances from the AI coding assistant.
+                </p>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    1
+                  </span>
+                  <div>
+                    <p className="font-medium mb-1">Open your Windsurf MCP config</p>
+                    <code className="mt-1 block text-xs text-muted-foreground leading-relaxed">
+                      Mac/Linux: ~/.codeium/windsurf/mcp_config.json
+                      <br />
+                      Windows: %USERPROFILE%\.codeium\windsurf\mcp_config.json
+                    </code>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    2
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium mb-2">Add the Finlynq server</p>
+                    <div className="relative">
+                      <pre className="text-xs bg-muted rounded-lg p-4 overflow-x-auto text-muted-foreground leading-relaxed pr-10">
+                        {windsurfConfig}
+                      </pre>
+                      <CopyButton text={windsurfConfig} />
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      Replace <code className="bg-muted px-1 rounded">YOUR_API_KEY</code> with your key from
+                      the section above.
+                    </p>
+                  </div>
+                </li>
+                <li className="flex gap-3">
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[11px] font-bold text-primary mt-0.5">
+                    3
+                  </span>
+                  <div>
+                    <p className="font-medium mb-1">Reload Windsurf</p>
+                    <p className="text-muted-foreground">
+                      Open the Command Palette → <strong>Windsurf: Reload MCP Servers</strong>. The Finlynq
+                      tools will appear in Cascade when you start a new conversation.
+                    </p>
+                  </div>
+                </li>
+              </ol>
+            )}
+
+            {activeTab === "custom" && (
+              <div className="space-y-6 text-sm text-foreground">
+                <p className="text-muted-foreground">
+                  Any MCP-compatible client can connect via HTTP or stdio. Use this for local LLMs, custom
+                  agents, or developer tooling.
+                </p>
+
+                <div>
+                  <h3 className="font-semibold mb-2 flex items-center gap-2">
+                    <Zap className="h-4 w-4 text-amber-400" />
+                    HTTP Transport (recommended)
+                  </h3>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    Works with any MCP client that supports Streamable HTTP:
+                  </p>
+                  <div className="relative">
+                    <pre className="text-xs bg-muted rounded-lg p-4 overflow-x-auto text-muted-foreground pr-10">
+                      {mcpUrl}
+                    </pre>
+                    <CopyButton text={mcpUrl} />
+                  </div>
+                </div>
+
+                <div>
+                  <h3 className="font-semibold mb-2 flex items-center gap-2">
+                    <Terminal className="h-4 w-4 text-slate-400" />
+                    Stdio Transport (self-hosted only)
+                  </h3>
+                  <p className="text-xs text-muted-foreground mb-2">
+                    For self-hosted setups. Requires building the MCP server first:
+                  </p>
+                  <div className="relative mb-2">
+                    <pre className="text-xs bg-muted rounded-lg p-4 overflow-x-auto text-muted-foreground leading-relaxed pr-10">
+                      {stdioConfig}
+                    </pre>
+                    <CopyButton text={stdioConfig} />
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Build the server:{" "}
+                    <code className="bg-muted px-1 py-0.5 rounded">npm run build:mcp</code> in the pf-app
+                    directory.
+                  </p>
+                </div>
+
+                <div className="rounded-lg bg-amber-500/5 border border-amber-500/20 p-4">
+                  <p className="text-xs text-muted-foreground">
+                    <strong className="text-foreground">Windsurf:</strong> Use the dedicated{" "}
+                    <button
+                      onClick={() => setActiveTab("windsurf")}
+                      className="underline underline-offset-2 text-foreground hover:text-primary transition-colors"
+                    >
+                      Windsurf tab
+                    </button>{" "}
+                    for step-by-step setup instructions.
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </section>
+
+        {/* Example Prompts */}
+        <section className="mb-10">
+          <h2 className="mb-1 text-lg font-semibold text-foreground">Example Prompts</h2>
+          <p className="mb-4 text-sm text-muted-foreground">Click any prompt to copy it, then paste into your AI assistant.</p>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {examplePrompts.map((item, i) => (
+              <button
+                key={i}
+                className="group flex items-start gap-3 rounded-lg border border-border/50 bg-card p-3 hover:border-primary/30 hover:bg-card/80 transition-colors text-left"
+                onClick={() => navigator.clipboard.writeText(item.prompt)}
+                title="Click to copy"
+              >
+                <span className="mt-0.5 text-[11px] font-semibold px-1.5 py-0.5 rounded bg-primary/10 text-primary shrink-0">
+                  {item.category}
+                </span>
+                <p className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
+                  {item.prompt}
+                </p>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {/* Worked examples — copy-paste prompts that trigger multi-tool flows */}
+        <section className="mb-10">
+          <h2 className="mb-1 text-lg font-semibold text-foreground">Try a full flow</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            Paste any of these into Claude to see a preview / confirm / execute flow end-to-end. Claude asks
+            before it commits anything destructive.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {workedExamples.map((ex) => (
+              <button
+                key={ex.title}
+                onClick={() => navigator.clipboard.writeText(ex.prompt)}
+                className="group flex flex-col gap-2 rounded-xl border border-border/50 bg-card p-4 text-left hover:border-primary/30 transition-colors"
+                title="Click to copy prompt"
+              >
+                <div className="flex items-center gap-2">
+                  <Copy className="h-3.5 w-3.5 text-muted-foreground/60 shrink-0 group-hover:text-foreground transition-colors" />
+                  <p className="text-sm font-semibold text-foreground">{ex.title}</p>
+                </div>
+                <p className="text-sm text-muted-foreground group-hover:text-foreground transition-colors">
+                  {ex.prompt}
+                </p>
+                <p className="mt-auto pt-1 text-[11px] font-mono text-muted-foreground/70">{ex.flow}</p>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {/* What Claude can do — capability groups, not tool-by-tool */}
+        <section>
+          <h2 className="mb-1 text-lg font-semibold text-foreground">What Claude can do</h2>
+          <p className="mb-4 text-sm text-muted-foreground">
+            90 tools (HTTP) / 86 (stdio) organized by task. Claude picks the right ones — you describe the outcome in plain English.
+            For the full alphabetical tool list with parameters, see{" "}
+            <code className="bg-muted px-1 rounded">/api-docs</code> or{" "}
+            <code className="bg-muted px-1 rounded">/.well-known/mcp.json</code>.
+          </p>
+          <div className="grid gap-4 md:grid-cols-2">
+            {toolGroups.map((group) => {
+              const Icon = group.icon;
+              return (
+                <div
+                  key={group.title}
+                  className="flex flex-col gap-3 rounded-xl border border-border bg-card p-5"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                      <Icon className="h-4 w-4 text-primary" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-sm font-semibold text-foreground">{group.title}</h3>
+                      <p className="mt-1 text-xs text-muted-foreground leading-relaxed">{group.blurb}</p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => navigator.clipboard.writeText(group.example)}
+                    className="flex items-start gap-2 rounded-lg border border-border/50 bg-muted/40 px-3 py-2 text-left text-xs text-muted-foreground hover:border-primary/30 hover:text-foreground transition-colors"
+                    title="Click to copy prompt"
+                  >
+                    <Copy className="mt-0.5 h-3 w-3 shrink-0 opacity-50" />
+                    <span className="italic">&quot;{group.example}&quot;</span>
+                  </button>
+                  <div className="flex flex-wrap gap-1 pt-1">
+                    {group.tools.map((t) => (
+                      <code
+                        key={t}
+                        className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground"
+                      >
+                        {t}
+                      </code>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div className="mt-4 rounded-lg bg-muted/30 border border-border/50 px-4 py-3">
+            <p className="text-xs text-muted-foreground">
+              <strong className="text-foreground">How destructive ops stay safe:</strong> bulk updates,
+              deletes, imports, and subscription-detection all use a preview → confirm → execute pattern.
+              The preview returns a signed token scoped to the exact payload; the execute step rejects
+              unless the token matches. Claude can&apos;t skip the preview, and it can&apos;t mutate the
+              payload between steps without invalidating the token.
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/consent-controls.tsx
+++ b/src/app/privacy/consent-controls.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  setAnalyticsConsent,
+  getAnalyticsConsent,
+} from "@/components/analytics-consent";
+
+type ConsentState = "accepted" | "declined" | "unset";
+
+export function ConsentControls() {
+  const [consent, setConsent] = useState<ConsentState>("unset");
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+    setConsent(getAnalyticsConsent());
+    const onChange = () => setConsent(getAnalyticsConsent());
+    window.addEventListener("finlynq:analytics-consent", onChange);
+    return () => {
+      window.removeEventListener("finlynq:analytics-consent", onChange);
+    };
+  }, []);
+
+  if (!hydrated) {
+    return (
+      <div className="my-4 rounded-lg border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-4 rounded-lg border border-border bg-card p-4">
+      <p className="text-sm mb-3">
+        Current choice:{" "}
+        <strong>
+          {consent === "accepted"
+            ? "Accepted"
+            : consent === "declined"
+              ? "Declined"
+              : "Not yet decided"}
+        </strong>
+      </p>
+      <div className="flex gap-2 flex-wrap">
+        <button
+          type="button"
+          onClick={() => setAnalyticsConsent("accepted")}
+          className="px-3 py-1.5 rounded-md border border-border text-sm hover:bg-muted"
+        >
+          Accept analytics
+        </button>
+        <button
+          type="button"
+          onClick={() => setAnalyticsConsent("declined")}
+          className="px-3 py-1.5 rounded-md border border-border text-sm hover:bg-muted"
+        >
+          Decline analytics
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,407 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ConsentControls } from "./consent-controls";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Finlynq",
+  description:
+    "What Finlynq collects, how it's encrypted, what we never share, and how to export or delete your data.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <header className="mb-12 border-b border-border pb-8">
+          <Link
+            href="/"
+            className="text-xs font-mono uppercase tracking-wider text-muted-foreground hover:text-foreground"
+          >
+            ← Finlynq
+          </Link>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight">Privacy Policy</h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Last updated: 2026-05-07
+          </p>
+        </header>
+
+        <section className="prose prose-invert max-w-none space-y-8 text-[15px] leading-relaxed">
+          <p className="text-base">
+            Finlynq is an open-source personal-finance application (AGPL v3) that
+            you can run on your own hardware or use through our managed cloud at{" "}
+            <code>finlynq.com</code>. This policy applies to the managed cloud.
+            If you self-host, you are the data controller — this policy does not
+            apply to your own deployment.
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">1. What we collect</h2>
+          <p>
+            On the managed cloud, Finlynq stores only the data you put into it
+            yourself:
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              Account identity: a username (your choice), an email address (used
+              only for password recovery and security alerts), and a password
+              hash.
+            </li>
+            <li>
+              Financial data you import or enter: accounts, transactions,
+              budgets, investments, loans, goals, attached receipts.
+            </li>
+            <li>
+              Operational logs: HTTP request logs (IP address, user agent, URL
+              path, status code), kept 30 days for abuse prevention and
+              debugging.
+            </li>
+            <li>
+              MCP / API tokens you generate: stored as one-way hashes; the raw
+              token is shown to you once at creation and cannot be re-shown.
+            </li>
+          </ul>
+          <p>
+            We do not collect bank credentials. Finlynq has no Plaid, MX,
+            Yodlee, or Finicity integration. Your bank login never touches our
+            servers. You import data via CSV / OFX / QFX / PDF / email.
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            2. How your financial data is encrypted
+          </h2>
+          <p>
+            Finlynq uses per-user envelope encryption. The mechanism is
+            documented in detail in our{" "}
+            <a
+              href="https://github.com/finlynq/finlynq/blob/main/pf-app/docs/architecture/encryption.md"
+              className="underline underline-offset-2 hover:text-primary"
+            >
+              encryption architecture doc
+            </a>
+            . Summary:
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              Each user has a Data Encryption Key (DEK) generated at signup.
+            </li>
+            <li>
+              The DEK is wrapped with a Key Encryption Key (KEK) derived from
+              your password using <strong>scrypt</strong> with a server-side
+              pepper.
+            </li>
+            <li>
+              Sensitive fields (transaction payees, notes, tags, attached
+              files, encrypted display names) are stored as{" "}
+              <strong>AES-256-GCM</strong> ciphertext with random IV and
+              authentication tags.
+            </li>
+            <li>
+              Your DEK lives only in memory while you are signed in (sliding 2h
+              idle timeout). It is never persisted in plaintext on disk.
+            </li>
+            <li>
+              If you forget your password, your encrypted data cannot be
+              recovered. This is by design. Email recovery resets your account
+              identity, not the encrypted contents.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            3. What we never share
+          </h2>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              We do not sell, rent, or share your data with advertisers, data
+              brokers, or any third party.
+            </li>
+            <li>
+              We do not move money. Finlynq is not a broker, bank, advisor, or
+              SEC-registered RIA. We have no ability to initiate transfers from
+              your accounts.
+            </li>
+            <li>
+              We do not use your financial data to train AI models. The MCP
+              server lets <em>you</em> grant a third-party AI assistant
+              (Claude, ChatGPT, etc.) access to your data — but that access is
+              under your control, scoped per session, and revocable at any
+              time.
+            </li>
+            <li>
+              We do not use third-party analytics on the application itself.
+              Marketing pages (<code>/</code>, <code>/cloud</code>,{" "}
+              <code>/self-hosted</code>) load Google Analytics; the rest of the
+              application loads no analytics scripts.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            4. AI assistants and the MCP server
+          </h2>
+          <p>
+            When you connect Finlynq to an AI assistant via our MCP server, the
+            assistant authenticates through OAuth 2.1 (or with a Bearer API key
+            if you are using a CLI client). It receives only the data returned
+            by the specific tool it calls, scoped to your account.
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              The AI vendor (e.g., Anthropic) sees the tool responses, because
+              they pass through the model. We have no control over the AI
+              vendor's data handling — refer to their privacy policy.
+            </li>
+            <li>
+              You can revoke an OAuth grant at any time from{" "}
+              <code>Settings → Connected apps</code>.
+            </li>
+            <li>
+              Destructive operations (bulk delete, bulk update, imports) use a
+              preview-confirm-execute pattern with a server-signed token, so an
+              AI cannot mutate your data without your explicit confirmation in
+              the conversation.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            5. Sub-processors
+          </h2>
+          <p>
+            The managed cloud runs on a single VPS that we operate. We do not
+            use third-party data processors for the application database. The
+            only outbound integrations are:
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              Yahoo Finance, CoinGecko, Stooq — anonymous public-price queries
+              for portfolio valuation. No user data is sent.
+            </li>
+            <li>
+              Resend — transactional email (password reset, account alerts) and
+              the optional inbound-import address. Recipient email + content;
+              no body data shared beyond the email itself.
+            </li>
+            <li>
+              GitHub Sponsors / Ko-fi — donation processing, only if you
+              choose to donate. They handle their own KYC/payment data.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            6. Cookies and analytics
+          </h2>
+          <p>
+            The application itself (everything under <code>/dashboard</code>,{" "}
+            <code>/transactions</code>, etc.) loads no third-party analytics,
+            no advertising scripts, and no tracking pixels. Authentication uses
+            a single first-party session cookie required to keep you signed in;
+            it expires automatically.
+          </p>
+          <p>
+            On the public marketing pages — the homepage,{" "}
+            <code>/cloud</code>, and <code>/self-hosted</code> — we load Google
+            Analytics to understand which posts bring people here. GA is
+            non-essential, so we ask for your consent before loading it. Your
+            choice is stored in <code>localStorage</code> on your device only;
+            we don&apos;t see who declined. You can change your mind at any
+            time:
+          </p>
+          <ConsentControls />
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            7. Records of processing (GDPR Article 30)
+          </h2>
+          <p>
+            For users protected by GDPR, the following is our public record of
+            processing activities. Internal records are kept current and made
+            available to supervisory authorities on request.
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              <strong>Controller:</strong> Finlynq (operated from Canada by the
+              project maintainer). Contact: <code>privacy@finlynq.com</code>.
+            </li>
+            <li>
+              <strong>EU representative:</strong> Finlynq does not target the
+              EU market and processes data only on user-initiated requests.
+              Per GDPR Article 27(2), no representative is currently
+              designated. We will appoint one if processing volume or
+              targeting changes.
+            </li>
+            <li>
+              <strong>Purposes of processing:</strong> (1) provide the personal
+              finance application requested by the user; (2) authenticate
+              users; (3) deliver the optional MCP server access; (4) send
+              transactional email (password reset, security alerts); (5)
+              prevent abuse and debug operational issues.
+            </li>
+            <li>
+              <strong>Lawful basis:</strong> performance of a contract (signup
+              creates the contract — Article 6(1)(b)) and legitimate interest
+              for security logs (Article 6(1)(f)).
+            </li>
+            <li>
+              <strong>Categories of data subjects:</strong> users who sign up
+              for the managed cloud at finlynq.com.
+            </li>
+            <li>
+              <strong>Categories of personal data:</strong> username, email
+              address, password hash, financial transactions / accounts /
+              budgets / investments / loans / goals as entered or imported by
+              the user, MCP / API tokens (hashes only), HTTP request metadata.
+              No special-category (Article 9) data is collected.
+            </li>
+            <li>
+              <strong>Recipients / sub-processors:</strong> see Section 5
+              above. We do not sell or rent personal data.
+            </li>
+            <li>
+              <strong>Cross-border transfers:</strong> data is stored in
+              Canada. Canada is on the EU Commission&apos;s adequacy list for
+              commercial transfers (Article 45), so no additional safeguards
+              are required.
+            </li>
+            <li>
+              <strong>Retention:</strong> see Section 9 below.
+            </li>
+            <li>
+              <strong>Technical and organizational measures:</strong> per-user
+              envelope encryption with AES-256-GCM and scrypt-derived KEK
+              (Section 2); HTTPS/TLS in transit; principle of least privilege
+              for staff; rate limiting and origin validation on the MCP
+              endpoint; no production database access for non-essential staff;
+              regular dependency updates.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            8. Security incident response
+          </h2>
+          <p>
+            Our breach response process aligns with GDPR Articles 33 and 34:
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              <strong>Detection:</strong> automated monitoring on the
+              authentication endpoints, OAuth grant lifecycle, and unusual
+              access patterns. Manual review of any anomaly within one
+              business day.
+            </li>
+            <li>
+              <strong>Containment:</strong> on suspicion of compromise, we
+              rotate <code>DEPLOY_GENERATION</code> (force-logs-out every
+              session and invalidates in-flight JWTs), revoke OAuth grants if
+              scoped, and lock affected accounts.
+            </li>
+            <li>
+              <strong>Notification to supervisory authority:</strong> if a
+              personal-data breach occurs, we notify the relevant supervisory
+              authority within 72 hours of becoming aware, per Article 33(1).
+            </li>
+            <li>
+              <strong>Notification to affected users:</strong> when a breach
+              is likely to result in high risk, we notify affected users
+              without undue delay (Article 34), using the email on file plus
+              an in-app banner.
+            </li>
+            <li>
+              <strong>Documentation:</strong> we maintain an internal incident
+              log including the facts, effects, and remedial actions taken
+              (Article 33(5)).
+            </li>
+            <li>
+              <strong>Reporting a vulnerability:</strong> please email{" "}
+              <code>privacy@finlynq.com</code> with details. We aim to confirm
+              receipt within 48 hours.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            9. Retention and deletion
+          </h2>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              You can export your full account at any time as a JSON backup
+              from <code>Settings → Data → Export</code>.
+            </li>
+            <li>
+              You can wipe your account from{" "}
+              <code>Settings → Data → Delete account</code>. This removes every
+              row scoped to your <code>user_id</code> across all 22 tables in a
+              single transaction.
+            </li>
+            <li>
+              Operational logs (HTTP requests) are retained for 30 days, then
+              rotated.
+            </li>
+            <li>
+              Database backups are retained for 7 days. After 7 days, deleted
+              account data is unrecoverable from backups.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            10. Children&apos;s privacy
+          </h2>
+          <p>
+            Finlynq is not directed at children under 16 and we do not
+            knowingly collect data from children. If you become aware of a
+            child's account, contact us and we will delete it.
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            11. Jurisdiction and your rights
+          </h2>
+          <p>
+            Finlynq is operated from Canada. You can exercise your access,
+            rectification, deletion, and portability rights at any time
+            directly from <code>Settings → Data</code>; you do not need to ask
+            us. For other inquiries (GDPR Article 15 access requests, CCPA
+            opt-outs, EU data-subject requests), contact us using the address
+            below — we will respond within 30 days.
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">12. Changes</h2>
+          <p>
+            We will update this page when our practices change and bump the
+            "Last updated" date at the top. Material changes (a new
+            sub-processor, a change to encryption guarantees) will also be
+            announced in the project{" "}
+            <a
+              href="https://github.com/finlynq/finlynq/blob/main/CHANGELOG.md"
+              className="underline underline-offset-2 hover:text-primary"
+            >
+              changelog
+            </a>
+            .
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">13. Contact</h2>
+          <p>
+            Privacy questions, data-subject requests, security disclosures:{" "}
+            <code>privacy@finlynq.com</code>. Source-code questions, bugs,
+            feature requests: open an issue at{" "}
+            <a
+              href="https://github.com/finlynq/finlynq/issues"
+              className="underline underline-offset-2 hover:text-primary"
+            >
+              github.com/finlynq/finlynq
+            </a>
+            .
+          </p>
+
+          <p className="mt-12 text-xs text-muted-foreground">
+            The full encryption design, including the key-derivation parameters
+            and threat model, is published at{" "}
+            <a
+              href="https://github.com/finlynq/finlynq/blob/main/pf-app/docs/architecture/encryption.md"
+              className="underline underline-offset-2 hover:text-primary"
+            >
+              pf-app/docs/architecture/encryption.md
+            </a>
+            . The code that implements it is in{" "}
+            <code>pf-app/src/lib/crypto/</code>. Both are AGPL v3 — read the
+            code, audit it, fork it.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/vs/era/page.tsx
+++ b/src/app/vs/era/page.tsx
@@ -1,0 +1,319 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { GoogleAnalytics } from "@/components/google-analytics";
+
+export const metadata: Metadata = {
+  title: "Finlynq vs Era — open-source MCP personal finance alternative",
+  description:
+    "Era is a hosted, AI-first personal finance SaaS with a closed MCP server. Finlynq is the open-source, self-hostable alternative — same MCP-driven UX, your infrastructure, your encryption keys.",
+};
+
+export default function VsEraPage() {
+  return (
+    <div className="min-h-screen bg-dot-pattern ambient-glow">
+      <GoogleAnalytics />
+      <div className="mx-auto w-full max-w-3xl px-6 py-12">
+        <Link
+          href="/"
+          className="mb-8 inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+        >
+          ← Back
+        </Link>
+
+        <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary">
+          <span className="text-2xl font-extrabold tracking-wide text-primary-foreground">
+            FL
+          </span>
+        </div>
+
+        <h1 className="mb-3 text-3xl font-bold tracking-tight text-foreground">
+          Finlynq vs Era
+        </h1>
+        <p className="mb-10 text-muted-foreground">
+          Era is a hosted, AI-first personal finance SaaS with a closed-source
+          MCP server. Finlynq is the open-source, self-hostable alternative —
+          same MCP-driven UX, your infrastructure, your encryption keys, no
+          aggregator hostage.
+        </p>
+
+        <section className="mb-10">
+          <h2 className="mb-3 text-lg font-semibold text-foreground">
+            When to choose Era
+          </h2>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li>
+              ✓ You want bank sync to &ldquo;just work&rdquo; out of the box.
+              Era ships with aggregator-grade automatic transactions across
+              thousands of US institutions; Finlynq is currently file/email
+              import only.
+            </li>
+            <li>
+              ✓ You want a native iOS/Android app today. Era&rsquo;s Agency is
+              a real native mobile app; Finlynq has a mobile-friendly web UI
+              but no native app yet.
+            </li>
+            <li>
+              ✓ You want regulated investment advisory or brokerage.
+              Era&rsquo;s Thesis (private beta) is an SEC-registered
+              investment adviser with brokerage via Alpaca. Finlynq is not —
+              and explicitly never will be.
+            </li>
+            <li>
+              ✓ You don&rsquo;t want to think about Postgres, Docker,
+              encryption keys, or password recovery. Era is hosted; that&rsquo;s
+              the whole pitch.
+            </li>
+            <li>
+              ✓ You want shared household finances baked in. Era&rsquo;s
+              multi-user shared views are first-class.
+            </li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-3 text-lg font-semibold text-foreground">
+            When to choose Finlynq
+          </h2>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li>
+              ✓ <strong>You want the source code.</strong> Finlynq is AGPL v3,
+              fully on GitHub. Era is closed-source.
+            </li>
+            <li>
+              ✓ <strong>You want to self-host.</strong> Finlynq runs on your
+              hardware via Docker + PostgreSQL. Era cannot be self-hosted.
+            </li>
+            <li>
+              ✓ <strong>You want per-user encryption with keys derived from
+              your password.</strong> Finlynq&rsquo;s envelope encryption
+              (AES-256-GCM with scrypt-derived KEK) means even the operator
+              cannot read your transaction notes, payees, tags, or display
+              names.
+            </li>
+            <li>
+              ✓ <strong>You want the bigger MCP surface.</strong> Finlynq
+              exposes 90 HTTP tools and 86 stdio tools across budgets,
+              transactions, portfolios, goals, loans, subscriptions, and
+              rules. Era&rsquo;s public Context surface is four primary
+              capabilities.
+            </li>
+            <li>
+              ✓ <strong>You want plaintext-accounting workflows.</strong>{" "}
+              Finlynq is built for users who already think in ledger files;
+              Era is not.
+            </li>
+            <li>
+              ✓ <strong>You want to own your data on the day Era pivots, gets
+              acquired, or shuts down.</strong>
+            </li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-3 text-lg font-semibold text-foreground">
+            Side-by-side
+          </h2>
+          <div className="overflow-x-auto rounded-xl border border-border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted text-muted-foreground">
+                <tr>
+                  <th className="p-3 text-left font-medium">&nbsp;</th>
+                  <th className="p-3 text-left font-medium">Finlynq</th>
+                  <th className="p-3 text-left font-medium">Era</th>
+                </tr>
+              </thead>
+              <tbody className="text-foreground">
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">License</td>
+                  <td className="p-3">AGPL v3</td>
+                  <td className="p-3">Closed source</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Hosting</td>
+                  <td className="p-3">Self-host or managed cloud</td>
+                  <td className="p-3">Hosted SaaS only</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">First-party MCP</td>
+                  <td className="p-3">90 HTTP / 86 stdio tools</td>
+                  <td className="p-3">~4 primary capabilities</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">MCP auth</td>
+                  <td className="p-3">OAuth 2.1 + DCR / Bearer / stdio</td>
+                  <td className="p-3">OAuth 2.1, scoped</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">REST/HTTP API</td>
+                  <td className="p-3">Full surface mirrored from MCP</td>
+                  <td className="p-3">Not publicly documented</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Bank sync</td>
+                  <td className="p-3">File / email import; no Plaid</td>
+                  <td className="p-3">Aggregator-based auto-sync</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Encryption at rest</td>
+                  <td className="p-3">
+                    Per-user envelope (AES-256-GCM, scrypt-derived KEK)
+                  </td>
+                  <td className="p-3">AES-256 at rest, operator-held keys</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Multi-currency</td>
+                  <td className="p-3">Native, per-currency cost basis</td>
+                  <td className="p-3">US-feed centric</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Investment / portfolio</td>
+                  <td className="p-3">Cost basis + dividends, not advisory</td>
+                  <td className="p-3">Thesis: SEC-RIA + Alpaca brokerage</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Native mobile app</td>
+                  <td className="p-3">No (mobile web)</td>
+                  <td className="p-3">Yes — Agency</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Multi-user / household</td>
+                  <td className="p-3">No (single-user)</td>
+                  <td className="p-3">Yes — shared views</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Pricing</td>
+                  <td className="p-3">Donation-based</td>
+                  <td className="p-3">Freemium + paid tiers</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="p-3 font-medium">Revenue model</td>
+                  <td className="p-3">Donations</td>
+                  <td className="p-3">Subscriptions</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-3 text-lg font-semibold text-foreground">
+            Migrating from Era
+          </h2>
+          <ol className="space-y-2 text-sm text-muted-foreground">
+            <li>
+              1. Export your transactions and category/recurring rules from
+              Era. Verify Era&rsquo;s current export options at era.app.
+            </li>
+            <li>
+              2. Import into Finlynq via{" "}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                /import/reconcile
+              </code>{" "}
+              — upload a CSV, review and edit each row in the staging dialog,
+              approve. Multi-currency, transfer-pair detection, and dedup are
+              all built into the staging flow.
+            </li>
+            <li>
+              3. Hook up your AI client. Open Claude → Customize → Connectors
+              → &ldquo;+&rdquo; → paste{" "}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">
+                https://finlynq.com/mcp
+              </code>
+              . OAuth handles the rest. For self-host, point Claude at your
+              own deployment&rsquo;s{" "}
+              <code className="rounded bg-muted px-1 py-0.5 text-xs">/mcp</code>{" "}
+              URL.
+            </li>
+          </ol>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="mb-3 text-lg font-semibold text-foreground">FAQ</h2>
+          <div className="space-y-4 text-sm text-muted-foreground">
+            <div>
+              <p className="font-semibold text-foreground">
+                Why are you comparing yourself to a paid product when
+                you&rsquo;re free?
+              </p>
+              <p>
+                Because the comparison isn&rsquo;t price — it&rsquo;s where
+                your data lives, who can read it, and what happens if the
+                operator pivots. Finlynq&rsquo;s argument is structural, not a
+                discount.
+              </p>
+            </div>
+            <div>
+              <p className="font-semibold text-foreground">
+                Doesn&rsquo;t Era&rsquo;s bank sync make this a non-comparison
+                for most users?
+              </p>
+              <p>
+                For users who want one-click bank sync and don&rsquo;t care
+                about source code or self-hosting, Era is the better default.
+                Finlynq&rsquo;s audience is users who specifically don&rsquo;t
+                want a third-party aggregator holding their bank credentials.
+              </p>
+            </div>
+            <div>
+              <p className="font-semibold text-foreground">
+                Why does this read like a hit piece?
+              </p>
+              <p>
+                It&rsquo;s not. Era ships real things — first-party MCP,
+                OAuth-scoped tools, native mobile, an investment-advisory
+                product Finlynq legally cannot offer. The honest difference
+                is: Era is hosted convenience for users who trust an operator
+                with their financial life, and Finlynq is the substrate for
+                users who don&rsquo;t want to.
+              </p>
+            </div>
+            <div>
+              <p className="font-semibold text-foreground">
+                Does Finlynq have a mobile app?
+              </p>
+              <p>
+                Not yet. The web UI is mobile-friendly, but a native iOS /
+                Android wrapper isn&rsquo;t shipped. If you need native mobile
+                today, Era is ahead.
+              </p>
+            </div>
+            <div>
+              <p className="font-semibold text-foreground">
+                Will Finlynq ever offer regulated investment advisory like
+                Era&rsquo;s Thesis?
+              </p>
+              <p>
+                No. Becoming an SEC-registered investment adviser is
+                incompatible with the AGPL self-hostable design — the
+                regulator wants a single accountable entity, the design wants
+                none. Finlynq is the database; the user can hire whatever
+                advisor they want against the data.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-10 rounded-xl border border-border bg-muted/40 p-6">
+          <h2 className="mb-2 text-lg font-semibold text-foreground">
+            Try Finlynq
+          </h2>
+          <p className="mb-3 text-sm text-muted-foreground">
+            Demo login{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">
+              demo@finlynq.com
+            </code>{" "}
+            /{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">
+              finlynq-demo
+            </code>{" "}
+            — resets nightly. Or self-host:
+          </p>
+          <pre className="overflow-x-auto rounded-xl bg-muted p-4 text-sm">
+            <code>{`curl -O https://raw.githubusercontent.com/finlynq/finlynq/main/pf-app/docker-compose.yml
+docker compose up -d`}</code>
+          </pre>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/analytics-consent.tsx
+++ b/src/components/analytics-consent.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+/**
+ * Analytics consent banner + consent-gated Google Analytics loader.
+ *
+ * Replaces the unconditional `<GoogleAnalytics />` on public marketing pages.
+ * Required for ePrivacy / GDPR compliance: GA cookies are non-essential, so
+ * they cannot load until the user explicitly opts in.
+ *
+ * Persistence: localStorage key `finlynq:analytics-consent` ∈ {"accepted",
+ * "declined"}. Absence = banner is shown. Choice persists across sessions on
+ * the same browser; user can change it from /privacy.
+ */
+
+import { useEffect, useState } from "react";
+import Script from "next/script";
+
+const GA_MEASUREMENT_ID = "G-ZDQJXS0C3Z";
+const STORAGE_KEY = "finlynq:analytics-consent";
+
+type Consent = "accepted" | "declined" | "unset";
+
+function readConsent(): Consent {
+  if (typeof window === "undefined") return "unset";
+  const v = window.localStorage.getItem(STORAGE_KEY);
+  if (v === "accepted" || v === "declined") return v;
+  return "unset";
+}
+
+function writeConsent(value: "accepted" | "declined") {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, value);
+  window.dispatchEvent(new Event("finlynq:analytics-consent"));
+}
+
+function useConsent() {
+  const [consent, setConsent] = useState<Consent>("unset");
+
+  useEffect(() => {
+    setConsent(readConsent());
+    const onChange = () => setConsent(readConsent());
+    window.addEventListener("finlynq:analytics-consent", onChange);
+    window.addEventListener("storage", onChange);
+    return () => {
+      window.removeEventListener("finlynq:analytics-consent", onChange);
+      window.removeEventListener("storage", onChange);
+    };
+  }, []);
+
+  return consent;
+}
+
+function GoogleAnalyticsScripts() {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `}
+      </Script>
+    </>
+  );
+}
+
+function ConsentBanner({ onChoice }: { onChoice: (v: "accepted" | "declined") => void }) {
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Analytics cookies"
+      style={{
+        position: "fixed",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 9999,
+        background: "#0e1116",
+        borderTop: "1px solid #2a3139",
+        color: "#e8eaed",
+        padding: "14px 18px",
+        boxShadow: "0 -8px 24px rgba(0,0,0,0.35)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1100,
+          margin: "0 auto",
+          display: "flex",
+          gap: 18,
+          alignItems: "center",
+          flexWrap: "wrap",
+          fontSize: 13,
+          lineHeight: 1.45,
+        }}
+      >
+        <p style={{ flex: "1 1 320px", margin: 0, color: "#cdd2d8" }}>
+          We use Google Analytics on our public marketing pages to understand
+          which posts bring people here. We don&apos;t use any analytics inside
+          the app itself, and we never sell your data. You can decline below
+          and the page works fine.{" "}
+          <a
+            href="/privacy"
+            style={{ color: "#f5a623", textDecoration: "underline" }}
+          >
+            Privacy policy
+          </a>
+          .
+        </p>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            type="button"
+            onClick={() => onChoice("declined")}
+            style={{
+              background: "transparent",
+              color: "#9aa3ad",
+              border: "1px solid #2a3139",
+              padding: "8px 14px",
+              borderRadius: 6,
+              cursor: "pointer",
+              fontSize: 13,
+            }}
+          >
+            Decline
+          </button>
+          <button
+            type="button"
+            onClick={() => onChoice("accepted")}
+            style={{
+              background: "#f5a623",
+              color: "#0e1116",
+              border: "1px solid #f5a623",
+              padding: "8px 14px",
+              borderRadius: 6,
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AnalyticsConsent() {
+  const consent = useConsent();
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  // Until we've hydrated, render nothing — avoids SSR/CSR mismatch and never
+  // loads GA before consent state is known.
+  if (!hydrated) return null;
+
+  return (
+    <>
+      {consent === "accepted" && <GoogleAnalyticsScripts />}
+      {consent === "unset" && (
+        <ConsentBanner
+          onChoice={(v) => writeConsent(v)}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Public helper for /privacy to let users change their mind.
+ */
+export function setAnalyticsConsent(value: "accepted" | "declined") {
+  writeConsent(value);
+}
+
+export function getAnalyticsConsent(): Consent {
+  return readConsent();
+}


### PR DESCRIPTION
## Summary

**This is a DRAFT — not intended to merge as-is.** It exists to preserve five untracked files that have been sitting on the working tree for multiple sessions, flagged in `SECURITY_HANDOVER_2026-05-07.md` as "predates this work, needs user judgment." Now committed somewhere safe so dev's working tree is clean for the security batch (Cleanup #7 / #8 from session 4).

## What's in this branch

- `mcp-server/auto-annotations.ts` — MCP tool annotations (title/readOnlyHint/destructiveHint) for the Anthropic Connectors Directory submission. Monkey-patches `server.tool()` to inject inferred annotations from tool name. Real feature, not throwaway.
- `src/components/analytics-consent.tsx` — GDPR/ePrivacy consent banner gating the Google Analytics loader on public marketing pages. localStorage at `finlynq:analytics-consent`. Required before the always-on GA on `/`, `/cloud`, `/self-hosted` can ship to EU users.
- `src/app/privacy/{page.tsx,consent-controls.tsx}` — public privacy policy + in-page consent revocation toggle.
- `src/app/vs/era/page.tsx` — competitor comparison page (Era launched on Anthropic Directory 2026-05-06).
- `src/app/mcp-guide/page.tsx` — PUBLIC version of the existing `src/app/(app)/mcp-guide/page.tsx`. 912 lines. Updated copy for unauthenticated visitors + current tool counts (90 HTTP / 86 stdio vs the auth-gated page's stale 78). Refactor target appears to be replacing the auth-gated version with the public one.

## Build conflict (why this is a draft)

`src/app/mcp-guide/` and `src/app/(app)/mcp-guide/` are parallel routes resolving to the same `/mcp-guide` path:

```
You cannot have two parallel pages that resolve to the same path.
Please check /(app)/mcp-guide and /mcp-guide.
```

CI will fail until one is removed. **`stash@{0}` on dev contains the deletion of `src/app/(app)/mcp-guide/page.tsx`** plus a bunch of other migration work (chat-engine, import-hash, etc.) that has SINCE been independently shipped via the security batch — popping that stash blindly would conflict heavily. Recommended path: cherry-pick just the mcp-guide deletion out of `stash@{0}` when ready to merge this PR.

## Stash review (Cleanup #8)

For the operator's reference. None popped, none dropped — they're safer in the stash list than in the working tree.

| Stash | Branch | Status | Recommendation |
|---|---|---|---|
| `stash@{0}` | dev | WIP migration, mostly superseded by B1–B10 security batch | Cherry-pick only the `(app)/mcp-guide/page.tsx` deletion when merging this PR. Drop the rest. |
| `stash@{1}` | claude/issue-131 | deploy.sh standalone asset copy | Already shipped in main; safe to drop. |
| `stash@{2}` | claude/issue-124 | issue-123 WIP | Stale (issue 123 closed long ago). Safe to drop unless WIP is still relevant. |
| `stash@{3}` | claude/issue-88 | stale changes | Stale (issue 88 closed). Safe to drop. |

## Recommended path forward

1. Decide on the `mcp-guide` migration: keep public, drop `(app)/mcp-guide/`?
2. If yes: cherry-pick `git checkout stash@{0} -- src/app/\(app\)/mcp-guide/page.tsx && git rm src/app/\(app\)/mcp-guide/page.tsx` onto this branch
3. CI will go green
4. Mark this PR ready, merge

Or close this PR if the in-progress work has gone stale and isn't worth shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)