### PR TITLE
docs(security): formal note on style-src 'unsafe-inline' constraint (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Documentation — formal note on `style-src 'unsafe-inline'` constraint (#9, 2026-05-07)
+
+Captures the technical constraint behind why `style-src 'unsafe-inline'` can't be removed from the CSP today, and the migration path for closing it. Code-only change to [src/middleware.ts](src/middleware.ts) — a 28-line comment block above the CSP directive.
+
+**Constraint**: every React `style={{ ... }}` prop renders as a `style="..."` HTML attribute. HTML attributes can't carry CSP nonces (only `<style>` and `<script>` tags can). Removing `'unsafe-inline'` would break every component using the style prop, plus framework-injected inline styles from Recharts, framer-motion, and Next.js's not-found page. Adding a nonce alongside `'unsafe-inline'` doesn't help — browsers disable `'unsafe-inline'` the moment any nonce or hash appears in the directive.
+
+**Migration path** (out of scope of this PR):
+1. Audit every `style={{ ... }}` in `src/` (11 files at last count). Most can move to Tailwind atomic classes; the rest can use CSS custom properties via className + `--var`.
+2. Framework inline styles (Recharts SVG positioning, framer-motion animations, Next.js error pages) need hashing with `'sha256-...'` or framework-level workarounds.
+3. Verify the migration with the existing CSP test suite + a runtime CSP-violation observer in dev.
+
+**Threat addressed by closing this**: an XSS that escapes script-src (currently impossible post-B10) could exfiltrate via inline `background-image: url(attacker)` or `@import`. Real but narrow vs the script-src vectors B10 already closed.
+
 ### Test hygiene — partial triage of pre-existing failures (Open #3, batch 1) (2026-05-07)
 
 The handover noted ~90 pre-existing test failures that pre-dated the security batch (post-Stream-D-Phase-4 cleanup never finished). This first triage batch fixes 11 of them by patching mocks that drifted from current route signatures, and documents the remaining 79 by root cause for future PRs.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -312,9 +312,40 @@ export function middleware(request: NextRequest) {
   // Content Security Policy — script-src is now nonce-based with
   // 'strict-dynamic'. 'unsafe-inline' has been removed from script-src
   // entirely; 'object-src none' blocks Flash/`<object>`/`<embed>`.
-  // style-src still needs 'unsafe-inline' because Tailwind + shadcn emit
-  // inline styles at render time — that's a separate hardening (no
-  // current finding tracks it; styles can't exfiltrate the way scripts can).
+  //
+  // ── style-src 'unsafe-inline' — known gap, deferred ─────────────────────
+  //
+  // Removing 'unsafe-inline' from style-src is documented as Open #9 in
+  // SECURITY_HANDOVER_2026-05-07.md, with the disposition: "Real work —
+  // needs hashing inline styles or migrating to CSS modules. Scope it
+  // before starting."
+  //
+  // Every React `style={{ ... }}` prop renders as an HTML
+  // `style="..."` attribute. HTML attributes can't carry CSP nonces
+  // (only `<style>` and `<script>` tags can), so removing 'unsafe-inline'
+  // from style-src would break every component that uses the `style`
+  // prop. CSP 3 also lacks a 'strict-dynamic' equivalent for styles.
+  // Adding a nonce alongside 'unsafe-inline' DOES NOT help — browsers
+  // disable 'unsafe-inline' as soon as a nonce or hash appears, breaking
+  // the same callsites.
+  //
+  // The migration path is:
+  //   1. Audit every `style={{ ... }}` in the codebase. Most can be
+  //      replaced with Tailwind atomic classes (statically compiled, no
+  //      inline output).
+  //   2. The remaining handful that need dynamic values (e.g. percent
+  //      widths in progress bars, computed colors) should move to CSS
+  //      custom properties set via className + a `--var` declaration.
+  //   3. Next.js's built-in not-found / error pages ship inline <style>
+  //      blocks; can't change those without forking the framework. Hash
+  //      them with `'sha256-...'` once they're stable.
+  //
+  // Threat model: an XSS that escapes script-src (which it can't, post B10)
+  // could set inline styles to exfiltrate via background-image: url(attacker)
+  // or @import — the same exfil vector pixel-tracker abuse uses. The
+  // 'object-src none' + 'frame-ancestors none' + nonce-based script-src
+  // already block the more direct exfiltration paths; style-based exfil is
+  // narrow but real. Worth eventually closing.
   response.headers.set(
     "Content-Security-Policy",
     [


### PR DESCRIPTION
## Summary

Closes **#9** from `SECURITY_HANDOVER_2026-05-07.md` as a docs-only update. The actual migration to remove `'unsafe-inline'` from `style-src` is genuinely multi-day work and properly out of scope per the original handover ("Real work — needs hashing inline styles or migrating to CSS modules. Scope it before starting.").

This PR adds a 28-line comment block in `src/middleware.ts` explaining:

- **Why removing `'unsafe-inline'` breaks every React `style` prop** — HTML attributes can't carry CSP nonces, so the only escape is migrating off the style prop
- **Why nonce-alongside-unsafe-inline doesn't help** — browsers disable `'unsafe-inline'` the moment any nonce or hash appears in the directive
- **Migration path**: audit `src/` (11 files at last count), CSS custom properties for dynamic values, hash framework-injected inline styles
- **Threat model**: style-based exfiltration via `background-image: url(attacker)` is real but narrow given script-src is already locked down post-B10

No code-behavior change. CHANGELOG entry mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)