### PR TITLE
test: triage 90 pre-existing failures — recover 11 (Open #3, batch 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Test hygiene — partial triage of pre-existing failures (Open #3, batch 1) (2026-05-07)
+
+The handover noted ~90 pre-existing test failures that pre-dated the security batch (post-Stream-D-Phase-4 cleanup never finished). This first triage batch fixes 11 of them by patching mocks that drifted from current route signatures, and documents the remaining 79 by root cause for future PRs.
+
+- **fx-service mock missing `getDisplayCurrency`** ([tests/api/budgets.test.ts](tests/api/budgets.test.ts), [tests/api/dashboard.test.ts](tests/api/dashboard.test.ts), [tests/api/fx.test.ts](tests/api/fx.test.ts), [tests/api/reports.test.ts](tests/api/reports.test.ts)) — every route gained a `await getDisplayCurrency(userId, ?currency)` call to honor the user's display-currency preference, but the four tests that mock `@/lib/fx-service` never added the function to their mock factory. Fix: add `getDisplayCurrency: vi.fn(async (_userId, override) => override ?? "CAD")` to each mock object.
+- **`getRateMap` second-arg mismatch** ([tests/api/budgets.test.ts:99](tests/api/budgets.test.ts), [tests/api/dashboard.test.ts:65](tests/api/dashboard.test.ts)) — Stream D added a `userId` second argument to `getRateMap` for per-user rate caching. Two tests asserted only the currency arg (`toHaveBeenCalledWith("EUR")`); fixed to include the auth-mock's userId (`"default"`).
+- **schema mock missing `portfolioHoldings`/`holdingAccounts`** ([tests/api/reports.test.ts](tests/api/reports.test.ts)) — the reports route now calls `getHoldingsValueByAccount` for unrealized P&L, which references `schema.portfolioHoldings.id`. Added stubs for `portfolioHoldings`, `holdingAccounts`, and the additional columns (quantity, portfolioHoldingId, userId, type, linkId, tradeLinkId, enteredAmount, enteredCurrency on transactions; userId on categories/accounts/portfolio_holdings).
+
+**Result**: 90 → 79 failing tests (11 recovered). `tests/security-tenant-isolation.test.ts`, `tests/oauth-scopes.test.ts`, `tests/envelope-pepper-version.test.ts`, `tests/api/middleware-csrf.test.ts`, `tests/login-lockout-enumeration.test.ts`, all middleware/request-origins tests still passing.
+
+**Remaining 79 failures grouped by root cause** (each is its own follow-up PR; this triage is the foundation):
+
+1. **Stream D Phase 4 plaintext-name fallout** (~30 failures) — tests expect routes to return `name: "Groceries"` but they now return `name: null` because the column was dropped and tests don't seed `name_ct` ciphertext. Per-feature fixture update + DEK seeding. Files: `tests/api/categories.test.ts`, `tests/api/goals.test.ts`, `tests/api/loans.test.ts`, `tests/api/subscriptions.test.ts`.
+2. **Drizzle proxy-mock `rows.map is not a function`** (~20 failures) — the `mockDbChain` Proxy returns the chain object on every property access; awaited `db.select()` chains expect to terminate in an array. Needs the proxy to be thenable / mock-resolveable. Files: `tests/api/reports.test.ts`, `tests/api/snapshots.test.ts`, `tests/api/recap.test.ts`, `tests/api/scenarios.test.ts`, `tests/api/recurring.test.ts`.
+3. **404 vs 200 on routes that gained `requireEncryption()`** (~15 failures) — handlers now refuse with 423 if no DEK, and tests don't supply one. Mock should set `dek: <Buffer>` on the auth context. Files: `tests/api/data.test.ts`, `tests/api/import-execute.test.ts`, `tests/api/portfolio.test.ts`, `tests/api/insights.test.ts`, `tests/api/onboarding.test.ts`, `tests/api/tax.test.ts`, `tests/api/monte-carlo.test.ts`, `tests/api/fire.test.ts`.
+4. **`rawGoals.map is not a function`** ([tests/api/goals.test.ts](tests/api/goals.test.ts)) — overlaps with #1 and #2. Goals route now JOINs through `goal_accounts` (issue #130, 2026-05-04); the proxy mock doesn't reflect the new shape.
+5. **MFA / require-auth schema drift** ([tests/auth/mfa.test.ts](tests/auth/mfa.test.ts), [tests/auth/require-auth.test.ts](tests/auth/require-auth.test.ts)) — the B7 MFA pending-JWT + `revoked_jtis` work added behavior these tests didn't anticipate.
+6. **chat-engine `userId` parameter** ([tests/api/chat.test.ts](tests/api/chat.test.ts)) — the B3 cross-tenant fix added a required `userId` param; test doesn't pass one.
+7. **rules POST `match_payee` reference** ([tests/api/rules.test.ts](tests/api/rules.test.ts)) — the well-known pre-existing `match_payee` column bug (per CLAUDE.md "Several MCP rule-management tools reference `match_payee` (a non-existent column)").
+8. **transactions schema-drift** ([tests/api/transactions.test.ts](tests/api/transactions.test.ts)) — pre-mock-only references; tests still seed the dropped Stream-D plaintext columns.
+
+Each group is independent; an agent could pick any single bucket and ship a targeted PR. Recommended order: #3 (DEK on auth context) → #1 (Stream D fixtures) → #2 (Drizzle proxy mock) — biggest blocks of failures and least risk of cross-contamination.
+
 ### Security — Session 4 batch E: PF_PEPPER rotation support (Open #2) (2026-05-07)
 - **Pepper rotation is now non-destructive.** Until this PR, rotating `PF_PEPPER` invalidated every encrypted DEK envelope: the new scrypt input didn't match the wrap, so unwrap failed with a bad-tag error and active users would silently render encrypted columns as null. The handover called this out as a "load-bearing, must be tested against a copy of prod DB first" follow-up.
 - **Schema** ([scripts/migrations/20260507_pepper_version.sql](scripts/migrations/20260507_pepper_version.sql)) — `users.pepper_version SMALLINT NOT NULL DEFAULT 1`. Names which env var holds the pepper used when the row's DEK envelope was last wrapped: version 1 → `PF_PEPPER` (legacy default), version N → `PF_PEPPER_V<N>` (rotated). Partial index on `pepper_version` to make the rotation script's "find stragglers" SELECT cheap.

--- a/tests/api/budgets.test.ts
+++ b/tests/api/budgets.test.ts
@@ -32,6 +32,10 @@ const mockConvertWithRateMap = vi.fn();
 vi.mock("@/lib/fx-service", () => ({
   getRateMap: (...a: unknown[]) => mockGetRateMap(...a),
   convertWithRateMap: (...a: unknown[]) => mockConvertWithRateMap(...a),
+  // Routes call getDisplayCurrency to resolve `?currency=` against the user's
+  // settings. The override-or-CAD fallback matches every existing test that
+  // doesn't explicitly pass a currency.
+  getDisplayCurrency: vi.fn(async (_userId: string, override: string | null) => override ?? "CAD"),
 }));
 
 import { GET, POST, DELETE } from "@/app/api/budgets/route";
@@ -92,7 +96,8 @@ describe("API /api/budgets", () => {
       ]);
       const req = createMockRequest("http://localhost:3000/api/budgets?month=2024-01&currency=EUR");
       await GET(req);
-      expect(mockGetRateMap).toHaveBeenCalledWith("EUR");
+      // getRateMap signature is (displayCurrency, userId) per Stream D rate caching.
+      expect(mockGetRateMap).toHaveBeenCalledWith("EUR", "default");
     });
   });
 

