### PR TITLE
fix(deploy): atomic .next swap to avoid rm race with live service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### deploy.sh — atomic `.next` swap to fix live-service rm race (2026-05-09)
+
+The dev deploy for the merge-from-main commit (`c7a481c`) failed at the `rm -rf .next` step with `Directory not empty` on `.next/standalone`. Root cause: the running pf-dev service writes runtime fetch-cache files into `.next/standalone/.next/cache/fetch-cache/` on every outbound HTTP fetch (FX rates, Yahoo prices, etc.), and those new files appeared mid-traversal faster than `rm` could clean them — so `rm` finished traversing but the parent dir was never empty when it tried to rmdir it. The partial rm had already deleted `.next/standalone/server.js`, leaving dev returning 500 on every page request (`/api/healthz` still passed because it doesn't touch the build) until the workflow was re-run with the service stopped.
+
+Fix in [deploy.sh](deploy.sh): swap the in-place `rm -rf .next` for `mv .next .next.old.$$ && rm -rf .next.old.$$`. The `mv` is atomic and the running service keeps its file handles via the inode, so the rm operates on a detached tree that nobody is writing to. Also added a belt-and-suspenders sweep of `.next.old.*` in case a previous deploy died after the mv but before the rm. Pre-existing race that had been latent until today's deploy timing happened to overlap with active fetch traffic.
+
 ### Demo seed — let `PF_ALLOW_DEMO_SEED=1` bypass the multi-user guard (2026-05-09)
 
 The Finlynq prod VPS provisions both the demo user (`00000000-0000-0000-0000-00000000demo`) and the operator's real account onto the same `pf` Postgres DB — the demo doesn't have its own database. The B9 hygiene PR ([#172](https://github.com/finlynq/finlynq/pull/172)) added a count-based safety guard in `assertDemoDatabase` that refuses to run when the DB has >1 user row, intended to catch wrong-DB-connection mistakes. On this prod topology that guard trips every time and prevented the seed from running today after PR #199 shipped (the seed's actual wipe step is `WHERE user_id = $1` with the demo UUID at every table, so multi-user has always been safe — the count guard was just a backstop). Now the existing `PF_ALLOW_DEMO_SEED=1` opt-in (which already bypassed guard #1, the URL substring check) also bypasses guard #3. Operator on a multi-tenant prod DB sets the env var on `finlynq-demo-reset.service` once; defaults still refuse for fresh self-hosters.

--- a/deploy.sh
+++ b/deploy.sh
@@ -256,8 +256,25 @@ if [ "$SKIP_BUILD" = false ]; then
   if [ -d .next ] && [ -n "$REPO_OWNER" ]; then
     sudo chown -R "$REPO_OWNER:$REPO_OWNER" .next 2>/dev/null || true
   fi
+  # Atomic detach instead of in-place rm. The running service writes runtime
+  # cache files into .next/standalone/.next/cache/fetch-cache/ on every
+  # outbound HTTP fetch (FX rates, Yahoo prices, etc.). When `rm -rf .next`
+  # ran against the live tree, new fetch-cache entries appeared mid-traversal
+  # and `rm` failed with "Directory not empty" on the parent — partial-deleting
+  # the build (server.js gone, dev returning 500 on every page) until the next
+  # successful deploy. The fix: `mv` is atomic and the running service keeps
+  # its open inodes through the rename, so the rm operates on a detached tree
+  # that nobody is writing to. PID-suffixed name avoids collision if a second
+  # deploy fires before the previous .next.old.* finished cleaning up.
   echo "==> Removing stale build output..."
-  run_as "rm -rf .next"
+  if [ -d .next ]; then
+    OLD_NEXT=".next.old.$$"
+    run_as "mv .next $OLD_NEXT"
+    run_as "rm -rf $OLD_NEXT"
+  fi
+  # Belt-and-suspenders: clean any orphaned .next.old.* trees from a previous
+  # deploy that died after the mv but before the rm (e.g. SSH dropout).
+  run_as "rm -rf .next.old.* 2>/dev/null" || true
   echo "==> Building Next.js..."
   run_as "npm run build"
 else


### PR DESCRIPTION
## Summary

- Today's dev deploy (run [25605616861](https://github.com/finlynq/finlynq/actions/runs/25605616861)) failed at `rm -rf .next` with `Directory not empty` on `.next/standalone`. The partial rm had already deleted `.next/standalone/server.js`, so dev served 500 on every page request until the workflow was re-run with the service stopped.
- Root cause: pf-dev writes runtime fetch-cache files into `.next/standalone/.next/cache/fetch-cache/` on every outbound HTTP fetch (FX rates, Yahoo prices, etc.). New files appeared mid-`rm` faster than rm could clean them, so the parent dir was never empty when rm tried to rmdir it. Pre-existing race that had been latent until today's deploy happened to overlap with active fetch traffic.
- Fix: swap `rm -rf .next` for `mv .next .next.old.$$ && rm -rf .next.old.$$`. The `mv` is atomic and the running service keeps its file handles through the rename via the inode, so the rm operates on a detached tree that nobody is writing to. Also a belt-and-suspenders sweep of `.next.old.*` for the case where a previous deploy died after the mv but before the rm.

## Test plan

- [ ] Squash-merge to `dev`. The next dev deploy (this PR's own merge commit) is the live test — if it succeeds, the fix works against the same live-service-writes-to-.next/cache scenario that just failed today.
- [ ] After merge, watch the GH Actions log for the new banner `==> Removing stale build output...` followed by no error from `mv`/`rm`, and a subsequent `==> Building Next.js...`.
- [ ] Verify https://dev.finlynq.com/ returns 200 post-deploy.
- [ ] Once dev validates, promote to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)