### PR TITLE
MCP schema: reject negative monetary inputs; strip *_ct from list_subscriptions (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+### MCP schema: reject negative monetary inputs; strip *_ct from list_subscriptions / get_subscription_summary (#207, 2026-05-09)
+
+Closes the auditor's `reviews/2026-05-09/11-schema-numeric-and-currency-constraints.md`. Two coupled MCP HTTP gaps:
+
+- **Negative-monetary inputs** — `set_budget`, `add_goal` / `update_goal`, `add_loan` / `update_loan`, `add_subscription` / `update_subscription` accepted negative amounts despite docstrings claiming positive. The Zod schemas used a bare `z.number()`. Each callsite now uses `.positive()` (= `> 0`) for principal / target / amount / payment / budget, and `.nonnegative()` (= `>= 0`) for `annual_rate` and `extra_payment` (zero is a valid 0%-promo / no-extra case). `term_months` was already correct. Pattern mirrors `set_fx_override.rate`. ([mcp-server/register-tools-pg.ts](mcp-server/register-tools-pg.ts))
+- **Ciphertext leak in `list_subscriptions` and `get_subscription_summary`** — the response shapers spread `...r` (the raw DB row), carrying `name_ct`, `category_name_ct`, and `account_name_ct` through to the client alongside the decrypted plaintext. Stream D Phase 4 (CLAUDE.md: "writes use `name_ct` + `name_lookup` ONLY") expects ciphertext to stay server-side except via the user's DEK-unwrap path; the API surface had been silently emitting it for every authenticated read. Both shapers now use an explicit field whitelist. The `taggedSubs` shaper in `get_subscription_summary` re-spreads `s` — fixed at the construction site so the downstream spread inherits clean rows.
+- **Section C (currency-enum widening) — already shipped under #206**: the six `z.enum(["CAD", "USD"])` callsites mentioned in the issue (`add_account` / `update_account` / `add_portfolio_holding` / `update_portfolio_holding` / `add_subscription` / `update_subscription`) already use `supportedCurrencyEnum` (the full SUPPORTED_CURRENCIES list). No additional work needed.
+
+**Audit follow-up:** `list_loans` (`mcp-server/register-tools-pg.ts:5582`) has the same `...r` + `name_ct` SELECT shape and is leaking `name_ct` and `account_name_ct`. Filed as a separate issue per the original audit's "out of scope for THIS PR" guidance — a single shaper-audit issue covers any other shapers that surface.
+
+**Out of scope:** date-shape validation (covered by `05-date-validation-across-mcp.md`), empty-string `group` normalization (separate `get_account_balances` shaper fix), removal of `*_ct` columns from the DB (load-bearing per Stream D Phase 4 — do NOT touch).
+
+**Build-only verification.** Stdio MCP `list_subscriptions` already refuses via `streamDRefuseRead` (`register-core-tools.ts:1949`); stdio create/update tools for the affected tables already refuse per Stream D Phase 4. No DB migration. No `name_ct` / `name_lookup` / `decryptName()` path changes. No `invalidateUser(userId)` needed (no tx mutations). No CSP / cron / env-var / MCP tool count changes — the surface stays at **90 HTTP / 86 stdio** tools.
+
 ### CRITICAL: FX historical-rate bug + cache poisoning + currency validation (#206, 2026-05-09)
 
 Fixes the auditor's #1 finding from `reviews/2026-05-09/04-fx-rate-historical-and-cache-poisoning.md`. Four compounding defects in the FX cache + lookup were silently poisoning every cross-currency cost basis, FX gain, and reporting-currency conversion in the system.

--- a/mcp-server/register-tools-pg.ts
+++ b/mcp-server/register-tools-pg.ts
@@ -1532,8 +1532,17 @@ export function registerPgTools(
         WHERE s.user_id = ${userId}
         ORDER BY s.status
       `);
+      // Issue #207 — explicit whitelist so *_ct ciphertexts never escape via
+      // the downstream `taggedSubs` spread. Building a clean shape here means
+      // `taggedSubs.map(s => ({ ...s, ... }))` below carries no ciphertext.
       const subs: Row[] = rawSubs.map((r) => ({
-        ...r,
+        id: r.id,
+        amount: r.amount,
+        currency: r.currency,
+        frequency: r.frequency,
+        next_date: r.next_date,
+        status: r.status,
+        category_id: r.category_id,
         name: r.name_ct && dek ? decryptField(dek, r.name_ct) : null,
         category_name: r.category_name_ct && dek ? decryptField(dek, r.category_name_ct) : null,
       }));
@@ -2200,7 +2209,7 @@ export function registerPgTools(
     {
       category: z.string().describe("Category name"),
       month: z.string().describe("Month (YYYY-MM)"),
-      amount: z.number().describe("Budget amount (positive number)"),
+      amount: z.number().positive().describe("Budget amount (must be > 0)"),
     },
     async ({ category, month, amount }) => {
       // Stream D Phase 4 — match by name_lookup HMAC.
@@ -2227,7 +2236,7 @@ export function registerPgTools(
     {
       name: z.string().describe("Goal name"),
       type: z.enum(["savings", "debt_payoff", "investment", "emergency_fund"]).describe("Goal type"),
-      target_amount: z.number().describe("Target amount"),
+      target_amount: z.number().positive().describe("Target amount (must be > 0)"),
       deadline: z.string().optional().describe("Deadline (YYYY-MM-DD)"),
       account: z.string().optional().describe("Legacy single-account linker — name or alias (fuzzy matched). Prefer `account_ids` for multi-account goals."),
       account_ids: z.array(z.number().int()).optional().describe("Multi-account linker (issue #130). Goal progress sums transactions across every account id supplied. Each id must belong to the user. Empty array = unlinked (manual tracking)."),
@@ -3794,7 +3803,7 @@ export function registerPgTools(
     "Update a financial goal's target, deadline, status, or linked accounts. `account_ids` (issue #130) replaces the existing account-link set atomically — pass `[]` to unlink all, or omit to leave links unchanged.",
     {
       goal: z.string().describe("Goal name (fuzzy matched)"),
-      target_amount: z.number().optional(),
+      target_amount: z.number().positive().optional().describe("Target amount (must be > 0)"),
       deadline: z.string().optional().describe("YYYY-MM-DD"),
       status: z.enum(["active", "completed", "paused"]).optional(),
       name: z.string().optional().describe("Rename the goal"),
@@ -5610,15 +5619,15 @@ export function registerPgTools(
     {
       name: z.string().describe("Loan name"),
       type: z.string().describe("Loan type (e.g. 'mortgage', 'auto', 'student', 'personal')"),
-      principal: z.number().describe("Original loan principal"),
-      annual_rate: z.number().describe("Annual interest rate (e.g. 5.5 for 5.5%)"),
+      principal: z.number().positive().describe("Original loan principal (must be > 0)"),
+      annual_rate: z.number().nonnegative().describe("Annual interest rate, e.g. 5.5 for 5.5% (must be >= 0; zero allowed for 0% promo)"),
       term_months: z.number().int().positive().describe("Loan term in months"),
       start_date: z.string().describe("Loan start date (YYYY-MM-DD)"),
       account: z.string().optional().describe("Linked account — name or alias (fuzzy matched against name; exact match on alias)"),
-      payment_amount: z.number().optional().describe("Override computed monthly payment"),
+      payment_amount: z.number().positive().optional().describe("Override computed monthly payment (must be > 0)"),
       payment_frequency: z.enum(["monthly", "biweekly"]).optional().describe("Default monthly"),
-      extra_payment: z.number().optional().describe("Extra principal per payment (default 0)"),
-      min_payment: z.number().optional().describe("Alias for payment_amount — minimum required payment"),
+      extra_payment: z.number().nonnegative().optional().describe("Extra principal per payment (must be >= 0; default 0)"),
+      min_payment: z.number().positive().optional().describe("Alias for payment_amount — minimum required payment (must be > 0)"),
       note: z.string().optional(),
     },
     async ({ name, type, principal, annual_rate, term_months, start_date, account, payment_amount, payment_frequency, extra_payment, min_payment, note }) => {
@@ -5652,13 +5661,13 @@ export function registerPgTools(
       id: z.number().describe("Loan id"),
       name: z.string().optional(),
       type: z.string().optional(),
-      principal: z.number().optional(),
-      annual_rate: z.number().optional(),
+      principal: z.number().positive().optional().describe("Original loan principal (must be > 0)"),
+      annual_rate: z.number().nonnegative().optional().describe("Annual interest rate, e.g. 5.5 for 5.5% (must be >= 0)"),
       term_months: z.number().int().positive().optional(),
       start_date: z.string().optional(),
-      payment_amount: z.number().optional(),
+      payment_amount: z.number().positive().optional().describe("Monthly payment override (must be > 0)"),
       payment_frequency: z.enum(["monthly", "biweekly"]).optional(),
-      extra_payment: z.number().optional(),
+      extra_payment: z.number().nonnegative().optional().describe("Extra principal per payment (must be >= 0)"),
       account: z.string().optional().describe("Linked account — name or alias (fuzzy matched against name; exact match on alias). Pass empty string to clear."),
       note: z.string().optional(),
     },
@@ -6006,8 +6015,20 @@ export function registerPgTools(
           ${status && status !== "all" ? sql`AND s.status = ${status}` : sql``}
         ORDER BY s.status
       `);
+      // Issue #207 — explicit field whitelist so *_ct ciphertexts never escape
+      // the encryption boundary. Spreading `r` (`...r`) would carry name_ct,
+      // category_name_ct, and account_name_ct through to the client.
       const rows = raw.map((r) => ({
-        ...r,
+        id: r.id,
+        amount: r.amount,
+        currency: r.currency,
+        frequency: r.frequency,
+        next_date: r.next_date,
+        status: r.status,
+        cancel_reminder_date: r.cancel_reminder_date,
+        notes: r.notes,
+        category_id: r.category_id,
+        account_id: r.account_id,
         name: r.name_ct && dek ? decryptField(dek, r.name_ct) : null,
         category_name: r.category_name_ct && dek ? decryptField(dek, r.category_name_ct) : null,
         account_name: r.account_name_ct && dek ? decryptField(dek, r.account_name_ct) : null,
@@ -6022,7 +6043,7 @@ export function registerPgTools(
     "Create a new subscription",
     {
       name: z.string().describe("Subscription name (unique per user)"),
-      amount: z.number().describe("Amount per billing cycle (positive number)"),
+      amount: z.number().positive().describe("Amount per billing cycle (must be > 0)"),
       cadence: z.enum(["weekly", "monthly", "quarterly", "annual", "yearly"]).describe("Billing frequency"),
       next_billing_date: z.string().describe("Next billing date (YYYY-MM-DD)"),
       currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code (default CAD). Issue #206: full SUPPORTED_CURRENCIES list."),
@@ -6077,7 +6098,7 @@ export function registerPgTools(
     {
       id: z.number().describe("Subscription id"),
       name: z.string().optional(),
-      amount: z.number().optional(),
+      amount: z.number().positive().optional().describe("Amount per billing cycle (must be > 0)"),
       cadence: z.enum(["weekly", "monthly", "quarterly", "annual", "yearly"]).optional(),
       next_billing_date: z.string().optional().describe("YYYY-MM-DD"),
       currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code (issue #206: full SUPPORTED_CURRENCIES list)."),


### PR DESCRIPTION
Closes #207

## Summary

- **Section A (negatives):** `set_budget`, `add_goal` / `update_goal`, `add_loan` / `update_loan`, `add_subscription` / `update_subscription` Zod schemas tightened — `.positive()` for principal/target/amount/payment/budget, `.nonnegative()` for `annual_rate` and `extra_payment` (zero allowed for 0% promo / no-extra). `term_months` already correct.
- **Section B (ciphertext leak):** `list_subscriptions` and `get_subscription_summary` previously spread `...r` from the DB row, leaking `name_ct` / `category_name_ct` / `account_name_ct` to clients alongside the decrypted plaintext. Both shapers now use an explicit field whitelist. The `taggedSubs` double-spread in `get_subscription_summary` is fixed at the construction site so the downstream spread inherits clean rows.
- **Section C (currency enum):** Already shipped under #206 — the six callsites in the issue already use `supportedCurrencyEnum` (full SUPPORTED_CURRENCIES list, includes EUR/GBP/JPY/etc + crypto + metals). Documented in CHANGELOG as no-op.

## Docs updated

- `pf-app/CHANGELOG.md` — `[Unreleased]` entry above the #206 section.
- No CLAUDE.md changes — this fix doesn't introduce a new gotcha (Stream D Phase 4 invariants already documented).
- No topic doc changes — existing encryption.md guidance ("ciphertext stays server-side") covers the principle.

## Promotion to main

- **Build-only.** No DB migration. No new env vars. No CSP changes. No cron changes. No deps. No UI changes. No backfill needed. **MCP tool surface count unchanged: 90 HTTP / 86 stdio.**
- Stdio MCP `list_subscriptions` already refuses via `streamDRefuseRead` (`register-core-tools.ts:1949`) — no parallel fix required. Stdio create/update tools for the affected tables already refuse per Stream D Phase 4.
- No `invalidateUser(userId)` needed (no tx mutations).

## Audit follow-up

`list_loans` (mcp-server/register-tools-pg.ts:5582) has the same `...r` + `name_ct` anti-pattern (leaks `name_ct` + `account_name_ct`). Per the audit's "out of scope for THIS PR if the audit surfaces new ones — file follow-ups" guidance, a separate issue will cover any further shaper leaks.

## How I tested

- `npx tsc --noEmit` — clean.
- `npm run build` — clean.
- Verified `supportedCurrencyEnum` already wraps the six currency callsites mentioned in the issue (post #206).
- Confirmed the Zod constraint pattern matches `set_fx_override.rate` (the existing reference at L5830).
- Greppped the file for `\.\.\.r,` near `name_ct` — confirmed only `list_subscriptions` and `get_subscription_summary` shapers (now fixed) plus `list_loans` (filed as follow-up) match the leak shape.