--- a/tests/api/dashboard.test.ts
+++ b/tests/api/dashboard.test.ts
@@ -20,6 +20,7 @@ const mockConvertWithRateMap = vi.fn();
 vi.mock("@/lib/fx-service", () => ({
   getRateMap: (...a: unknown[]) => mockGetRateMap(...a),
   convertWithRateMap: (...a: unknown[]) => mockConvertWithRateMap(...a),
+  getDisplayCurrency: vi.fn(async (_userId: string, override: string | null) => override ?? "CAD"),
 }));
 
 import { GET } from "@/app/api/dashboard/route";
@@ -61,7 +62,7 @@ describe("API /api/dashboard", () => {
     const res = await GET(req);
     const { data } = await parseResponse(res);
     expect((data as { displayCurrency: string }).displayCurrency).toBe("USD");
-    expect(mockGetRateMap).toHaveBeenCalledWith("USD");
+    expect(mockGetRateMap).toHaveBeenCalledWith("USD", "default");
   });
 
   it("converts account balances to display currency", async () => {

--- a/tests/api/fx.test.ts
+++ b/tests/api/fx.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/lib/fx-service", () => ({
   getActiveCurrencies: (...a: unknown[]) => mockGetActiveCurrencies(...a),
   getRateMap: (...a: unknown[]) => mockGetRateMap(...a),
   convertWithRateMap: (...a: unknown[]) => mockConvertWithRateMap(...a),
+  getDisplayCurrency: vi.fn(async (_userId: string, override: string | null) => override ?? "CAD"),
 }));
 
 import { GET } from "@/app/api/fx/route";

