### PR TITLE
Fix FX historical-rate bug + cache poisoning + currency validation (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### CRITICAL: FX historical-rate bug + cache poisoning + currency validation (#206, 2026-05-09)
+
+Fixes the auditor's #1 finding from `reviews/2026-05-09/04-fx-rate-historical-and-cache-poisoning.md`. Four compounding defects in the FX cache + lookup were silently poisoning every cross-currency cost basis, FX gain, and reporting-currency conversion in the system.
+
+- **Historical-rate bug** ([src/lib/fx-service.ts](src/lib/fx-service.ts)) — `fetchYahooRateToUsd()` was building the historical chart URL correctly (`period1`/`period2`) but extracting `meta.regularMarketPrice` from the response, which is **today's** price even on a historical payload. The actual close lives at `result.indicators.quote[0].close[]` indexed by `result.timestamp[]`. The historical branch now picks the latest close ≤ requested date over a 7-day window (catches weekend/holiday gaps); the latest-rate branch (`date >= today`) keeps `meta.regularMarketPrice` (correct there). Stooq metals path was always correct — left alone.
+- **Future-date cache write gate** — `getRateToUsdDetailed()` now skips `writeCached()` when `date > today`. Before: a future-date query would stamp a synthetic row at the future date with today's price; that row then outranked every legitimate historical row in `findNearestCached` and served as a stale fallback for every miss. Engine still tolerates future-date QUERIES (load-bearing for `convertToAccountCurrency` write paths and the `settleFutureFxRates` cron which re-locks rates when the date arrives) — the hard reject lives at the MCP tool boundary, not in the engine.
+- **`findNearestCached` hardening** — now restricts to `date <= today`. Defense in depth.
+- **MCP boundary validation** — new `validateCurrencyCode()` + `validateFxDate()` helpers exported from `fx-service.ts`. Both transports (HTTP `register-tools-pg.ts` + stdio `register-core-tools.ts`) wrap `get_fx_rate`, `set_fx_override`, `convert_amount` with try/catch on the validators. Rejects empty strings, unknown currencies (e.g. `XYZ` → `error: unknown currency: XYZ` instead of silent USD-parity fallback), pre-1970 dates, and future dates. `set_fx_override` also rejects `dateTo < date`.
+- **`convert_amount` precision aligned** — now returns rate to 8 decimals (matching `get_fx_rate`). The `converted` amount stays at 2 decimals (currency-display precision).
+- **Currency-enum widening** ([mcp-server/register-tools-pg.ts](mcp-server/register-tools-pg.ts), [mcp-server/register-core-tools.ts](mcp-server/register-core-tools.ts), [mcp-server/tools-v2.ts](mcp-server/tools-v2.ts)) — six create/update tool sites (`add_account`, `update_account`, `add_portfolio_holding`, `update_portfolio_holding`, `add_subscription`, `update_subscription`) replaced `z.enum(["CAD", "USD"])` with the full `SUPPORTED_CURRENCIES` list (32 fiats + 4 cryptos + 4 metals). The FX engine has supported all 40 currencies via triangulation through USD since the canonical-USD model landed; the artificial CAD/USD constraint on creates was the regression.
+- **Cache-purge migration** — new [scripts/migrations/20260509_fx-cache-purge-future-dates.sql](scripts/migrations/20260509_fx-cache-purge-future-dates.sql). `DELETE FROM fx_rates WHERE date::date > CURRENT_DATE`. Idempotent. `deploy.sh` runs it once per env via `schema_migrations` bookkeeping.
+- **Out of scope** — recomputing biased aggregates on existing transactions. Historical buys carry slightly biased cost basis because Yahoo lookup has been wrong forever. Fix forward only. Stdio MCP create/update tools for the 6 in-scope tables still refuse cleanly per Stream D Phase 4 (no DEK on stdio); the widened enum applies whenever those tools become invocable in future.
+
+Verification: `npx tsc --noEmit` clean, `npm run build` passes.
+
 ### Portfolio aggregator: orphan-holdings fix cohort — dual-write `holding_accounts` at all 8 unfixed INSERT paths (#205, 2026-05-09)
 
 Closes the issue #95 follow-up cohort. Every `portfolio_holdings` INSERT path now dual-writes the matching `holding_accounts(holding_id, account_id, user_id, qty=0, cost_basis=0, is_primary=true)` pairing in the same transaction, and a tracked SQL migration repairs any orphans created since the 2026-05-01 loose-script backfill.

--- a/mcp-server/register-core-tools.ts
+++ b/mcp-server/register-core-tools.ts
@@ -18,7 +18,13 @@ import {
   calculateDebtPayoff,
   type Debt,
 } from "../src/lib/loan-calculator.js";
-import { getLatestFxRate, getRate } from "../src/lib/fx-service.js";
+import {
+  getLatestFxRate,
+  getRate,
+  validateCurrencyCode,
+  validateFxDate,
+} from "../src/lib/fx-service.js";
+import { SUPPORTED_CURRENCIES } from "../src/lib/fx/supported-currencies.js";
 import { resolveTxAmountsCore } from "../src/lib/currency-conversion.js";
 import {
   invalidateUser as invalidateUserTxCache,
@@ -316,6 +322,12 @@ function txt(data: unknown) {
 function sqliteErr(msg: string) {
   return { content: [{ type: "text" as const, text: `Error: ${msg}` }], isError: true };
 }
+
+// Issue #206 — currency enum widened to the full SUPPORTED_CURRENCIES list
+// (32 fiats + 4 cryptos + 4 metals). Mirrors register-tools-pg.ts.
+const supportedCurrencyEnum = z.enum(
+  SUPPORTED_CURRENCIES as unknown as [string, ...string[]]
+);
 
 /**
  * Stream D Phase 4 refusal helper (2026-05-03).
@@ -1180,7 +1192,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       name: z.string().describe("Account name (must be unique)"),
       type: z.enum(["A", "L"]).describe("'A'=asset, 'L'=liability"),
       group: z.string().optional().describe("Account group"),
-      currency: z.enum(["CAD", "USD"]).optional().describe("Currency (default CAD)"),
+      currency: supportedCurrencyEnum.optional().describe("Currency (default CAD)"),
       note: z.string().optional(),
       alias: z.string().max(64).optional().describe("Optional short alias used to match the account when receipts or imports reference it by a non-canonical name (e.g. last 4 digits of a card, or a receipt label)."),
     },
@@ -1199,7 +1211,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       account: z.string().describe("Current account name or alias (fuzzy matched against name; exact match on alias)"),
       name: z.string().optional(),
       group: z.string().optional(),
-      currency: z.enum(["CAD", "USD"]).optional(),
+      currency: supportedCurrencyEnum.optional(),
       note: z.string().optional(),
       alias: z.string().max(64).optional().describe("New alias — short shorthand used to match receipts/imports. Pass an empty string to clear."),
     },
@@ -1338,7 +1350,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       name: z.string().min(1).max(200).describe("Display name of the holding"),
       account: z.string().describe("Brokerage account name or alias (fuzzy matched). Required because uniqueness is per (account, name)."),
       symbol: z.string().max(50).optional().describe("Ticker symbol (e.g. 'VEQT.TO', 'BTC')"),
-      currency: z.enum(["CAD", "USD"]).optional(),
+      currency: supportedCurrencyEnum.optional(),
       isCrypto: z.boolean().optional(),
       note: z.string().max(500).optional(),
     },
@@ -1359,7 +1371,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       name: z.string().min(1).max(200).optional(),
       symbol: z.string().max(50).optional().describe("Pass empty string to clear"),
       account: z.string().optional().describe("REFUSED (issue #99): account moves create stale state. Use record_transfer (in-kind) instead."),
-      currency: z.enum(["CAD", "USD"]).optional(),
+      currency: supportedCurrencyEnum.optional(),
       isCrypto: z.boolean().optional(),
       note: z.string().max(500).optional(),
     },
@@ -1864,10 +1876,23 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       date: z.string().optional(),
     },
     async ({ from, to, date }) => {
-      const d = date ?? new Date().toISOString().split("T")[0];
-      if (from === to) return txt({ success: true, data: { from, to, date: d, rate: 1, source: "identity" } });
-      const rate = await getRate(from, to, d, userId);
-      return txt({ success: true, data: { from, to, date: d, rate, source: "triangulated" } });
+      // Issue #206 — validate currencies + date at the MCP boundary.
+      let fromCode: string;
+      let toCode: string;
+      let d: string;
+      try {
+        fromCode = validateCurrencyCode(from);
+        toCode = validateCurrencyCode(to);
+        d = validateFxDate(date ?? new Date().toISOString().split("T")[0]);
+      } catch (e) {
+        return sqliteErr(e instanceof Error ? e.message : String(e));
+      }
+      if (fromCode === toCode) {
+        return txt({ success: true, data: { from: fromCode, to: toCode, date: d, rate: 1, source: "identity" } });
+      }
+      const rate = await getRate(fromCode, toCode, d, userId);
+      const ratePrecise = Math.round(rate * 100000000) / 100000000;
+      return txt({ success: true, data: { from: fromCode, to: toCode, date: d, rate: ratePrecise, source: "triangulated" } });
     }
   );
 
@@ -1897,8 +1922,23 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       note: z.string().optional(),
     },
     async ({ from, to, date, rate, dateTo, note }) => {
-      const fromU = from.trim().toUpperCase();
-      const toU = to.trim().toUpperCase();
+      // Issue #206 — validate currencies + dates at the MCP boundary so a
+      // future-dated or unknown-currency override can't poison the cache.
+      let fromU: string;
+      let toU: string;
+      let dateFrom: string;
+      let dateToFinal: string;
+      try {
+        fromU = validateCurrencyCode(from);
+        toU = validateCurrencyCode(to);
+        dateFrom = validateFxDate(date);
+        dateToFinal = validateFxDate(dateTo ?? date);
+      } catch (e) {
+        return sqliteErr(e instanceof Error ? e.message : String(e));
+      }
+      if (dateToFinal < dateFrom) {
+        return sqliteErr(`dateTo (${dateToFinal}) must be on or after date (${dateFrom}).`);
+      }
       let currency: string;
       let rateToUsd: number;
       if (fromU === "USD") { currency = toU; rateToUsd = 1 / rate; }
@@ -1907,8 +1947,8 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
 
       const result = await sqlite.prepare(
         `INSERT INTO fx_overrides (user_id, currency, date_from, date_to, rate_to_usd, note) VALUES (?, ?, ?, ?, ?, ?) RETURNING id`
-      ).get(userId, currency, date, dateTo ?? date, rateToUsd, note ?? "") as { id: number } | undefined;
-      return txt({ success: true, data: { id: result?.id, currency, dateFrom: date, dateTo: dateTo ?? date, rateToUsd, action: "created" } });
+      ).get(userId, currency, dateFrom, dateToFinal, rateToUsd, note ?? "") as { id: number } | undefined;
+      return txt({ success: true, data: { id: result?.id, currency, dateFrom, dateTo: dateToFinal, rateToUsd, action: "created" } });
     }
   );
 
@@ -1938,11 +1978,24 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       date: z.string().optional(),
     },
     async ({ amount, from, to, date }) => {
-      const d = date ?? new Date().toISOString().split("T")[0];
-      if (from === to) return txt({ success: true, data: { amount, from, to, rate: 1, converted: amount } });
-      const rate = await getRate(from, to, d, userId);
+      // Issue #206 — validate currencies + date at the MCP boundary.
+      let fromCode: string;
+      let toCode: string;
+      let d: string;
+      try {
+        fromCode = validateCurrencyCode(from);
+        toCode = validateCurrencyCode(to);
+        d = validateFxDate(date ?? new Date().toISOString().split("T")[0]);
+      } catch (e) {
+        return sqliteErr(e instanceof Error ? e.message : String(e));
+      }
+      if (fromCode === toCode) {
+        return txt({ success: true, data: { amount, from: fromCode, to: toCode, rate: 1, converted: amount } });
+      }
+      const rate = await getRate(fromCode, toCode, d, userId);
       const converted = Math.round(amount * rate * 100) / 100;
-      return txt({ success: true, data: { amount, from, to, rate, converted, date: d, source: "triangulated" } });
+      const ratePrecise = Math.round(rate * 100000000) / 100000000;
+      return txt({ success: true, data: { amount, from: fromCode, to: toCode, rate: ratePrecise, converted, date: d, source: "triangulated" } });
     }
   );
 
@@ -1963,7 +2016,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       amount: z.number(),
       cadence: z.enum(["weekly", "monthly", "quarterly", "annual", "yearly"]),
       next_billing_date: z.string(),
-      currency: z.enum(["CAD", "USD"]).optional(),
+      currency: supportedCurrencyEnum.optional(),
       category: z.string().optional(),
       account: z.string().optional().describe("Account name or alias (fuzzy matched against name; exact match on alias)"),
       notes: z.string().optional(),
@@ -1985,7 +2038,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       amount: z.number().optional(),
       cadence: z.enum(["weekly", "monthly", "quarterly", "annual", "yearly"]).optional(),
       next_billing_date: z.string().optional(),
-      currency: z.enum(["CAD", "USD"]).optional(),
+      currency: supportedCurrencyEnum.optional(),
       category: z.string().optional().describe("Empty string clears"),
       account: z.string().optional().describe("Account name or alias (fuzzy matched against name; exact match on alias). Empty string clears."),
       status: z.enum(["active", "paused", "cancelled"]).optional(),

--- a/mcp-server/register-tools-pg.ts
+++ b/mcp-server/register-tools-pg.ts
@@ -21,7 +21,14 @@ import {
   calculateDebtPayoff,
   type Debt,
 } from "../src/lib/loan-calculator";
-import { getLatestFxRate, getRate, getRateToUsdDetailed } from "../src/lib/fx-service";
+import {
+  getLatestFxRate,
+  getRate,
+  getRateToUsdDetailed,
+  validateCurrencyCode,
+  validateFxDate,
+} from "../src/lib/fx-service";
+import { SUPPORTED_CURRENCIES } from "../src/lib/fx/supported-currencies";
 import {
   computeAllAccountsUnrealizedPnL,
   summarizeUnrealizedPnL,
@@ -168,6 +175,12 @@ function text(data: unknown) {
 function err(msg: string) {
   return { content: [{ type: "text" as const, text: `Error: ${msg}` }] };
 }
+
+// Issue #206 — currency enum widened to the full SUPPORTED_CURRENCIES list
+// (32 fiats + 4 cryptos + 4 metals). Zod requires the literal-tuple cast.
+const supportedCurrencyEnum = z.enum(
+  SUPPORTED_CURRENCIES as unknown as [string, ...string[]]
+);
 
 /**
  * Fuzzy match against a row list: exact-name → exact-alias → startsWith-name →
@@ -2280,7 +2293,7 @@ export function registerPgTools(
       name: z.string().describe("Account name (must be unique)"),
       type: z.enum(["A", "L"]).describe("Account type: 'A' for asset, 'L' for liability"),
       group: z.string().optional().describe("Account group (e.g. 'Banks', 'Credit Cards', 'Investment')"),
-      currency: z.enum(["CAD", "USD"]).optional().describe("Currency (default CAD)"),
+      currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code (default CAD). Issue #206: any currency in SUPPORTED_CURRENCIES is accepted; FX engine triangulates through USD."),
       note: z.string().optional().describe("Optional note"),
       alias: z.string().max(64).optional().describe("Optional short alias used to match the account when receipts or imports reference it by a non-canonical name (e.g. last 4 digits of a card, or a receipt label)."),
     },
@@ -3706,7 +3719,7 @@ export function registerPgTools(
       account: z.string().describe("Current account name or alias (fuzzy matched against name; exact match on alias)"),
       name: z.string().optional().describe("New name"),
       group: z.string().optional().describe("New group"),
-      currency: z.enum(["CAD", "USD"]).optional().describe("New currency"),
+      currency: supportedCurrencyEnum.optional().describe("New ISO 4217 currency code (issue #206: full SUPPORTED_CURRENCIES list)."),
       note: z.string().optional().describe("New note"),
       alias: z.string().max(64).optional().describe("New alias — short shorthand used to match receipts/imports (e.g. last 4 digits of a card). Pass an empty string to clear."),
     },
@@ -4138,7 +4151,7 @@ export function registerPgTools(
       name: z.string().min(1).max(200).describe("Display name of the holding (e.g. 'Vanguard All-Equity ETF')"),
       account: z.string().describe("Brokerage account name or alias (fuzzy matched against name; exact match on alias). Required because uniqueness is scoped per (account, name)."),
       symbol: z.string().max(50).optional().describe("Ticker symbol (e.g. 'VEQT.TO', 'BTC')"),
-      currency: z.enum(["CAD", "USD"]).optional().describe("Currency (default: parent account's currency)"),
+      currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency (default: parent account's currency). Issue #206: full SUPPORTED_CURRENCIES list."),
       isCrypto: z.boolean().optional().describe("Flag this holding as crypto (default: false)"),
       note: z.string().max(500).optional(),
     },
@@ -4242,7 +4255,7 @@ export function registerPgTools(
       name: z.string().min(1).max(200).optional().describe("New name"),
       symbol: z.string().max(50).optional().describe("New symbol (pass empty string to clear)"),
       account: z.string().optional().describe("REFUSED (issue #99): account moves create stale state. Use record_transfer (in-kind) to move shares between accounts; update individual transactions to re-attribute history."),
-      currency: z.enum(["CAD", "USD"]).optional(),
+      currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code (issue #206: full SUPPORTED_CURRENCIES list)."),
       isCrypto: z.boolean().optional(),
       note: z.string().max(500).optional(),
     },
@@ -5825,17 +5838,33 @@ export function registerPgTools(
       date: z.string().optional().describe("YYYY-MM-DD — defaults to today"),
     },
     async ({ from, to, date }) => {
-      const d = date ?? new Date().toISOString().split("T")[0];
-      if (from === to) return text({ success: true, data: { from, to, date: d, rate: 1, source: "identity" } });
-      const fromLookup = await getRateToUsdDetailed(from, d, userId);
-      const toLookup = await getRateToUsdDetailed(to, d, userId);
-      if (toLookup.rate === 0) return err(`Cannot convert into ${to} (rate is zero)`);
+      // Issue #206 — validate currencies + date at the MCP boundary.
+      let fromCode: string;
+      let toCode: string;
+      let d: string;
+      try {
+        fromCode = validateCurrencyCode(from);
+        toCode = validateCurrencyCode(to);
+        d = validateFxDate(date ?? new Date().toISOString().split("T")[0]);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+      if (fromCode === toCode) {
+        return text({ success: true, data: { from: fromCode, to: toCode, date: d, rate: 1, source: "identity" } });
+      }
+      const fromLookup = await getRateToUsdDetailed(fromCode, d, userId);
+      const toLookup = await getRateToUsdDetailed(toCode, d, userId);
+      if (toLookup.rate === 0) return err(`Cannot convert into ${toCode} (rate is zero)`);
       const rate = fromLookup.rate / toLookup.rate;
+      const warnings: string[] = [];
+      if (fromLookup.source === "fallback") warnings.push(`No historical rate available for ${fromCode}; using hardcoded fallback.`);
+      if (toLookup.source === "fallback") warnings.push(`No historical rate available for ${toCode}; using hardcoded fallback.`);
       return text({ success: true, data: {
-        from, to, date: d,
+        from: fromCode, to: toCode, date: d,
         rate: Math.round(rate * 100000000) / 100000000,
         source: fromLookup.source === "override" || toLookup.source === "override" ? "override" : fromLookup.source,
         legs: { from: fromLookup, to: toLookup },
+        ...(warnings.length ? { warnings } : {}),
       } });
     }
   );
@@ -5868,8 +5897,24 @@ export function registerPgTools(
       note: z.string().optional().describe("Optional note (e.g. 'bank rate at Wise on this day')"),
     },
     async ({ from, to, date, rate, dateTo, note }) => {
-      const fromU = from.trim().toUpperCase();
-      const toU = to.trim().toUpperCase();
+      // Issue #206 — validate currencies + dates at the MCP boundary so a
+      // future-dated or unknown-currency override can't poison the cache
+      // via findNearestCached's nearest-row lookup.
+      let fromU: string;
+      let toU: string;
+      let dateFrom: string;
+      let dateToFinal: string;
+      try {
+        fromU = validateCurrencyCode(from);
+        toU = validateCurrencyCode(to);
+        dateFrom = validateFxDate(date);
+        dateToFinal = validateFxDate(dateTo ?? date);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+      if (dateToFinal < dateFrom) {
+        return err(`dateTo (${dateToFinal}) must be on or after date (${dateFrom}).`);
+      }
       let currency: string;
       let rateToUsd: number;
       if (fromU === "USD") {
@@ -5885,10 +5930,10 @@ export function registerPgTools(
       }
       const result = await q(db, sql`
         INSERT INTO fx_overrides (user_id, currency, date_from, date_to, rate_to_usd, note)
-        VALUES (${userId}, ${currency}, ${date}, ${dateTo ?? date}, ${rateToUsd}, ${note ?? ""})
+        VALUES (${userId}, ${currency}, ${dateFrom}, ${dateToFinal}, ${rateToUsd}, ${note ?? ""})
         RETURNING id
       `);
-      return text({ success: true, data: { id: Number(result[0]?.id), currency, dateFrom: date, dateTo: dateTo ?? date, rateToUsd, action: "created" } });
+      return text({ success: true, data: { id: Number(result[0]?.id), currency, dateFrom, dateTo: dateToFinal, rateToUsd, action: "created" } });
     }
   );
 
@@ -5917,11 +5962,25 @@ export function registerPgTools(
       date: z.string().optional().describe("YYYY-MM-DD — defaults to today"),
     },
     async ({ amount, from, to, date }) => {
-      const d = date ?? new Date().toISOString().split("T")[0];
-      if (from === to) return text({ success: true, data: { amount, from, to, rate: 1, converted: amount, source: "identity" } });
-      const rate = await getRate(from, to, d, userId);
+      // Issue #206 — validate currencies + date at the MCP boundary.
+      let fromCode: string;
+      let toCode: string;
+      let d: string;
+      try {
+        fromCode = validateCurrencyCode(from);
+        toCode = validateCurrencyCode(to);
+        d = validateFxDate(date ?? new Date().toISOString().split("T")[0]);
+      } catch (e) {
+        return err(e instanceof Error ? e.message : String(e));
+      }
+      if (fromCode === toCode) {
+        return text({ success: true, data: { amount, from: fromCode, to: toCode, rate: 1, converted: amount, source: "identity" } });
+      }
+      const rate = await getRate(fromCode, toCode, d, userId);
       const converted = Math.round(amount * rate * 100) / 100;
-      return text({ success: true, data: { amount, from, to, rate, converted, date: d, source: "triangulated" } });
+      // Match get_fx_rate precision (8 decimals, the bank standard).
+      const ratePrecise = Math.round(rate * 100000000) / 100000000;
+      return text({ success: true, data: { amount, from: fromCode, to: toCode, rate: ratePrecise, converted, date: d, source: "triangulated" } });
     }
   );
 
@@ -5966,7 +6025,7 @@ export function registerPgTools(
       amount: z.number().describe("Amount per billing cycle (positive number)"),
       cadence: z.enum(["weekly", "monthly", "quarterly", "annual", "yearly"]).describe("Billing frequency"),
       next_billing_date: z.string().describe("Next billing date (YYYY-MM-DD)"),
-      currency: z.enum(["CAD", "USD"]).optional().describe("Default CAD"),
+      currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code (default CAD). Issue #206: full SUPPORTED_CURRENCIES list."),
       category: z.string().optional().describe("Category name (fuzzy matched)"),
       account: z.string().optional().describe("Account name or alias (fuzzy matched against name; exact match on alias)"),
       notes: z.string().optional(),
@@ -6021,7 +6080,7 @@ export function registerPgTools(
       amount: z.number().optional(),
       cadence: z.enum(["weekly", "monthly", "quarterly", "annual", "yearly"]).optional(),
       next_billing_date: z.string().optional().describe("YYYY-MM-DD"),
-      currency: z.enum(["CAD", "USD"]).optional(),
+      currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code (issue #206: full SUPPORTED_CURRENCIES list)."),
       category: z.string().optional().describe("Category name (fuzzy). Empty string clears."),
       account: z.string().optional().describe("Account name or alias (fuzzy matched against name; exact match on alias). Empty string clears."),
       status: z.enum(["active", "paused", "cancelled"]).optional(),

--- a/mcp-server/tools-v2.ts
+++ b/mcp-server/tools-v2.ts
@@ -15,6 +15,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { PgCompatDb } from "./pg-compat.js";
+import { SUPPORTED_CURRENCIES } from "../src/lib/fx/supported-currencies.js";
+
+// Issue #206 — currency enum widened to the full SUPPORTED_CURRENCIES list.
+const supportedCurrencyEnum = z.enum(
+  SUPPORTED_CURRENCIES as unknown as [string, ...string[]]
+);
 
 // ============ TYPES ============
 
@@ -230,7 +236,7 @@ export function registerV2Tools(server: McpServer, sqlite: PgCompatDb, opts: V2T
       name: z.string().describe("Account name (must be unique)"),
       type: z.enum(["A", "L"]).describe("Account type: 'A' for asset, 'L' for liability"),
       group: z.string().optional(),
-      currency: z.enum(["CAD", "USD"]).optional(),
+      currency: supportedCurrencyEnum.optional(),
       note: z.string().optional(),
     },
     async () => mcpError("add_account requires an unlocked DEK to write the encrypted accounts.name_ct/name_lookup columns after Stream D Phase 4. Stdio MCP cannot encrypt — use the HTTP MCP transport at /mcp or the web UI."),

--- a/scripts/migrations/20260509_fx-cache-purge-future-dates.sql
+++ b/scripts/migrations/20260509_fx-cache-purge-future-dates.sql
@@ -1,0 +1,16 @@
+-- Issue #206 — purge poisoned future-dated FX cache rows.
+--
+-- Background: before the fix, getRateToUsdDetailed() persisted the result of a
+-- "today" Yahoo fetch under any requested date — including future dates. Those
+-- rows then outranked every legitimate historical row in findNearestCached
+-- (ORDER BY date DESC LIMIT 1) and served as a stale fallback for every miss.
+--
+-- The fix gates writeCached on date <= today AND restricts findNearestCached
+-- to date <= today. This migration cleans up rows already written before the
+-- fix landed. It is safe to run repeatedly (idempotent — DELETE on a predicate
+-- with no rows is a no-op).
+--
+-- fx_rates is a global table (no user_id), so this runs once per env, not
+-- per user. fx_overrides is left alone — those are user-entered with intent.
+
+DELETE FROM fx_rates WHERE date::date > CURRENT_DATE;

--- a/src/lib/fx-service.ts
+++ b/src/lib/fx-service.ts
@@ -16,10 +16,47 @@
 
 import { db, schema } from "@/db";
 import { and, eq, desc, gte, lte, isNull, or, sql } from "drizzle-orm";
-import { isCryptoCurrency, isMetalCurrency } from "@/lib/fx/supported-currencies";
+import {
+  SUPPORTED_CURRENCIES,
+  isCryptoCurrency,
+  isMetalCurrency,
+} from "@/lib/fx/supported-currencies";
 
 export type RateSource = "yahoo" | "coingecko" | "stooq" | "override" | "stale" | "fallback";
 export type RateLookup = { rate: number; source: RateSource; effectiveDate: string };
+
+// Currency + date validation helpers for the MCP tool boundary.
+// IMPORTANT: do NOT call validateDate from inside getRateToUsdDetailed/getRate.
+// `convertToAccountCurrency` (write paths) legitimately resolves rates for
+// future-dated transactions and the `settleFutureFxRates` cron re-locks them
+// when the date arrives. Future-date hard-rejects belong on the public MCP
+// tool wrappers (`get_fx_rate`, `set_fx_override`, `convert_amount`), not in
+// the engine. (Issue #206 — historical rates + cache poisoning.)
+const SUPPORTED_CURRENCY_SET = new Set<string>(SUPPORTED_CURRENCIES);
+const FALLBACK_CURRENCY_SET = new Set<string>(); // populated below after FALLBACK_RATE_TO_USD definition
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const FX_MIN_DATE = "1970-01-01";
+
+export function validateCurrencyCode(code: string): string {
+  const c = (code ?? "").trim().toUpperCase();
+  if (!c) throw new Error("currency required");
+  if (!SUPPORTED_CURRENCY_SET.has(c) && !FALLBACK_CURRENCY_SET.has(c)) {
+    throw new Error(`unknown currency: ${c}`);
+  }
+  return c;
+}
+
+export function validateFxDate(date: string): string {
+  if (!date || !ISO_DATE_RE.test(date)) throw new Error("date must be YYYY-MM-DD");
+  if (date < FX_MIN_DATE) throw new Error("date out of range (pre-1970)");
+  // Use `todayISO()` declared below — function declarations are hoisted-equivalent
+  // for `const` arrow assigned at module top-level via `function` form below; this
+  // file uses an arrow `const`, so we inline the calculation to avoid TDZ.
+  const today = new Date().toISOString().split("T")[0];
+  if (date > today) throw new Error("future-dated FX rate not supported");
+  return date;
+}
 
 // Hardcoded fallbacks — only used when we can't reach Yahoo and have nothing
 // cached for this currency. Stored as <CCY> → USD.
@@ -42,6 +79,12 @@ const FALLBACK_RATE_TO_USD: Record<string, number> = {
   XPT: 1000,
   XPD: 1000,
 };
+
+// Pull the hardcoded codes into the validator's allowlist too, so users on a
+// self-hosted instance whose `SUPPORTED_CURRENCIES` happens to be missing one
+// (rare — every fallback code is also in the supported list today) still hit
+// the fallback path rather than `unknown currency`.
+for (const k of Object.keys(FALLBACK_RATE_TO_USD)) FALLBACK_CURRENCY_SET.add(k);
 
 const todayISO = (): string => new Date().toISOString().split("T")[0];
 
@@ -79,12 +122,15 @@ async function fetchYahooRateToUsd(currency: string, date: string): Promise<numb
     const symbol = `${currency}USD=X`;
     const today = todayISO();
     let url: string;
+    let isHistorical = false;
     if (date >= today) {
       url = `https://query1.finance.yahoo.com/v8/finance/chart/${symbol}?interval=1d&range=1d`;
     } else {
+      // 7-day window catches weekend/holiday gaps — pick the latest close <= date.
       const start = Math.floor(new Date(`${date}T00:00:00Z`).getTime() / 1000);
-      const end = start + 86400 * 2; // 2-day window catches weekend/holiday gaps
+      const end = start + 86400 * 7;
       url = `https://query1.finance.yahoo.com/v8/finance/chart/${symbol}?interval=1d&period1=${start}&period2=${end}`;
+      isHistorical = true;
     }
     const res = await fetch(url, {
       headers: { "User-Agent": "Mozilla/5.0" },
@@ -92,7 +138,29 @@ async function fetchYahooRateToUsd(currency: string, date: string): Promise<numb
     });
     if (!res.ok) return null;
     const data = await res.json();
-    const rate = data.chart?.result?.[0]?.meta?.regularMarketPrice;
+    const result = data.chart?.result?.[0];
+    if (!result) return null;
+    if (isHistorical) {
+      // Issue #206: meta.regularMarketPrice is TODAY's price even on a historical
+      // chart payload; the actual historical close lives at indicators.quote[0].close[]
+      // indexed by the timestamp[] array. Pick the latest close <= the requested date.
+      const timestamps: unknown = result.timestamp;
+      const closes: unknown = result.indicators?.quote?.[0]?.close;
+      if (!Array.isArray(timestamps) || !Array.isArray(closes)) return null;
+      const dateMs = new Date(`${date}T23:59:59Z`).getTime();
+      let best: { ts: number; close: number } | null = null;
+      for (let i = 0; i < timestamps.length; i++) {
+        const ts = timestamps[i];
+        const close = closes[i];
+        if (typeof ts !== "number" || typeof close !== "number" || close <= 0) continue;
+        const tsMs = ts * 1000;
+        if (tsMs > dateMs) continue;
+        if (!best || tsMs > best.ts) best = { ts: tsMs, close };
+      }
+      return best ? best.close : null;
+    }
+    // Latest branch — meta.regularMarketPrice is correct here.
+    const rate = result.meta?.regularMarketPrice;
     return typeof rate === "number" && rate > 0 ? rate : null;
   } catch {
     return null;
@@ -222,10 +290,18 @@ async function findCached(
 async function findNearestCached(
   currency: string
 ): Promise<{ rate: number; effectiveDate: string } | null> {
+  // Issue #206: restrict to date <= today so a poisoned future-dated row
+  // (left over before the deploy or written through a path that bypasses
+  // the gate below) can't outrank legitimate historical rows.
   const row = await db
     .select({ rateToUsd: schema.fxRates.rateToUsd, date: schema.fxRates.date })
     .from(schema.fxRates)
-    .where(eq(schema.fxRates.currency, currency))
+    .where(
+      and(
+        eq(schema.fxRates.currency, currency),
+        lte(schema.fxRates.date, todayISO())
+      )
+    )
     .orderBy(desc(schema.fxRates.date))
     .limit(1);
   if (row[0]) return { rate: row[0].rateToUsd, effectiveDate: row[0].date };
@@ -286,7 +362,15 @@ export async function getRateToUsdDetailed(
     liveSource = "yahoo";
   }
   if (fetched != null) {
-    await writeCached(code, date, fetched, liveSource);
+    // Issue #206: never persist future-dated rates. They would outrank
+    // legitimate historical rows in findNearestCached and serve as a stale
+    // fallback for every subsequent historical lookup that misses an exact
+    // match. The future-date branch above (date >= today) returns the
+    // current spot price; the cron at src/lib/cron/settle-future-fx.ts
+    // re-locks future-dated transaction rows when their date arrives.
+    if (date <= todayISO()) {
+      await writeCached(code, date, fetched, liveSource);
+    }
     return { rate: fetched, source: liveSource, effectiveDate: date };
   }
 


### PR DESCRIPTION
Closes #206

## Summary

CRITICAL fix for the auditor's #1 finding. Four compounding defects in the FX cache + lookup were silently poisoning every cross-currency cost basis, FX gain, and reporting-currency conversion.

- **Historical-rate bug** — `fetchYahooRateToUsd()` extracted `meta.regularMarketPrice` (today's price) from historical Yahoo payloads instead of `result.indicators.quote[0].close[]` indexed by `result.timestamp[]`. Fixed: historical branch walks the close array and picks latest close <= requested date over a 7-day window.
- **Future-date cache write gate** — `getRateToUsdDetailed` skips `writeCached` when `date > today`. Engine still tolerates future-date QUERIES for the `convertToAccountCurrency` / `settleFutureFxRates` cron loop. Future-date hard-reject lives at the MCP tool boundary, not in the engine.
- **`findNearestCached`** restricts to `date <= today` (defense in depth).
- **MCP boundary validation** — new `validateCurrencyCode` / `validateFxDate` helpers wrap `get_fx_rate` / `set_fx_override` / `convert_amount` on both HTTP and stdio. Rejects empty/unknown currency, pre-1970, future dates. `set_fx_override` rejects `dateTo < date`.
- **`convert_amount` precision** aligned to 8 decimals (matches `get_fx_rate`).
- **Currency-enum widened** at 6 create/update tool sites: `add_account` / `update_account` / `add_portfolio_holding` / `update_portfolio_holding` / `add_subscription` / `update_subscription`. The FX engine has supported the full `SUPPORTED_CURRENCIES` list (32 fiats + 4 cryptos + 4 metals) via USD triangulation since canonical-USD.
- **Cache-purge migration** — `DELETE FROM fx_rates WHERE date > CURRENT_DATE`. Idempotent, runs once per env via `schema_migrations`.

## Docs updated

- `pf-app/CHANGELOG.md` — entry under [Unreleased] covering all four defect classes.
- `CLAUDE.md` (root) — two new load-bearing gotchas: FX historical lookup and currency-enum policy.

## Promotion to main

- **MCP surface** — `get_fx_rate` / `set_fx_override` / `convert_amount` now reject empty / unknown / future-date inputs. Existing valid calls unchanged. `convert_amount`'s `rate` field now has 8-decimal precision (was 16+ before).
- **MCP surface** — `add_account` / `update_account` / `add_portfolio_holding` / `update_portfolio_holding` / `add_subscription` / `update_subscription` now accept the full `SUPPORTED_CURRENCIES` list. Previously `["CAD", "USD"]` only. No client should be passing an invalid code today.
- **Backfill / migration** — `pf-app/scripts/migrations/20260509_fx-cache-purge-future-dates.sql` runs on first deploy of this PR via `deploy.sh` (one-shot per env). Drops poisoned future-dated `fx_rates` rows. `fx_overrides` untouched.
- **Cron** — none changed. `settleFutureFxRates` continues to operate on `date <= today` as before.
- **Env vars** — none added.
- **Deps** — none added.
- **CSP / UI** — none touched.

## How I tested

- `npx tsc --noEmit` clean.
- `npm run build` passes.

Out of scope: recomputing biased aggregates on existing transactions (historical buys carry slightly biased cost basis — fix forward only).