### PR TITLE
promote dev to main: 8 commits (Anthropic Directory prep + B1-B10 security batch + test triage)

### DIFF
--- a/mcp-server/auto-annotations.ts
+++ b/mcp-server/auto-annotations.ts
@@ -1,0 +1,158 @@
+/**
+ * Auto-annotation helper for MCP tools.
+ *
+ * The Anthropic Connectors Directory submission requires every tool to expose
+ * `title` and either `readOnlyHint` or `destructiveHint` annotations. We have
+ * 90 HTTP / 86 stdio tools across four registration files; rather than touch
+ * every callsite, we monkey-patch `server.tool()` once per server instance to
+ * inject inferred annotations from the tool name.
+ *
+ * Annotations are HINTS to clients per the MCP spec; the underlying handler
+ * is unchanged. Confirmation-token / preview-execute safety is enforced
+ * server-side regardless of the client's interpretation of these hints.
+ *
+ * Inference rules (by name prefix / contained token):
+ *   read-only        get_  list_  find_  search_  analyze_  preview_  test_
+ *                    trace_  detect_  convert_  suggest_  describe_  read_
+ *                    finlynq_help  *_help
+ *   destructive      delete_*   *_delete   reject_*
+ *   idempotent       set_*  update_*  replace_*  delete_*  reject_*  + read tools
+ *   open-world       false (Finlynq operates only on the user's own DB)
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+type ToolAnnotations = {
+  title?: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+};
+
+const READ_PREFIXES = [
+  "get_",
+  "list_",
+  "find_",
+  "search_",
+  "analyze_",
+  "preview_",
+  "test_",
+  "trace_",
+  "detect_",
+  "convert_",
+  "suggest_",
+  "describe_",
+  "read_",
+];
+
+const IDEMPOTENT_WRITE_PREFIXES = ["set_", "update_", "replace_"];
+
+export function inferAnnotations(name: string): ToolAnnotations {
+  const isReadOnly =
+    READ_PREFIXES.some((p) => name.startsWith(p)) ||
+    name === "finlynq_help" ||
+    name.endsWith("_help");
+
+  const isDestructive =
+    name.startsWith("delete_") ||
+    /_delete(_|$)/.test(name) ||
+    name.startsWith("reject_");
+
+  const isIdempotent =
+    isReadOnly ||
+    isDestructive ||
+    IDEMPOTENT_WRITE_PREFIXES.some((p) => name.startsWith(p));
+
+  return {
+    title: toTitle(name),
+    readOnlyHint: isReadOnly,
+    destructiveHint: isDestructive,
+    idempotentHint: isIdempotent,
+    openWorldHint: false,
+  };
+}
+
+function toTitle(snake: string): string {
+  return snake
+    .split("_")
+    .map((w) => (w.length === 0 ? w : w[0].toUpperCase() + w.slice(1)))
+    .join(" ");
+}
+
+const PATCHED = Symbol.for("finlynq.autoAnnotated");
+
+/**
+ * Patch a McpServer instance so that every subsequent `server.tool(...)` call
+ * gets inferred annotations injected before the handler. Idempotent — calling
+ * twice on the same server is a no-op.
+ */
+export function withAutoAnnotations(server: McpServer): McpServer {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const s = server as any;
+  if (s[PATCHED]) return server;
+  s[PATCHED] = true;
+
+  const original = s.tool.bind(server);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  s.tool = function patchedTool(...args: any[]) {
+    if (args.length < 2 || typeof args[0] !== "string") {
+      return original(...args);
+    }
+
+    const name = args[0] as string;
+    const last = args[args.length - 1];
+    if (typeof last !== "function") {
+      return original(...args);
+    }
+
+    if (args.length >= 4) {
+      const candidate = args[args.length - 2];
+      if (looksLikeAnnotations(candidate)) {
+        return original(...args);
+      }
+    }
+
+    const annotations = inferAnnotations(name);
+
+    // tool(name, description, schema, callback)
+    if (
+      args.length === 4 &&
+      typeof args[1] === "string" &&
+      args[2] !== null &&
+      typeof args[2] === "object"
+    ) {
+      return original(args[0], args[1], args[2], annotations, args[3]);
+    }
+
+    // tool(name, description, callback)
+    if (args.length === 3 && typeof args[1] === "string") {
+      return original(args[0], args[1], annotations, args[2]);
+    }
+
+    // tool(name, schema, callback)
+    if (
+      args.length === 3 &&
+      args[1] !== null &&
+      typeof args[1] === "object"
+    ) {
+      return original(args[0], args[1], annotations, args[2]);
+    }
+
+    return original(...args);
+  };
+
+  return server;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function looksLikeAnnotations(o: any): boolean {
+  if (!o || typeof o !== "object") return false;
+  return (
+    "readOnlyHint" in o ||
+    "destructiveHint" in o ||
+    "idempotentHint" in o ||
+    "openWorldHint" in o ||
+    ("title" in o && typeof o.title === "string" && Object.keys(o).length <= 5)
+  );
+}

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -5,6 +5,7 @@ import { createPgCompat } from "./pg-compat.js";
 import { registerCoreTools } from "./register-core-tools.js";
 import { registerV2Tools } from "./tools-v2.js";
 import { registerImportTemplateTools } from "./tools-import-templates.js";
+import { withAutoAnnotations } from "./auto-annotations.js";
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
@@ -48,10 +49,10 @@ try {
 // This translates SQLite-style prepare/all/get/run calls to async PostgreSQL queries
 const db = createPgCompat(pool);
 
-const server = new McpServer({
+const server = withAutoAnnotations(new McpServer({
   name: "finlynq",
   version: "3.0.0",
-});
+}));
 
 registerCoreTools(server, db, { userId });
 registerV2Tools(server, db, { userId });

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -22,14 +22,50 @@ import { validateOauthToken, getIssuer } from "@/lib/oauth";
 import { DEFAULT_SCOPE, parseScope, isToolAllowedForScope } from "@/lib/oauth-scopes";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { registerPgTools } from "../../../../mcp-server/register-tools-pg";
+import { withAutoAnnotations } from "../../../../mcp-server/auto-annotations";
 
-/**
- * Authenticate for MCP: OAuth token > API key > session cookie.
- */
+// Origin allowlist - defense-in-depth against DNS rebinding and cross-site
+// cookie attacks against the session-cookie auth path. Bearer-token requests
+// typically don't send Origin, so a missing Origin is allowed - auth still
+// has to pass.
+const ALLOWED_ORIGIN_HOSTS = new Set([
+  "finlynq.com",
+  "www.finlynq.com",
+  "demo.finlynq.com",
+  "dev.finlynq.com",
+  "claude.ai",
+  "www.claude.ai",
+  "claude.com",
+  "www.claude.com",
+  "chat.openai.com",
+  "chatgpt.com",
+  "cursor.com",
+  "windsurf.dev",
+  "codeium.com",
+]);
+
+function isAllowedOrigin(origin: string | null): boolean {
+  if (!origin) return true;
+  try {
+    const u = new URL(origin);
+    if (u.hostname === "localhost" || u.hostname === "127.0.0.1") return true;
+    if (u.hostname.endsWith(".localhost")) return true;
+    return ALLOWED_ORIGIN_HOSTS.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function rejectBadOrigin(): NextResponse {
+  return NextResponse.json(
+    { error: "forbidden_origin", error_description: "Origin not allowed" },
+    { status: 403 }
+  );
+}
+
 async function authenticateMcp(request: NextRequest) {
   const authHeader = request.headers.get("authorization") ?? "";
 
-  // 1. OAuth 2.1 access token (pf_oauth_...)
   const oauthCandidate = authHeader.startsWith("Bearer pf_oauth_") ? authHeader.slice(7) : null;
   if (oauthCandidate) {
     const result = await validateOauthToken(oauthCandidate);
@@ -39,7 +75,6 @@ async function authenticateMcp(request: NextRequest) {
         context: { userId: result.userId, method: "oauth" as const, mfaVerified: false, dek: result.dek, sessionId: null as string | null, scope: result.scope },
       };
     }
-    // Token looks like OAuth but failed validation — return 401 with WWW-Authenticate
     const issuer = getIssuer();
     return {
       authenticated: false as const,
@@ -50,7 +85,6 @@ async function authenticateMcp(request: NextRequest) {
     };
   }
 
-  // 2 & 3. API key (pf_...) or X-API-Key header
   const hasApiKey =
     request.headers.get("X-API-Key") ||
     authHeader.startsWith("Bearer pf_");
@@ -59,11 +93,9 @@ async function authenticateMcp(request: NextRequest) {
     return requireAuth(request);
   }
 
-  // 4. Session cookie
   const sessionResult = await accountStrategy.authenticate(request);
   if (sessionResult.authenticated) return sessionResult;
 
-  // Nothing matched — return 401 with WWW-Authenticate pointing to OAuth
   const issuer = getIssuer();
   return {
     authenticated: false as const,
@@ -79,21 +111,11 @@ async function authenticateMcp(request: NextRequest) {
   };
 }
 
-// M-21 (SECURITY_REVIEW 2026-05-06): cap MCP request bodies at 1 MB. The MCP
-// surface is auth-gated, but a logged-in attacker (or a buggy client) could
-// otherwise stream an unbounded payload — JSON parsing happens inside the
-// SDK transport with no size guard. 1 MB comfortably exceeds any legitimate
-// MCP message; staging upload (the largest legitimate body) goes through
-// /api/import/staging/upload, not here.
 const MCP_MAX_BODY_BYTES = 1 * 1024 * 1024;
 
-// POST — MCP messages (initialize + tool calls)
 export async function POST(request: NextRequest) {
-  // Pre-check Content-Length BEFORE auth so we don't parse / buffer huge
-  // bodies when we'll reject. Mirror the pattern in
-  // /api/import/staging/upload/route.ts:91-97. We require the header — MCP
-  // clients all send Content-Length, and chunked uploads are not expected
-  // on this endpoint.
+  if (!isAllowedOrigin(request.headers.get("origin"))) return rejectBadOrigin();
+
   const contentLengthRaw = request.headers.get("content-length");
   if (contentLengthRaw == null) {
     return NextResponse.json(
@@ -118,7 +140,6 @@ export async function POST(request: NextRequest) {
   const auth = await authenticateMcp(request);
   if (!auth.authenticated) return auth.response;
 
-  // Rate limit MCP requests per user: 60 requests per minute
   const rl = checkRateLimit(`mcp:${auth.context.userId}`, 60, 60_000);
   if (!rl.allowed) {
     return NextResponse.json(
@@ -127,15 +148,11 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const server = new McpServer({ name: "finlynq", version: "2.3.0" });
+  // Apply auto-annotations FIRST so every tool gets title + readOnlyHint /
+  // destructiveHint / idempotentHint / openWorldHint inferred from name.
+  // The scope filter below then wraps that further; both patches compose.
+  const server = withAutoAnnotations(new McpServer({ name: "finlynq", version: "3.0.0" }));
 
-  // Resolve the effective scope for this request. OAuth tokens carry a stored
-  // scope; API-key / session-cookie auth defaults to DEFAULT_SCOPE (full
-  // read+write — those auth methods predate scope plumbing and remain
-  // unrestricted). When scope is narrower than full, wrap server.tool() so
-  // every out-of-scope tool registration becomes a no-op — the SDK never
-  // even learns about those tools, so they don't appear in tools/list and
-  // can't be called.
   const scopeString = "scope" in auth.context ? auth.context.scope : DEFAULT_SCOPE;
   const scopeSet = parseScope(scopeString);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -143,33 +160,26 @@ export async function POST(request: NextRequest) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (server as any).tool = (name: string, ...args: unknown[]) => {
     if (!isToolAllowedForScope(name, scopeSet)) {
-      // Drop registration silently — out-of-scope tools shouldn't surface in
-      // tools/list as "I exist but you can't call me", because that leaks
-      // information about what the broader API supports. The OAuth dance
-      // already told the client which scope it asked for.
       return undefined;
     }
     return originalTool(name, ...args);
   };
 
-  // PostgreSQL-only mode — async Drizzle queries, user-scoped.
-  // DEK comes from whichever auth path we matched: API-key envelope, session
-  // cookie cache, or null for OAuth (OAuth DEK envelope is Phase 3).
   const dek = "dek" in auth.context ? auth.context.dek : null;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   registerPgTools(server, db as any, auth.context.userId, dek);
 
   const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: undefined, // stateless — no session tracking
-    enableJsonResponse: true,      // JSON responses, not SSE
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
   });
 
   await server.connect(transport);
   return transport.handleRequest(request);
 }
 
-// GET — return 401 with WWW-Authenticate so MCP clients can discover OAuth endpoints
-export async function GET() {
+export async function GET(request: NextRequest) {
+  if (!isAllowedOrigin(request.headers.get("origin"))) return rejectBadOrigin();
   const issuer = getIssuer();
   return NextResponse.json(
     { error: "Finlynq MCP requires authentication. Use POST with a valid Bearer token." },
@@ -182,7 +192,6 @@ export async function GET() {
   );
 }
 
-// DELETE — not used in stateless mode
 export async function DELETE() {
   return Response.json(
     { error: "Stateless mode — no sessions to delete." },

--- a/src/app/cloud/page.tsx
+++ b/src/app/cloud/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useEffect, useRef, Suspense } from "react";
-import { GoogleAnalytics } from "@/components/google-analytics";
+import { AnalyticsConsent } from "@/components/analytics-consent";
 
 type Tab = "login" | "register";
 
@@ -419,7 +419,7 @@ function CloudAuthPageInner() {
 export default function CloudAuthPage() {
   return (
     <Suspense>
-      <GoogleAnalytics />
+      <AnalyticsConsent />
       <CloudAuthPageInner />
     </Suspense>
   );

--- a/src/app/mcp-guide/page.tsx
+++ b/src/app/mcp-guide/page.tsx
@@ -382,7 +382,7 @@ export default function McpGuidePage() {
             </div>
             {!apiKey && (
               <p className="text-xs text-muted-foreground">
-                Only a hash is stored, so the raw key can&rsquo;t be re-shown. Head to <a href="/settings/account" className="underline underline-offset-2 hover:text-foreground">Settings → API Key</a> and click <strong>Regenerate Key</strong> to get a fresh one.
+                Sign in at <a href="/cloud" className="underline underline-offset-2 hover:text-foreground">finlynq.com/cloud</a> (free), then visit <a href="/settings/account" className="underline underline-offset-2 hover:text-foreground">Settings → API Key</a> to generate one. We only store a hash — the raw key is shown to you once at creation and cannot be re-shown.
               </p>
             )}
           </div>
@@ -852,7 +852,7 @@ export default function McpGuidePage() {
         <section>
           <h2 className="mb-1 text-lg font-semibold text-foreground">What Claude can do</h2>
           <p className="mb-4 text-sm text-muted-foreground">
-            78 tools organized by task. Claude picks the right ones — you describe the outcome in plain English.
+            90 tools (HTTP) / 86 (stdio) organized by task. Claude picks the right ones — you describe the outcome in plain English.
             For the full alphabetical tool list with parameters, see{" "}
             <code className="bg-muted px-1 rounded">/api-docs</code> or{" "}
             <code className="bg-muted px-1 rounded">/.well-known/mcp.json</code>.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useRef } from "react";
-import { GoogleAnalytics } from "@/components/google-analytics";
+import { AnalyticsConsent } from "@/components/analytics-consent";
 import "./landing.css";
 
 const FEATURES = [
@@ -39,7 +39,7 @@ const FEATURES = [
   {
     idx: "F.06 · PRIVACY",
     title: "Self-host. Or don't.",
-    desc: "Run it on your Mac, your homelab, or our cloud — same features either way. AES-256 via SQLCipher. Your key never leaves your device.",
+    desc: "Run it on your Mac, your homelab, or our cloud — same features either way. Per-user envelope encryption (AES-256-GCM, scrypt-derived key). Your DEK lives only in memory while you're signed in.",
     viz: "pips",
   },
 ] as const;
@@ -74,15 +74,15 @@ const MCP_TOOLS = [
 ];
 
 const PLAN_FEATS = [
-  "27+ MCP tools — read & write",
-  "AES-256 encryption (SQLCipher)",
+  "90 MCP tools (HTTP) · 86 (stdio) — read & write",
+  "AES-256-GCM envelope encryption · scrypt-derived KEK",
   "CSV, Excel, OFX/QFX, PDF import",
   "Budgets, portfolio, goals, loans",
   "Natural-language AI chat",
   "FIRE calculator & Monte Carlo sim",
   "Rules & auto-categorize",
   "Self-host or managed cloud",
-  "REST API + MCP (HTTP & stdio)",
+  "REST API + MCP (HTTP & stdio · OAuth 2.1 + DCR)",
   "Dark mode, mobile-friendly UI",
 ];
 
@@ -242,7 +242,7 @@ export default function LandingPage() {
 
   return (
     <div className="fl-landing">
-      <GoogleAnalytics />
+      <AnalyticsConsent />
       {/* NAV */}
       <header className="fl-nav">
         <div className="fl-container nav-inner">
@@ -272,7 +272,7 @@ export default function LandingPage() {
           <div className="hero-copy reveal">
             <div className="hero-bar">
               <span className="tag">MCP</span>
-              <span>27 tools · Claude · Cursor · Windsurf · Cline</span>
+              <span>90 tools · Claude · ChatGPT · Cursor · Windsurf · Cline</span>
             </div>
 
             <h1 className="display-xl">
@@ -297,11 +297,11 @@ export default function LandingPage() {
 
             <div className="hero-meta">
               <div className="cell">
-                <div className="v num">27+</div>
+                <div className="v num">90</div>
                 <div className="k">MCP tools</div>
               </div>
               <div className="cell">
-                <div className="v num">AES-256</div>
+                <div className="v num">AES-256-GCM</div>
                 <div className="k">Encryption</div>
               </div>
               <div className="cell">
@@ -499,7 +499,7 @@ export default function LandingPage() {
               </h2>
             </div>
             <p className="lede reveal d2">
-              A built-in MCP server exposes 27 financial tools to any compatible client. No custom
+              A built-in MCP server exposes 90 financial tools to any compatible client over OAuth 2.1 + DCR. No custom
               code, no brittle exports, no exporting to a spreadsheet then copying into a prompt.
             </p>
           </div>
@@ -636,8 +636,8 @@ export default function LandingPage() {
             {[
               { k: "Step 01", t: "Your password" },
               { k: "Step 02", t: "Derive key (scrypt)" },
-              { k: "Step 03", t: "AES-256 encrypt" },
-              { k: "Step 04", t: "Stored encrypted" },
+              { k: "Step 03", t: "Wrap your DEK" },
+              { k: "Step 04", t: "AES-256-GCM at rest" },
             ].map((node, i, arr) => (
               <div key={node.k} className="priv-node">
                 <div className="k">{node.k}</div>
@@ -763,7 +763,7 @@ export default function LandingPage() {
               </div>
               <div className="cta-fact">
                 <div className="eyebrow">ENCRYPTED</div>
-                <div>AES-256 via SQLCipher. Your key, never ours.</div>
+                <div>AES-256-GCM envelope encryption. Your DEK, never ours.</div>
               </div>
               <div className="cta-fact">
                 <div className="eyebrow">PORTABLE</div>
@@ -834,6 +834,9 @@ export default function LandingPage() {
                   <a href="https://github.com/finlynq/finlynq/discussions" target="_blank" rel="noreferrer">
                     Discussions
                   </a>
+                </li>
+                <li>
+                  <Link href="/privacy">Privacy</Link>
                 </li>
               </ul>
             </div>

--- a/src/app/privacy/consent-controls.tsx
+++ b/src/app/privacy/consent-controls.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  setAnalyticsConsent,
+  getAnalyticsConsent,
+} from "@/components/analytics-consent";
+
+type ConsentState = "accepted" | "declined" | "unset";
+
+export function ConsentControls() {
+  const [consent, setConsent] = useState<ConsentState>("unset");
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+    setConsent(getAnalyticsConsent());
+    const onChange = () => setConsent(getAnalyticsConsent());
+    window.addEventListener("finlynq:analytics-consent", onChange);
+    return () => {
+      window.removeEventListener("finlynq:analytics-consent", onChange);
+    };
+  }, []);
+
+  if (!hydrated) {
+    return (
+      <div className="my-4 rounded-lg border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-4 rounded-lg border border-border bg-card p-4">
+      <p className="text-sm mb-3">
+        Current choice:{" "}
+        <strong>
+          {consent === "accepted"
+            ? "Accepted"
+            : consent === "declined"
+              ? "Declined"
+              : "Not yet decided"}
+        </strong>
+      </p>
+      <div className="flex gap-2 flex-wrap">
+        <button
+          type="button"
+          onClick={() => setAnalyticsConsent("accepted")}
+          className="px-3 py-1.5 rounded-md border border-border text-sm hover:bg-muted"
+        >
+          Accept analytics
+        </button>
+        <button
+          type="button"
+          onClick={() => setAnalyticsConsent("declined")}
+          className="px-3 py-1.5 rounded-md border border-border text-sm hover:bg-muted"
+        >
+          Decline analytics
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,348 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ConsentControls } from "./consent-controls";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Finlynq",
+  description:
+    "What Finlynq collects, how it's encrypted, what we never share, and how to export or delete your data.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="mx-auto max-w-3xl px-6 py-16">
+        <header className="mb-12 border-b border-border pb-8">
+          <Link
+            href="/"
+            className="text-xs font-mono uppercase tracking-wider text-muted-foreground hover:text-foreground"
+          >
+            ← Finlynq
+          </Link>
+          <h1 className="mt-4 text-4xl font-bold tracking-tight">Privacy Policy</h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Last updated: 2026-05-08
+          </p>
+        </header>
+
+        <section className="prose prose-invert max-w-none space-y-8 text-[15px] leading-relaxed">
+          <p className="text-base">
+            Finlynq is an open-source personal-finance application (AGPL v3) that
+            you can run on your own hardware or use through our managed cloud at{" "}
+            <code>finlynq.com</code>. This policy applies to the managed cloud.
+            If you self-host, you are the data controller — this policy does not
+            apply to your own deployment.
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">1. What we collect</h2>
+          <p>
+            On the managed cloud, Finlynq stores only the data you put into it
+            yourself:
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              Account identity: a username (your choice), an email address (used
+              only for password recovery and security alerts), and a password
+              hash.
+            </li>
+            <li>
+              Financial data you import or enter: accounts, transactions,
+              budgets, investments, loans, goals, attached receipts.
+            </li>
+            <li>
+              Operational logs: HTTP request logs (IP address, user agent, URL
+              path, status code), kept 30 days for abuse prevention and
+              debugging.
+            </li>
+            <li>
+              MCP / API tokens you generate: stored as one-way hashes; the raw
+              token is shown to you once at creation and cannot be re-shown.
+            </li>
+          </ul>
+          <p>
+            We do not collect bank credentials. Finlynq has no Plaid, MX,
+            Yodlee, or Finicity integration. Your bank login never touches our
+            servers. You import data via CSV / OFX / QFX / PDF / email.
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            2. How your financial data is encrypted
+          </h2>
+          <p>
+            Finlynq uses per-user envelope encryption. Summary:
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>Each user has a Data Encryption Key (DEK) generated at signup.</li>
+            <li>
+              The DEK is wrapped with a Key Encryption Key (KEK) derived from
+              your password using <strong>scrypt</strong> with a server-side pepper.
+            </li>
+            <li>
+              Sensitive fields (transaction payees, notes, tags, attached files,
+              encrypted display names) are stored as <strong>AES-256-GCM</strong>{" "}
+              ciphertext with random IV and authentication tags.
+            </li>
+            <li>
+              Your DEK lives only in memory while you are signed in (sliding 2h
+              idle timeout). It is never persisted in plaintext on disk.
+            </li>
+            <li>
+              If you forget your password, your encrypted data cannot be
+              recovered. This is by design.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">3. What we never share</h2>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              We do not sell, rent, or share your data with advertisers, data
+              brokers, or any third party.
+            </li>
+            <li>
+              We do not move money. Finlynq is not a broker, bank, advisor, or
+              SEC-registered RIA. We have no ability to initiate transfers from
+              your accounts.
+            </li>
+            <li>
+              We do not use your financial data to train AI models. The MCP
+              server lets <em>you</em> grant a third-party AI assistant access
+              to your data — under your control, scoped per session, revocable.
+            </li>
+            <li>
+              We do not use third-party analytics inside the application. The
+              public marketing pages load Google Analytics only after you
+              explicitly accept the cookie banner.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            4. AI assistants and the MCP server
+          </h2>
+          <p>
+            When you connect Finlynq to an AI assistant via our MCP server, the
+            assistant authenticates through OAuth 2.1 (or with a Bearer API key
+            if you are using a CLI client). It receives only the data returned
+            by the specific tool it calls, scoped to your account.
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              The AI vendor (e.g., Anthropic) sees the tool responses, because
+              they pass through the model. Refer to the vendor privacy policy.
+            </li>
+            <li>
+              You can revoke an OAuth grant at any time from{" "}
+              <code>Settings → Connected apps</code>.
+            </li>
+            <li>
+              Destructive operations (bulk delete, bulk update, imports) use a
+              preview-confirm-execute pattern with a server-signed token, so an
+              AI cannot mutate your data without your explicit confirmation.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">5. Sub-processors</h2>
+          <p>
+            The managed cloud runs on a single VPS that we operate. We do not
+            use third-party data processors for the application database. The
+            only outbound integrations are:
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              Yahoo Finance, CoinGecko, Stooq — anonymous public-price queries
+              for portfolio valuation. No user data is sent.
+            </li>
+            <li>
+              Resend — transactional email (password reset, account alerts) and
+              the optional inbound-import address.
+            </li>
+            <li>
+              GitHub Sponsors / Ko-fi — donation processing, only if you choose
+              to donate. They handle their own KYC/payment data.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">6. Cookies and analytics</h2>
+          <p>
+            The application itself loads no third-party analytics, no
+            advertising scripts, and no tracking pixels. Authentication uses a
+            single first-party session cookie required to keep you signed in;
+            it expires automatically.
+          </p>
+          <p>
+            On the public marketing pages we load Google Analytics to understand
+            which posts bring people here. GA is non-essential, so we ask for
+            your consent before loading it. You can change your mind at any time:
+          </p>
+          <ConsentControls />
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            7. Records of processing (GDPR Article 30)
+          </h2>
+          <p>
+            For users protected by GDPR, the following is our public record of
+            processing activities. Internal records are kept current and made
+            available to supervisory authorities on request.
+          </p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              <strong>Controller:</strong> Finlynq (operated from Canada).
+              Contact: <code>privacy@finlynq.com</code>.
+            </li>
+            <li>
+              <strong>EU representative:</strong> Per GDPR Article 27(2), no
+              representative is currently designated (small-scale processing,
+              no special-category data, no targeting of EU market).
+            </li>
+            <li>
+              <strong>Purposes of processing:</strong> (1) provide the personal
+              finance application; (2) authenticate users; (3) deliver MCP
+              server access; (4) send transactional email; (5) prevent abuse.
+            </li>
+            <li>
+              <strong>Lawful basis:</strong> performance of a contract (Article
+              6(1)(b)) and legitimate interest for security logs (6(1)(f)).
+            </li>
+            <li>
+              <strong>Categories of data subjects:</strong> users who sign up
+              for the managed cloud at finlynq.com.
+            </li>
+            <li>
+              <strong>Categories of personal data:</strong> username, email,
+              password hash, financial data entered by user, MCP/API token
+              hashes, HTTP request metadata. No special-category data.
+            </li>
+            <li>
+              <strong>Recipients / sub-processors:</strong> see Section 5. We
+              do not sell or rent personal data.
+            </li>
+            <li>
+              <strong>Cross-border transfers:</strong> data is stored in Canada,
+              which has an EU adequacy decision (Article 45). No additional
+              safeguards required.
+            </li>
+            <li>
+              <strong>Retention:</strong> see Section 9 below.
+            </li>
+            <li>
+              <strong>Technical and organizational measures:</strong> per-user
+              envelope encryption (AES-256-GCM, scrypt-derived KEK); HTTPS/TLS;
+              least-privilege staff access; rate limiting and origin validation
+              on the MCP endpoint; regular dependency updates.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            8. Security incident response
+          </h2>
+          <p>Our breach response process aligns with GDPR Articles 33 and 34:</p>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              <strong>Detection:</strong> automated monitoring on auth endpoints,
+              OAuth grant lifecycle, and unusual access patterns.
+            </li>
+            <li>
+              <strong>Containment:</strong> on suspicion of compromise, we
+              rotate <code>DEPLOY_GENERATION</code> (force-logout every session)
+              and revoke OAuth grants.
+            </li>
+            <li>
+              <strong>Notification to supervisory authority:</strong> within 72
+              hours of becoming aware (Article 33(1)).
+            </li>
+            <li>
+              <strong>Notification to affected users:</strong> when a breach is
+              likely to result in high risk, without undue delay (Article 34).
+            </li>
+            <li>
+              <strong>Reporting a vulnerability:</strong> please email{" "}
+              <code>privacy@finlynq.com</code>. We confirm receipt within 48 hours.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            9. Retention and deletion
+          </h2>
+          <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              You can export your full account at any time as a JSON backup
+              from <code>Settings → Data → Export</code>.
+            </li>
+            <li>
+              You can wipe your account from{" "}
+              <code>Settings → Data → Delete account</code>. This removes every
+              row scoped to your <code>user_id</code> across all 22 tables in a
+              single transaction.
+            </li>
+            <li>Operational logs are retained for 30 days, then rotated.</li>
+            <li>
+              Database backups are retained for 7 days. After 7 days, deleted
+              account data is unrecoverable from backups.
+            </li>
+          </ul>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">10. Children</h2>
+          <p>
+            Finlynq is not directed at children under 16 and we do not
+            knowingly collect data from children. If you become aware of a
+            child account, contact us and we will delete it.
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">
+            11. Jurisdiction and your rights
+          </h2>
+          <p>
+            Finlynq is operated from Canada. You can exercise your access,
+            rectification, deletion, and portability rights at any time directly
+            from <code>Settings → Data</code>; you do not need to ask us. For
+            other inquiries (GDPR Article 15 access requests, CCPA opt-outs,
+            EU data-subject requests), contact us using the address below — we
+            will respond within 30 days.
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">12. Changes</h2>
+          <p>
+            We will update this page when our practices change and bump the
+            Last updated date at the top. Material changes (a new sub-processor,
+            a change to encryption guarantees) will also be announced in the
+            project{" "}
+            <a
+              href="https://github.com/finlynq/finlynq/blob/main/CHANGELOG.md"
+              className="underline underline-offset-2 hover:text-primary"
+            >
+              changelog
+            </a>
+            .
+          </p>
+
+          <h2 className="text-xl font-semibold mt-12 mb-3">13. Contact</h2>
+          <p>
+            Privacy questions, data-subject requests, security disclosures:{" "}
+            <code>privacy@finlynq.com</code>. Source-code questions, bugs,
+            feature requests: open an issue at{" "}
+            <a
+              href="https://github.com/finlynq/finlynq/issues"
+              className="underline underline-offset-2 hover:text-primary"
+            >
+              github.com/finlynq/finlynq
+            </a>
+            .
+          </p>
+
+          <p className="mt-12 text-xs text-muted-foreground">
+            The full encryption design, including the key-derivation parameters
+            and threat model, is published at{" "}
+            <a
+              href="https://github.com/finlynq/finlynq/blob/main/pf-app/docs/architecture/encryption.md"
+              className="underline underline-offset-2 hover:text-primary"
+            >
+              pf-app/docs/architecture/encryption.md
+            </a>
+            . The code that implements it is in{" "}
+            <code>pf-app/src/lib/crypto/</code>. Both are AGPL v3 — read the
+            code, audit it, fork it.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/self-hosted/page.tsx
+++ b/src/app/self-hosted/page.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
-import { GoogleAnalytics } from "@/components/google-analytics";
+import { AnalyticsConsent } from "@/components/analytics-consent";
 
 export default function SelfHostedPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-dot-pattern ambient-glow">
-      <GoogleAnalytics />
+      <AnalyticsConsent />
       <div className="mx-auto w-full max-w-lg px-6 py-12">
         {/* Back link */}
         <Link

--- a/src/components/analytics-consent.tsx
+++ b/src/components/analytics-consent.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+/**
+ * Analytics consent banner + consent-gated Google Analytics loader.
+ *
+ * Replaces the unconditional <GoogleAnalytics /> on public marketing pages.
+ * Required for ePrivacy / GDPR compliance: GA cookies are non-essential, so
+ * they cannot load until the user explicitly opts in.
+ *
+ * Persistence: localStorage key "finlynq:analytics-consent" in
+ * {"accepted", "declined"}. Absence = banner is shown. Choice persists
+ * across sessions on the same browser; user can change it from /privacy.
+ */
+
+import { useEffect, useState } from "react";
+import Script from "next/script";
+
+const GA_MEASUREMENT_ID = "G-ZDQJXS0C3Z";
+const STORAGE_KEY = "finlynq:analytics-consent";
+
+type Consent = "accepted" | "declined" | "unset";
+
+function readConsent(): Consent {
+  if (typeof window === "undefined") return "unset";
+  const v = window.localStorage.getItem(STORAGE_KEY);
+  if (v === "accepted" || v === "declined") return v;
+  return "unset";
+}
+
+function writeConsent(value: "accepted" | "declined") {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEY, value);
+  window.dispatchEvent(new Event("finlynq:analytics-consent"));
+}
+
+function useConsent() {
+  const [consent, setConsent] = useState<Consent>("unset");
+
+  useEffect(() => {
+    setConsent(readConsent());
+    const onChange = () => setConsent(readConsent());
+    window.addEventListener("finlynq:analytics-consent", onChange);
+    window.addEventListener("storage", onChange);
+    return () => {
+      window.removeEventListener("finlynq:analytics-consent", onChange);
+      window.removeEventListener("storage", onChange);
+    };
+  }, []);
+
+  return consent;
+}
+
+function GoogleAnalyticsScripts() {
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `}
+      </Script>
+    </>
+  );
+}
+
+function ConsentBanner({ onChoice }: { onChoice: (v: "accepted" | "declined") => void }) {
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Analytics cookies"
+      style={{
+        position: "fixed",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        zIndex: 9999,
+        background: "#0e1116",
+        borderTop: "1px solid #2a3139",
+        color: "#e8eaed",
+        padding: "14px 18px",
+        boxShadow: "0 -8px 24px rgba(0,0,0,0.35)",
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1100,
+          margin: "0 auto",
+          display: "flex",
+          gap: 18,
+          alignItems: "center",
+          flexWrap: "wrap",
+          fontSize: 13,
+          lineHeight: 1.45,
+        }}
+      >
+        <p style={{ flex: "1 1 320px", margin: 0, color: "#cdd2d8" }}>
+          We use Google Analytics on our public marketing pages to understand
+          which posts bring people here. We don&apos;t use any analytics inside
+          the app itself, and we never sell your data. You can decline below
+          and the page works fine.{" "}
+          <a
+            href="/privacy"
+            style={{ color: "#f5a623", textDecoration: "underline" }}
+          >
+            Privacy policy
+          </a>
+          .
+        </p>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            type="button"
+            onClick={() => onChoice("declined")}
+            style={{
+              background: "transparent",
+              color: "#9aa3ad",
+              border: "1px solid #2a3139",
+              padding: "8px 14px",
+              borderRadius: 6,
+              cursor: "pointer",
+              fontSize: 13,
+            }}
+          >
+            Decline
+          </button>
+          <button
+            type="button"
+            onClick={() => onChoice("accepted")}
+            style={{
+              background: "#f5a623",
+              color: "#0e1116",
+              border: "1px solid #f5a623",
+              padding: "8px 14px",
+              borderRadius: 6,
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: 600,
+            }}
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AnalyticsConsent() {
+  const consent = useConsent();
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated) return null;
+
+  return (
+    <>
+      {consent === "accepted" && <GoogleAnalyticsScripts />}
+      {consent === "unset" && (
+        <ConsentBanner onChoice={(v) => writeConsent(v)} />
+      )}
+    </>
+  );
+}
+
+export function setAnalyticsConsent(value: "accepted" | "declined") {
+  writeConsent(value);
+}
+
+export function getAnalyticsConsent(): Consent {
+  return readConsent();
+}


### PR DESCRIPTION
## Summary

Periodic dev → main promotion. Bundles 8 commits that have been baking on `dev`:

1. **`525c6f6` feat: prep Anthropic Connectors Directory submission** (today)
   - Auto-annotations helper for the 90 HTTP / 86 stdio MCP tools (title + readOnlyHint/destructiveHint/idempotentHint/openWorldHint inferred from name)
   - Origin-header validation on `/api/mcp` (allowlist for finlynq.com, claude.ai, claude.com, chatgpt.com, cursor.com, windsurf.dev, codeium.com)
   - Public `/privacy` route with GDPR Article 30 record + Article 33/34 breach-response process + cookie consent management
   - `/mcp-guide` moved out of (app) auth group → publicly accessible for directory reviewers
   - Cookie consent banner gates Google Analytics on `/`, `/cloud`, `/self-hosted`
   - Landing-page stale-claim fixes: 27 → 90 MCP tools, SQLCipher → AES-256-GCM envelope, PBKDF2 → scrypt
   - MCP server version 2.3.0 → 3.0.0

2. **`8ba298f` docs(security): style-src 'unsafe-inline' constraint** (#191)
3. **`0091601` test: 11/90 test recovery via fx-service mock alignment** (#190)
4. **`34c8879` security: PF_PEPPER rotation support — pepper_version + lazy rewrap** (#189)
5. **`3531040` security: OAuth scope plumbing — read vs write split** (#188)
6. **`e4d1f6f` security: backup encryption-at-rest with gpg-symmetric** (#186)
7. **`57acc27` security: GH Actions SHA-pin + next re-pin + deploy.sh chown** (#185)
8. **`0a1e37d` security: CSRF login bypass + CSP dedup + lockout-enum probe** (#184)

## Test plan

- [ ] CI green (`npm install` → typecheck → `npm run build` → SSH deploy)
- [ ] Verified working on dev.finlynq.com prior to opening this PR
- [ ] Post-merge: confirm `https://finlynq.com/privacy` resolves (200, public)
- [ ] Post-merge: confirm `https://finlynq.com/mcp-guide` resolves without sign-in
- [ ] Post-merge: confirm cookie consent banner appears on `/`, `/cloud`, `/self-hosted` (incognito window)
- [ ] Post-merge: hit `https://finlynq.com/api/mcp` from Claude → expect OAuth 2.1 + DCR flow + 90 tools w/ annotations
- [ ] Post-merge: spot-check `tools/list` response includes `annotations.title` + `readOnlyHint`/`destructiveHint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)