--- a/tests/api/reports.test.ts
+++ b/tests/api/reports.test.ts
@@ -13,9 +13,14 @@ vi.mock("@/db", () => ({
     get: (_t, prop) => mockDbChain[prop as string] ?? vi.fn().mockReturnValue(mockDbChain),
   }),
   schema: {
-    transactions: { id: "id", date: "date", amount: "amount", accountId: "accountId", categoryId: "categoryId", currency: "currency", isBusiness: "isBusiness" },
-    categories: { id: "id", type: "type", group: "group", name: "name" },
-    accounts: { id: "id", type: "type", group: "group", name: "name", currency: "currency" },
+    transactions: { id: "id", date: "date", amount: "amount", accountId: "accountId", categoryId: "categoryId", currency: "currency", isBusiness: "isBusiness", quantity: "quantity", portfolioHoldingId: "portfolioHoldingId", userId: "userId", type: "type", linkId: "linkId", tradeLinkId: "tradeLinkId", enteredAmount: "enteredAmount", enteredCurrency: "enteredCurrency" },
+    categories: { id: "id", type: "type", group: "group", name: "name", userId: "userId" },
+    accounts: { id: "id", type: "type", group: "group", name: "name", currency: "currency", userId: "userId", isInvestment: "isInvestment" },
+    // Stream D / portfolio routes pull schema.portfolioHoldings off this mock.
+    // Without these stubs, getHoldingsValueByAccount blows up on
+    // `schema.portfolioHoldings.id` (undefined-property access).
+    portfolioHoldings: { id: "id", accountId: "accountId", userId: "userId", nameCt: "nameCt", symbolCt: "symbolCt", currency: "currency", isCrypto: "isCrypto", nameLookup: "nameLookup" },
+    holdingAccounts: { holdingId: "holdingId", accountId: "accountId", userId: "userId", qty: "qty", costBasis: "costBasis" },
   },
 }));
 
@@ -26,6 +31,7 @@ vi.mock("@/lib/auth/require-auth", () => ({
 vi.mock("@/lib/fx-service", () => ({
   getRateMap: vi.fn(async () => new Map([["CAD", 1]])),
   convertWithRateMap: vi.fn((amount: number) => amount),
+  getDisplayCurrency: vi.fn(async (_userId: string, override: string | null) => override ?? "CAD"),
 }));
 
 vi.mock("drizzle-orm", () => ({


### PR DESCRIPTION
## Summary

Closes batch 1 of **Open #3** from `SECURITY_HANDOVER_2026-05-07.md` — 90 pre-existing test failures the security batch inherited. This PR fixes 11 by aligning mocks with current route signatures, and groups the remaining 79 by root cause so future triage PRs can take one bucket each.

## Result: 90 → 79 failing

- 4 test files updated, 11 tests now pass
- All other passing tests still pass (no regressions)

## What was fixed

1. **`getDisplayCurrency` missing from fx-service mock** in 4 files. Every route now calls `await getDisplayCurrency(userId, ?currency)` to honor the user's display-currency preference, but the test mocks were never updated.
2. **`getRateMap` assertions missing userId second arg** in 2 files. Stream D added per-user rate caching; tests asserted only the currency.
3. **Schema mock missing `portfolioHoldings`/`holdingAccounts`** in `reports.test.ts`. The route now calls `getHoldingsValueByAccount` which references these.

## Remaining 79 failures, grouped by root cause

Each group is independent and would make a clean follow-up PR:

1. **Stream D Phase 4 plaintext-name fallout** (~30) — tests expect `name: "Groceries"` but routes return `name: null`. Per-feature fixture update + DEK seeding.
2. **Drizzle proxy-mock `rows.map is not a function`** (~20) — the chain proxy doesn't terminate in an array.
3. **404 vs 200 on routes that gained `requireEncryption()`** (~15) — tests don't supply a DEK on the auth context.
4. **Goals/holding-accounts JOIN drift** — overlaps with #1 + #2.
5. **MFA / require-auth schema drift** — B7 added pending-JWT + `revoked_jtis`.
6. **chat-engine `userId` param** — B3 cross-tenant fix added required arg.
7. **rules `match_payee` reference** — the well-known pre-existing column-doesn't-exist bug.
8. **transactions schema drift** — Stream D plaintext columns dropped.

Recommended order for follow-ups: #3 → #1 → #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)