### PR TITLE
feat(mcp): expose server logo + metadata via serverInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### MCP — serverInfo logo + metadata (2026-05-08)
+
+Adds `title`, `websiteUrl`, `description`, and `icons[]` to the `Implementation` object passed to both `McpServer` constructors so compatible MCP clients render the Finlynq mark instead of the default placeholder. Composes with the existing `withAutoAnnotations` wrap shipped in #193; server version stays at `3.0.0` — purely additive metadata, no behavior change.
+
+- HTTP route ([src/app/api/mcp/route.ts](src/app/api/mcp/route.ts)) and stdio entrypoint ([mcp-server/index.ts](mcp-server/index.ts)) both populated with the same fields.
+- Icon `src` reuses the existing `https://finlynq.com/favicon.svg` (mimeType `image/svg+xml`, sizes `["any"]`) — no new public asset.
+- Motivating context: Anthropic Connectors Directory submission ([HANDOVER_2026-05-08.md](../HANDOVER_2026-05-08.md)) — directory listings render server `icons[0].src` in the "Connect" UI.
+
 ### Documentation — formal note on `style-src 'unsafe-inline'` constraint (#9, 2026-05-07)
 
 Captures the technical constraint behind why `style-src 'unsafe-inline'` can't be removed from the CSP today, and the migration path for closing it. Code-only change to [src/middleware.ts](src/middleware.ts) — a 28-line comment block above the CSP directive.

--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -51,7 +51,13 @@ const db = createPgCompat(pool);
 
 const server = withAutoAnnotations(new McpServer({
   name: "finlynq",
+  title: "Finlynq",
   version: "3.0.0",
+  websiteUrl: "https://finlynq.com",
+  description: "Track your money here, analyze it anywhere — open-source personal finance with 90 MCP tools.",
+  icons: [
+    { src: "https://finlynq.com/favicon.svg", mimeType: "image/svg+xml", sizes: ["any"] },
+  ],
 }));
 
 registerCoreTools(server, db, { userId });

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -151,7 +151,16 @@ export async function POST(request: NextRequest) {
   // Apply auto-annotations FIRST so every tool gets title + readOnlyHint /
   // destructiveHint / idempotentHint / openWorldHint inferred from name.
   // The scope filter below then wraps that further; both patches compose.
-  const server = withAutoAnnotations(new McpServer({ name: "finlynq", version: "3.0.0" }));
+  const server = withAutoAnnotations(new McpServer({
+    name: "finlynq",
+    title: "Finlynq",
+    version: "3.0.0",
+    websiteUrl: "https://finlynq.com",
+    description: "Track your money here, analyze it anywhere — open-source personal finance with 90 MCP tools.",
+    icons: [
+      { src: "https://finlynq.com/favicon.svg", mimeType: "image/svg+xml", sizes: ["any"] },
+    ],
+  }));
 
   const scopeString = "scope" in auth.context ? auth.context.scope : DEFAULT_SCOPE;
   const scopeSet = parseScope(scopeString);


### PR DESCRIPTION
## Summary

Populates the MCP `Implementation` (a.k.a. `serverInfo`) object passed to `new McpServer({...})` with the optional fields the SDK supports:

- `title: "Finlynq"` — display name distinct from the wire `name`.
- `websiteUrl: "https://finlynq.com"` — origin link in client UIs.
- `description` — short blurb (matches the project pitch).
- `icons[]` — single SVG entry pointing at the existing `https://finlynq.com/favicon.svg` (mimeType `image/svg+xml`, sizes `["any"]`).

Both the HTTP route ([src/app/api/mcp/route.ts](https://github.com/finlynq/finlynq/blob/feat/mcp-server-icons/src/app/api/mcp/route.ts)) and the stdio entrypoint ([mcp-server/index.ts](https://github.com/finlynq/finlynq/blob/feat/mcp-server-icons/mcp-server/index.ts)) receive identical metadata. Server version stays at `3.0.0` — purely additive, no behavior change.

The `withAutoAnnotations(...)` wrap from #193 still wraps the constructor; only the inner `Implementation` object is extended. The HTTP route's existing scope-filter wrap composes on top of `withAutoAnnotations` exactly as before.

SDK reference: `ImplementationSchema` in `@modelcontextprotocol/sdk` (^1.27.1) — `IconSchema` is `{ src: string, mimeType?: string, sizes?: string[], theme?: "light"|"dark" }`. We use the minimal three-field shape.

Motivation: Anthropic Connectors Directory submission ([HANDOVER_2026-05-08.md](https://github.com/finlynq/finlynq/blob/feat/mcp-server-icons/HANDOVER_2026-05-08.md)). Without `icons[]` populated, the directory listing falls back to a generic placeholder. The favicon is already publicly served at the URL above.

## Test plan

- [x] `npm run build` passes (Next.js production build green; typecheck clean).
- [x] No new test failures attributable to this change (test suite has 79 pre-existing failures documented in CHANGELOG.md "Test hygiene — partial triage"; this PR does not regress that count).
- [ ] Post-deploy: re-add the Finlynq custom integration in claude.ai and confirm the Finlynq favicon renders in the connector picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)