### PR TITLE
fix(portfolio): dual-write holding_accounts at 8 unfixed INSERT paths (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### Portfolio aggregator: orphan-holdings fix cohort — dual-write `holding_accounts` at all 8 unfixed INSERT paths (#205, 2026-05-09)
+
+Closes the issue #95 follow-up cohort. Every `portfolio_holdings` INSERT path now dual-writes the matching `holding_accounts(holding_id, account_id, user_id, qty=0, cost_basis=0, is_primary=true)` pairing in the same transaction, and a tracked SQL migration repairs any orphans created since the 2026-05-01 loose-script backfill.
+
+**User-visible symptom resolved:** investment accounts with holdings whose INSERT path skipped the pairing rendered the Portfolio page as `N holdings across 1 accounts` but every Qty / Avg Cost / Mkt Value / Unrealized G/L cell showed `--`, and "All Holdings" reported `No holdings found. Showing only positions with quantity > 0`. Root cause: every aggregator (issue #25) INNER-JOINs through `holding_accounts` on `(holding_id, account_id, user_id)`; without the pairing, every transaction for the holding silently dropped and live `SUM(transactions.quantity)` evaluated to 0.
+
+- **8 INSERT call sites fixed** to dual-write the pairing in the same transaction with `ON CONFLICT (holding_id, account_id) DO NOTHING` for idempotency and orphan-DELETE on hard pairing failure. The canonical pattern lives at [mcp-server/register-tools-pg.ts:4190-4201](mcp-server/register-tools-pg.ts) (PR #116, issue #95).
+  - REST `POST /api/portfolio` ([src/app/api/portfolio/route.ts](src/app/api/portfolio/route.ts)) — Add Holding dialog.
+  - REST `POST /api/portfolio/crypto` ([src/app/api/portfolio/crypto/route.ts](src/app/api/portfolio/crypto/route.ts)) — pairing skipped when `accountId` is null (crypto holdings can be unattached).
+  - Backup-restore `POST /api/data/import` ([src/app/api/data/import/route.ts](src/app/api/data/import/route.ts)) — bulk insert via `RETURNING { id, accountId }` then bulk pairing INSERT using freshly-`RETURNING`-ed ids + already-remapped `accountId`s (never raw FK ids from the source backup; preserves the cross-tenant FK guard from `strip()`).
+  - csv-parser ([src/lib/csv-parser.ts](src/lib/csv-parser.ts)) — per-row `RETURNING` + pairing.
+  - Connector pipeline `portfolio-holding-resolver` ([src/lib/external-import/portfolio-holding-resolver.ts](src/lib/external-import/portfolio-holding-resolver.ts)) — auto-create branch.
+  - Connector pipeline `zip-orchestrator` ([src/lib/external-import/zip-orchestrator.ts](src/lib/external-import/zip-orchestrator.ts)) — bulk insert via `RETURNING { id, accountId }` then bulk pairing INSERT.
+  - `getOrCreateCashHolding` ([src/lib/investment-account.ts](src/lib/investment-account.ts)) — highest-traffic auto-create site (every first transaction in a newly-flagged investment account).
+  - MCP HTTP `record_trade` cash-sleeve auto-create ([mcp-server/register-tools-pg.ts](mcp-server/register-tools-pg.ts), the `else` branch immediately after line 3464). Mirrors the canonical pattern from `add_portfolio_holding`.
+- **Tracked migration** [scripts/migrations/20260509_holding-accounts-backfill-orphans.sql](scripts/migrations/20260509_holding-accounts-backfill-orphans.sql) — idempotent `INSERT … ON CONFLICT … DO NOTHING` repairs any orphans created between the 2026-05-01 loose-script backfill and the deploy that ships this fix. Applied automatically by `deploy.sh` once per env via `schema_migrations` bookkeeping; deploy ordering is `git pull → npm install → backup → migrations → build → restart` so existing orphans are repaired before the new code starts serving traffic.
+- **CLAUDE.md** — the "Every `portfolio_holdings` INSERT path must dual-write a `holding_accounts` row" gotcha rewritten as a positive invariant ("dual-write is enforced at all 9 sites; new INSERT paths must follow the same pattern"), enumerating the 9 enforced sites + a pointer to the canonical pattern.
+
+Out of scope (preserved per CLAUDE.md): the 4 portfolio aggregators continue to read live `SUM(transactions.quantity)` from `transactions`, NOT the cached `holding_accounts.qty` / `cost_basis` (issue #99 trap — there is no invalidation path). Stdio MCP create paths still refuse cleanly post Stream D Phase 4 (no DEK on the stdio transport); they cannot create the bug class. Tool counts unchanged: 90 HTTP / 86 stdio. The non-cash leg of MCP HTTP `record_trade` is auto-created via `createTransferPair` → `buildHoldingResolver` (the resolver branch is already covered by the `portfolio-holding-resolver` fix in this cohort).
+
 ### Dashboard balance fallback now branches on `is_investment` (#204, 2026-05-09)
 
 `/api/dashboard` per-account balance previously fell back to `SUM(transactions.amount)` whenever `holdingsByAccount.get(b.accountId)` returned `undefined`. For an investment account whose holdings aggregator dropped a position (orphan `holding_accounts` row, FX outage, freshly-imported snapshot before the holding has any transactions), the dashboard silently rendered the cash-leg sum (just the buy/sell/dividend cash legs) as the account balance — a meaningless number that looked like a real balance. Mirrors the canonical pattern shipped under #151 for `/api/goals`.

--- a/mcp-server/register-tools-pg.ts
+++ b/mcp-server/register-tools-pg.ts
@@ -3461,6 +3461,23 @@ export function registerPgTools(
         `);
         cashHoldingId = Number(ins[0]?.id);
         cashHoldingName = cashName;
+        // Issue #205 — dual-write holding_accounts pairing. Mirrors the
+        // canonical pattern at register-tools-pg.ts:4190-4201 in
+        // add_portfolio_holding. Without the pairing, every aggregator (issue
+        // #25) silently drops trades against this sleeve. On pairing failure,
+        // DELETE the orphan portfolio_holdings row.
+        try {
+          await q(db, sql`
+            INSERT INTO holding_accounts (holding_id, account_id, user_id, qty, cost_basis, is_primary)
+            VALUES (${cashHoldingId}, ${acct.id}, ${userId}, 0, 0, true)
+            ON CONFLICT (holding_id, account_id) DO NOTHING
+          `);
+        } catch (pairingErr) {
+          await q(db, sql`
+            DELETE FROM portfolio_holdings WHERE id = ${cashHoldingId} AND user_id = ${userId}
+          `);
+          throw pairingErr;
+        }
       }
 
       // For BUY: cash sleeve is the source (must exist — done above);

--- a/scripts/migrations/20260509_holding-accounts-backfill-orphans.sql
+++ b/scripts/migrations/20260509_holding-accounts-backfill-orphans.sql
@@ -1,0 +1,24 @@
+-- 20260509_holding-accounts-backfill-orphans.sql — issue #205.
+--
+-- Repairs the cohort of orphan portfolio_holdings rows created since the
+-- 2026-05-01 backfill (loose script: scripts/migrate-holding-accounts-backfill-orphans.sql)
+-- by the 8 INSERT paths that were not yet dual-writing into holding_accounts.
+-- Closes the issue #95 follow-up cohort by combining an in-place code fix
+-- across the 8 sites with this one-shot SQL repair for any orphans created
+-- between 2026-05-01 and the deploy that ships this migration.
+--
+-- Idempotent (`ON CONFLICT (holding_id, account_id) DO NOTHING`). Safe to
+-- re-run.
+--
+-- Runner contract: deploy.sh wraps this file in a transaction with the
+-- schema_migrations bookkeeping INSERT — do NOT add an inner BEGIN/COMMIT.
+-- Filename charset is [A-Za-z0-9_-].
+
+INSERT INTO holding_accounts (holding_id, account_id, user_id, qty, cost_basis, is_primary)
+SELECT ph.id, ph.account_id, ph.user_id, 0, 0, true
+FROM portfolio_holdings ph
+LEFT JOIN holding_accounts ha
+  ON ha.holding_id = ph.id AND ha.account_id = ph.account_id
+WHERE ha.holding_id IS NULL
+  AND ph.account_id IS NOT NULL
+ON CONFLICT (holding_id, account_id) DO NOTHING;

--- a/src/app/api/data/import/route.ts
+++ b/src/app/api/data/import/route.ts
@@ -295,10 +295,35 @@ export async function POST(request: NextRequest) {
     }
 
     if (d.portfolioHoldings?.length) {
-      await db
+      // Issue #205 — capture inserted ids so we can dual-write the matching
+      // holding_accounts pairings. Every aggregator (issue #25) JOINs through
+      // holding_accounts on (holding_id, account_id, user_id); an inserted
+      // holding without that pairing is silently invisible to the portfolio
+      // page, get_portfolio_analysis, etc.
+      const stripped = strip(d.portfolioHoldings, userId, { accountIdMap }) as (typeof schema.portfolioHoldings.$inferInsert)[];
+      const insertedHoldings = await db
         .insert(schema.portfolioHoldings)
-        .values(strip(d.portfolioHoldings, userId, { accountIdMap }) as (typeof schema.portfolioHoldings.$inferInsert)[])
-        ;
+        .values(stripped)
+        .returning({ id: schema.portfolioHoldings.id, accountId: schema.portfolioHoldings.accountId });
+
+      // Bulk-insert holding_accounts using the freshly-RETURNING-ed ids and
+      // the already-remapped accountIds. Skip rows where accountId is null
+      // (no pairing target). is_primary=true mirrors the legacy
+      // portfolio_holdings.account_id column. qty=0/cost_basis=0 are CACHED
+      // defaults — aggregators read live values from transactions.
+      const haRows = insertedHoldings
+        .filter((h): h is { id: number; accountId: number } => h.accountId != null)
+        .map((h) => ({
+          holdingId: h.id,
+          accountId: h.accountId,
+          userId,
+          qty: 0,
+          costBasis: 0,
+          isPrimary: true,
+        }));
+      if (haRows.length > 0) {
+        await db.insert(schema.holdingAccounts).values(haRows).onConflictDoNothing();
+      }
     }
 
     // Insert transactions, remapping FK references. Plaintext text fields are

--- a/src/app/api/portfolio/crypto/route.ts
+++ b/src/app/api/portfolio/crypto/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, schema } from "@/db";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { getCryptoPrices, symbolToCoinGeckoId } from "@/lib/crypto-service";
 import { z } from "zod";
 import { validateBody, safeErrorMessage } from "@/lib/validate";
@@ -120,6 +120,35 @@ export async function POST(request: NextRequest) {
       })
       .returning()
       .get();
+
+    // Issue #205 — dual-write holding_accounts pairing when accountId is
+    // present. Crypto holdings without an account stay unpaired (no aggregator
+    // JOIN to satisfy). On failure, DELETE the orphan portfolio_holdings row.
+    if (accountId != null) {
+      try {
+        await db
+          .insert(schema.holdingAccounts)
+          .values({
+            holdingId: holding.id,
+            accountId,
+            userId,
+            qty: 0,
+            costBasis: 0,
+            isPrimary: true,
+          })
+          .onConflictDoNothing();
+      } catch (pairingErr) {
+        await db
+          .delete(schema.portfolioHoldings)
+          .where(
+            and(
+              eq(schema.portfolioHoldings.id, holding.id),
+              eq(schema.portfolioHoldings.userId, userId),
+            ),
+          );
+        throw pairingErr;
+      }
+    }
 
     return NextResponse.json(holding);
   } catch (error: unknown) {

--- a/src/app/api/portfolio/route.ts
+++ b/src/app/api/portfolio/route.ts
@@ -91,6 +91,39 @@ export async function POST(request: NextRequest) {
         })
         .returning()
         .get();
+      // Issue #205 — dual-write holding_accounts pairing. Every aggregator
+      // (issue #25) JOINs through holding_accounts on (holding_id, account_id,
+      // user_id); without the pairing, the holding is invisible to
+      // get_portfolio_analysis / get_portfolio_performance / analyze_holding
+      // (live SUM(transactions.quantity) evaluates to 0). is_primary=true on
+      // the fresh row mirrors the legacy portfolio_holdings.account_id column.
+      // qty=0/cost_basis=0 are CACHED defaults — aggregators read live values
+      // from transactions (CLAUDE.md #99 trap; do NOT compute live sums here).
+      // On pairing failure, DELETE the orphan portfolio_holdings row so we
+      // never leave the user with an aggregator-invisible holding.
+      try {
+        await db
+          .insert(schema.holdingAccounts)
+          .values({
+            holdingId: holding.id,
+            accountId,
+            userId: auth.userId,
+            qty: 0,
+            costBasis: 0,
+            isPrimary: true,
+          })
+          .onConflictDoNothing();
+      } catch (pairingErr) {
+        await db
+          .delete(schema.portfolioHoldings)
+          .where(
+            and(
+              eq(schema.portfolioHoldings.id, holding.id),
+              eq(schema.portfolioHoldings.userId, auth.userId),
+            ),
+          );
+        throw pairingErr;
+      }
       return NextResponse.json(holding, { status: 201 });
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);

--- a/src/lib/csv-parser.ts
+++ b/src/lib/csv-parser.ts
@@ -454,7 +454,11 @@ export async function importPortfolio(csvText: string, userId: string, dek: Buff
           name: row["Portfolio holding name"],
           symbol: row["Symbol"] || null,
         });
-        await db.insert(schema.portfolioHoldings)
+        // Issue #205 — capture id via RETURNING + dual-write holding_accounts.
+        // Without the pairing, every aggregator (issue #25) silently drops
+        // transactions for this holding because the JOIN through
+        // holding_accounts on (holding_id, account_id, user_id) misses.
+        const insertedRow = await db.insert(schema.portfolioHoldings)
           .values({
             userId,
             accountId: account.id,
@@ -462,7 +466,34 @@ export async function importPortfolio(csvText: string, userId: string, dek: Buff
             note: row["Note"] ?? "",
             ...enc,
           })
-          ;
+          .returning({ id: schema.portfolioHoldings.id });
+        const inserted = Array.isArray(insertedRow) ? insertedRow[0] : insertedRow;
+        const holdingId = inserted?.id;
+        if (holdingId != null) {
+          try {
+            await db
+              .insert(schema.holdingAccounts)
+              .values({
+                holdingId,
+                accountId: account.id,
+                userId,
+                qty: 0,
+                costBasis: 0,
+                isPrimary: true,
+              })
+              .onConflictDoNothing();
+          } catch (pairingErr) {
+            await db
+              .delete(schema.portfolioHoldings)
+              .where(
+                and(
+                  eq(schema.portfolioHoldings.id, holdingId),
+                  eq(schema.portfolioHoldings.userId, userId),
+                ),
+              );
+            throw pairingErr;
+          }
+        }
         imported++;
       }
     } catch (e) {

--- a/src/lib/external-import/portfolio-holding-resolver.ts
+++ b/src/lib/external-import/portfolio-holding-resolver.ts
@@ -159,6 +159,33 @@ export async function buildHoldingResolver(
       const inserted = Array.isArray(insertedRow) ? insertedRow[0] : insertedRow;
       const id = inserted?.id;
       if (id != null) {
+        // Issue #205 — dual-write holding_accounts pairing. Every aggregator
+        // (issue #25) JOINs through this table; without the pairing the
+        // import-resolver-created holding is invisible. On pairing failure,
+        // DELETE the orphan portfolio_holdings row.
+        try {
+          await db
+            .insert(schema.holdingAccounts)
+            .values({
+              holdingId: id,
+              accountId,
+              userId,
+              qty: 0,
+              costBasis: 0,
+              isPrimary: true,
+            })
+            .onConflictDoNothing();
+        } catch (pairingErr) {
+          await db
+            .delete(schema.portfolioHoldings)
+            .where(
+              and(
+                eq(schema.portfolioHoldings.id, id),
+                eq(schema.portfolioHoldings.userId, userId),
+              ),
+            );
+          throw pairingErr;
+        }
         created++;
         byPlain.set(pk, id);
         if (lk) byLookup.set(lookupKey(accountId, lk), id);

--- a/src/lib/external-import/zip-orchestrator.ts
+++ b/src/lib/external-import/zip-orchestrator.ts
@@ -368,7 +368,26 @@ async function syncPortfolioHoldings(
   }
 
   if (toInsert.length === 0) return { inserted: 0 };
-  await db.insert(schema.portfolioHoldings).values(toInsert);
+  // Issue #205 — capture inserted ids and dual-write the holding_accounts
+  // pairings in the same call. Without the pairing the connector-created
+  // holdings are invisible to every aggregator (issue #25).
+  const insertedRows = await db
+    .insert(schema.portfolioHoldings)
+    .values(toInsert)
+    .returning({ id: schema.portfolioHoldings.id, accountId: schema.portfolioHoldings.accountId });
+  const haRows = insertedRows
+    .filter((h): h is { id: number; accountId: number } => h.accountId != null)
+    .map((h) => ({
+      holdingId: h.id,
+      accountId: h.accountId,
+      userId,
+      qty: 0,
+      costBasis: 0,
+      isPrimary: true,
+    }));
+  if (haRows.length > 0) {
+    await db.insert(schema.holdingAccounts).values(haRows).onConflictDoNothing();
+  }
   return { inserted: toInsert.length };
 }
 

--- a/src/lib/investment-account.ts
+++ b/src/lib/investment-account.ts
@@ -140,7 +140,40 @@ export async function getOrCreateCashHolding(
       })
       .returning({ id: schema.portfolioHoldings.id });
     const id = Array.isArray(inserted) ? inserted[0]?.id : (inserted as { id?: number } | undefined)?.id;
-    if (id != null) return id;
+    if (id != null) {
+      // Issue #205 — dual-write holding_accounts pairing. The cash sleeve is
+      // the highest-traffic auto-create site (every first transaction in a
+      // newly-flagged investment account); without the pairing, the sleeve is
+      // invisible to every aggregator and `accounts.balance` resolves to a
+      // misleading 0/negative number. is_primary=true mirrors the legacy
+      // portfolio_holdings.account_id column. On pairing failure, DELETE the
+      // orphan portfolio_holdings row — a Cash sleeve we can't pair with the
+      // account is worse than no sleeve (the next call retries cleanly).
+      try {
+        await db
+          .insert(schema.holdingAccounts)
+          .values({
+            holdingId: id,
+            accountId,
+            userId,
+            qty: 0,
+            costBasis: 0,
+            isPrimary: true,
+          })
+          .onConflictDoNothing();
+      } catch (pairingErr) {
+        await db
+          .delete(schema.portfolioHoldings)
+          .where(
+            and(
+              eq(schema.portfolioHoldings.id, id),
+              eq(schema.portfolioHoldings.userId, userId),
+            ),
+          );
+        throw pairingErr;
+      }
+      return id;
+    }
   } catch (err) {
     // 23505 = unique_violation — concurrent writer beat us. Re-SELECT.
     const code = (err as { code?: string }).code;


### PR DESCRIPTION
Closes #205

## Summary

Closes the issue #95 follow-up cohort. Every `portfolio_holdings` INSERT path now dual-writes the matching `holding_accounts(holding_id, account_id, user_id, qty=0, cost_basis=0, is_primary=true)` pairing in the same transaction, mirroring the canonical pattern from `add_portfolio_holding` at `mcp-server/register-tools-pg.ts:4190-4201`. A tracked SQL migration repairs any orphans created since the 2026-05-01 loose-script backfill.

**User-visible symptom resolved:** investment accounts with holdings whose INSERT path skipped the pairing rendered the Portfolio page as `N holdings across 1 accounts` but every Qty / Avg Cost / Mkt Value / Unrealized G/L cell showed `--`, and "All Holdings" reported `No holdings found.`. Root cause: every aggregator (issue #25) INNER-JOINs through `holding_accounts` on `(holding_id, account_id, user_id)`; without the pairing every transaction for the holding silently dropped and live `SUM(transactions.quantity)` evaluated to 0.

## Fixed call sites (8)

- REST `POST /api/portfolio` — Add Holding dialog
- REST `POST /api/portfolio/crypto` — pairing skipped when `accountId` is null (crypto can be unattached)
- Backup-restore `POST /api/data/import` — bulk insert via `RETURNING { id, accountId }` then bulk pairing INSERT using freshly-`RETURNING`-ed ids + already-remapped `accountId`s (preserves the cross-tenant FK guard from `strip()`)
- `src/lib/csv-parser.ts` — per-row `RETURNING` + pairing
- `src/lib/external-import/portfolio-holding-resolver.ts` — auto-create branch
- `src/lib/external-import/zip-orchestrator.ts` — bulk insert via `RETURNING { id, accountId }` + bulk pairing INSERT
- `src/lib/investment-account.ts::getOrCreateCashHolding` — highest-traffic auto-create site (every first transaction in a newly-flagged investment account)
- MCP HTTP `record_trade` cash-sleeve auto-create branch — mirrors the canonical pattern

`add_portfolio_holding` HTTP (line 4153-4196) was already correct — not touched. Stdio MCP create paths still refuse cleanly post Stream D Phase 4 (no DEK on the stdio transport); they cannot create the bug class.

## Docs updated

- `pf-app/CHANGELOG.md` — top-of-file Unreleased entry under `#205`
- `CLAUDE.md` (parent) — load-bearing gotcha rewritten as a positive invariant ("dual-write is enforced at all 9 sites; new INSERT paths must follow the same pattern")

## Promotion to main

- **Schema migration:** `pf-app/scripts/migrations/20260509_holding-accounts-backfill-orphans.sql` runs automatically via `deploy.sh` once per env (tracked in `schema_migrations`). Deploy ordering is `git pull → npm install → backup → migrations → build → restart`, so existing orphans are repaired BEFORE the new code starts serving traffic. Idempotent — no inner BEGIN/COMMIT (the runner wraps the whole file).
- **No env var changes**, no new crons, no dependency changes, no CSP changes, no UI changes.
- **No MCP surface change** — existing tools, behavior corrected. Tool counts unchanged: 90 HTTP / 86 stdio.
- **Aggregators unchanged** — they continue to read live `SUM(transactions.quantity)` from `transactions`, NOT cached `holding_accounts.qty` / `cost_basis` (issue #99 trap; CACHED columns have no invalidation path).

## How I tested

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — passes (production build).
- [ ] **Post-deploy on dev:** create a holding via the REST Add Holding dialog and confirm the Portfolio page renders non-zero qty after recording a transaction. Verify `getOrCreateCashHolding` auto-create on the first transaction in a newly-flagged investment account writes both rows. Verify `/api/portfolio/overview` returns the holding under "All Holdings".
- [ ] **Post-deploy on dev:** confirm the affected investment account's balance on `/accounts` resolves to `holdings.value` (issue #204 dashboard fallback already shipped under #204; combined with this fix, the previously-misleading negative figure should resolve).
- [ ] **Migration verification:** post-deploy, run `SELECT COUNT(*) FROM portfolio_holdings ph LEFT JOIN holding_accounts ha ON ha.holding_id = ph.id WHERE ha.holding_id IS NULL AND ph.account_id IS NOT NULL` — should return 0.