### PR TITLE
fix(dashboard): branch balance on is_investment, not map presence (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Dashboard balance fallback now branches on `is_investment` (#204, 2026-05-09)
+
+`/api/dashboard` per-account balance previously fell back to `SUM(transactions.amount)` whenever `holdingsByAccount.get(b.accountId)` returned `undefined`. For an investment account whose holdings aggregator dropped a position (orphan `holding_accounts` row, FX outage, freshly-imported snapshot before the holding has any transactions), the dashboard silently rendered the cash-leg sum (just the buy/sell/dividend cash legs) as the account balance — a meaningless number that looked like a real balance. Mirrors the canonical pattern shipped under #151 for `/api/goals`.
+
+- **[src/app/api/dashboard/route.ts](src/app/api/dashboard/route.ts)** — replaced the `holdings ? holdings.value : cashFlowBasis` ternary with explicit branching on `b.isInvestment`. Investment accounts now return `holdings?.value ?? 0` (visible `0` when the aggregator emits nothing — diagnosable, not silently misleading); cash accounts return `cashFlowBasis` unchanged. Defensive `Boolean(b.isInvestment)` coercion in case a future refactor of `getAccountBalances` returns partial rows. `cashFlowBasis`, `holdingsValue`, `holdingsCostBasis`, and `convertedBalance` response fields preserved (no consumer regression on Accounts list, Account detail, Net Worth, or Income vs Expenses panels).
+- **Behavior change is user-visible** for any investment account where the aggregator currently returns empty: pre-fix shows a non-zero cash-leg number, post-fix shows `$0.00`. `$0` is the correct answer for "we couldn't compute holdings" and matches the goals page. `getAccountBalances` already returns `isInvestment` on every row ([src/lib/queries.ts:615](src/lib/queries.ts)) — no plumbing change required.
+- Independent of the upstream portfolio-aggregator orphan-holdings investigation (#205); the dashboard fallback rule is wrong on its own merits and remains correct after that fix lands.
+
 ### MCP `bulk_record_transactions` — fail loud on unknown category names (#203, 2026-05-09)
 
 `bulk_record_transactions` (MCP HTTP) previously coerced an unknown `category` name to `category_id = NULL` and reported the row as `success: true`, silently dropping the user's intent. The buggy branch lived at [mcp-server/register-tools-pg.ts:2765-2777](mcp-server/register-tools-pg.ts) where a `fuzzyFind` miss returned `null` instead of pushing a per-row failure. Sibling tools (`record_transaction`, `update_transaction`, `execute_bulk_update`) all fail loudly on unknown categories — this was the symmetric gap to issue #61's `unapplied[]` contract on the bulk-update side.

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -41,21 +41,34 @@ export async function GET(request: NextRequest) {
       accountNameCt: "accountName",
       aliasCt: "alias",
     });
-    // For investment accounts (any account with holdings), balance = market
-    // value of holdings (which already includes any cash sleeve via the
-    // currency-as-holding pattern). Transactions still drive cash-flow /
-    // income reports but no longer contribute to balance — this fixes the
-    // double-count where a payroll deposit was added to balance AND the
-    // ETF it was used to buy was also added.
+    // Per-account balance branches on `accounts.is_investment`, NOT on map
+    // presence (issue #204). Investment accounts always report holdings value
+    // (or 0 when the aggregator emits nothing); cash accounts report the
+    // transaction sum unchanged. Mirrors the canonical pattern from goals API
+    // (#151, src/app/api/goals/route.ts:244-247).
     //
-    // For pure-cash accounts (no holdings), balance = SUM(transactions.amount)
-    // unchanged. cashFlowBasis is the transaction sum exposed separately so
-    // the account detail page can display "Cash flow" alongside Market value.
+    // Pre-#204 the ternary keyed on map presence — when the holdings
+    // aggregator dropped every position for an investment account (orphan
+    // holding_accounts row, FX outage, freshly-imported snapshot before any
+    // transaction), the dashboard silently fell back to SUM(transactions.amount),
+    // which for an investment account is just the cash legs of buys/sells/
+    // dividends — meaningless as a "balance." Surfacing 0 instead is visible
+    // and diagnosable.
+    //
+    // For investment accounts the cash sleeve is already inside holdings.value
+    // via the currency-as-holding pattern, so we never sum (CLAUDE.md
+    // "Account balance for accounts with holdings" gotcha).
+    //
+    // cashFlowBasis is the transaction sum exposed separately so the account
+    // detail page can display "Cash flow" alongside Market value.
     const holdingsByAccount = await getHoldingsValueByAccount(userId, dek);
     const convertedBalances = balances.map((b: any) => {
       const holdings = holdingsByAccount.get(b.accountId);
       const cashFlowBasis = b.balance;
-      const totalBalance = holdings ? holdings.value : cashFlowBasis;
+      const isInvestment = Boolean(b.isInvestment);
+      const totalBalance = isInvestment
+        ? (holdings?.value ?? 0)
+        : cashFlowBasis;
       return {
         ...b,
         balance: totalBalance,


### PR DESCRIPTION
Closes #204

## Summary

`/api/dashboard` per-account balance previously used a ternary keyed on `holdingsByAccount.get(b.accountId)` presence. When the holdings aggregator dropped every position for an investment account (orphan `holding_accounts` row, FX outage, freshly-imported snapshot before any transaction), the dashboard silently fell back to `SUM(transactions.amount)` — for an investment account that's just the buy/sell/dividend cash legs, a meaningless number that looked like a real balance.

Mirror the goals-API pattern from #151: branch on `b.isInvestment`. Investment accounts return `holdings?.value ?? 0` (visible `$0` when the aggregator emits nothing — diagnosable, not silently misleading); cash accounts return `cashFlowBasis` unchanged. `cashFlowBasis`, `holdingsValue`, `holdingsCostBasis`, and `convertedBalance` response fields preserved.

`getAccountBalances` already returns `isInvestment` ([src/lib/queries.ts:615](src/lib/queries.ts)) — no plumbing change required. Defensive `Boolean(b.isInvestment)` coercion in case a future refactor returns partial rows.

## Docs updated

- CHANGELOG.md (always)

## Promotion to main — required steps

- [x] Code-only change. Plain git merge dev is sufficient.

Note for promoter: behavior change is user-visible for any investment account where the aggregator currently returns empty — pre-fix shows a non-zero cash-leg number, post-fix shows `$0.00`. This is intentional (matches goals page, matches CLAUDE.md "Account balance" gotcha) and called out in CHANGELOG.

## How I tested

- `npx tsc --noEmit` clean
- `npm run build` ✓ (all routes compile, dashboard route in route list)
- Static review: `b.isInvestment` confirmed in `getAccountBalances` SELECT/GROUP BY at queries.ts:615/629; `decryptNamedRows` preserves non-encrypted columns through; cash-account default is `false` not null per schema. Display sites (`(app)/accounts/page.tsx`, `(app)/accounts/[id]/page.tsx`) consume `balance` field as-is — no changes required.