### PR TITLE
fix(tx): enforce sign-vs-category invariant at every tx-write callsite (#212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## 2026-05-09 — Sign-vs-category invariant: hard-reject E-positive / I-negative writes at every tx-write callsite (#212)
+
+Closes the bug class behind a batch of receipt-OCR rows that landed on `Cash CAD` with **positive** `amount` on a `Groceries` (`E`-type) category — the seven historical rows understated expenses by ~$2,300 in the audit window. Every downstream aggregator (`get_income_statement`, `get_spending_trends`, `get_budget_summary`, `get_financial_health_score`, `get_spending_anomalies`, `get_weekly_recap`, account balance) inherited the wrong sign because no callsite enforced the documented sign-vs-category invariant. Coordinates with #203 (silent unknown-category drop) on the per-row failure envelope shape; #203 landed first, this PR reuses the same envelope.
+
+- **New helper** [`src/lib/transactions/sign-category-invariant.ts`](src/lib/transactions/sign-category-invariant.ts) — pure synchronous `validateSignVsCategory({ amount, categoryType, categoryName })` returns a `SignCategoryMismatchError` (`code: "sign_category_mismatch"`) when an asset/liability row violates the rule:
+  - `'E'` (expense) requires `amount ≤ 0`.
+  - `'I'` (income) requires `amount ≥ 0`.
+  - `'R'` (transfer) and the legacy `'T'` alias are exempt — sign convention varies per leg.
+  - `categoryType == null` (uncategorized) is exempt — receipt-OCR previews stay insertable.
+  - `amount === 0` is exempt (RSU vests, in-kind moves).
+  - Companion `validateSignVsCategoryById(userId, dek, categoryId, amount)` for the REST single-row path; bulk `getCategoryTypeMap(userId, dek, ids)` for batch use. `categories.type` is plaintext so DEK-less transports (stdio MCP) can still enforce the rule; only the error message degrades to `category #<id>` without a DEK.
+- **REST routes** ([src/app/api/transactions/route.ts](src/app/api/transactions/route.ts)) — `createTransaction` / `updateTransaction` ([src/lib/queries.ts](src/lib/queries.ts)) accept an optional `dek` and call `validateSignVsCategoryById` before INSERT/UPDATE; `updateTransaction` validates against the post-merge `(amount, categoryId)` pair when either is in the patch (mirrors the existing post-merge `requireHoldingForInvestmentAccount` pattern). Throws map to **400** with `code: sign_category_mismatch` and the offending `amount` / `categoryName` / `categoryType` in the body (mirrors the existing `InvestmentHoldingRequiredError` handler shape).
+- **MCP HTTP** ([mcp-server/register-tools-pg.ts](mcp-server/register-tools-pg.ts)) — `record_transaction` returns a hard error before INSERT; `bulk_record_transactions` per-row failures land in `results[i] = { success: false, code: "sign_category_mismatch", message, resolvedAccount, resolvedCategory }` and the batch keeps going (envelope shape coordinated with #203's silent-category-drop fix); `update_transaction` runs the validator on the post-merge state BEFORE any UPDATE so a violation aborts the patch atomically (the `enteredAmount` FX resolution was hoisted into a pre-flight pass to support this — same FX values land in the DB, no semantic change).
+- **MCP stdio** ([mcp-server/register-core-tools.ts](mcp-server/register-core-tools.ts)) — `record_transaction` + `update_transaction` (cash-account branch) both run the validator. Stdio cannot create or update names but CAN write transactions on cash accounts, so this closes the same hole on the stdio transport. Investment-account writes were already refused before this PR.
+- **Import pipeline** ([src/lib/import-pipeline.ts](src/lib/import-pipeline.ts)) — pre-fetches `getCategoryTypeMap` once per batch, per-row rejects violations into `importErrors[]` (mirrors the existing investment-account-rejection block), splices offending rows out without poisoning the batch. Staged-approve cash-bucket rows route through `executeImport` so they inherit the protection automatically; transfer-pair (`tx_type='R'`) and target-bound transfer (`createTransferPair`) rows are exempt by construction (categoryId always resolves to type='R').
+- **Transfers (`createTransferPair` / `createTransferPairViaSql`)** — type-`R` legs are exempt by construction; not wired (per the issue's "no-op for type-R" note) to keep the diff focused on the violating writers.
+- **Data migration** [`scripts/migrate-fix-receipt-sign-2026-05-09.sql`](scripts/migrate-fix-receipt-sign-2026-05-09.sql) — manual playbook (NOT in `scripts/migrations/`, per the code-FIRST-then-SQL convention for destructive UPDATEs). Audit SELECT + idempotent UPDATE for the seven flagged ids: flips `amount` and `entered_amount` sign, bumps `updated_at`, preserves `source`. Optional follow-up SELECT discovers any other historical wrong-sign rows for operator review (`c.type='E' AND a.type='A' AND t.amount > 0`).
+- **Tool count unchanged** — 90 HTTP / 86 stdio. Validator is a guard inside existing tools, not a new tool.
+
+**Verification.** `npx tsc --noEmit` clean; `npm run build` passes. Manual MCP smoke deferred to validator agent post-merge.
+
 ## 2026-05-09 — MCP API hygiene Phase 1: delete_budget / delete_loan / create_category / Available-PII / amount-override warning (#211)
 
 Phase 1 of the MCP API-hygiene cluster from `reviews/2026-05-09/12-mcp-api-hygiene-envelopes-and-pii.md`. Non-breaking — no envelope unification, no MCP version bump, no new `delete_category` tool. Phase 2 (fail-loud fuzzy match) and Phase 3 (envelope unification + version bump + new `delete_category` + Anthropic Directory re-coordination) remain to ship.

--- a/mcp-server/register-core-tools.ts
+++ b/mcp-server/register-core-tools.ts
@@ -35,6 +35,7 @@ import {
   verifyConfirmationToken,
 } from "../src/lib/mcp/confirmation-token.js";
 import { InvestmentHoldingRequiredError } from "../src/lib/investment-account.js";
+import { validateSignVsCategory } from "../src/lib/transactions/sign-category-invariant.js";
 import fs from "fs/promises";
 import {
   csvToRawTransactions,
@@ -752,15 +753,28 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
       }
 
       let catId: number | null = null;
+      let catType: string | null = null;
       if (category_id != null) {
-        // Validate ownership cheaply via id-only lookup; no plaintext name needed.
+        // Validate ownership + grab `type` for the issue #212 sign-vs-category
+        // invariant. `type` is plaintext on `categories` so stdio (no DEK) can
+        // still enforce the rule — only the error message degrades to
+        // `category #<id>`.
         const cat = await sqlite.prepare(
-          `SELECT id FROM categories WHERE user_id = ? AND id = ?`
-        ).get(userId, category_id) as { id: number } | undefined;
+          `SELECT id, type FROM categories WHERE user_id = ? AND id = ?`
+        ).get(userId, category_id) as { id: number; type?: string } | undefined;
         if (!cat) return sqliteErr(`Category #${category_id} not found or not owned by you.`);
         catId = Number(cat.id);
+        catType = cat.type != null ? String(cat.type) : null;
       } else {
         catId = await autoCategory(sqlite, userId, payee);
+        // Re-fetch type when autoCategory picked one — keeps the validator
+        // path symmetric with the explicit `category_id` branch above.
+        if (catId != null) {
+          const c = await sqlite.prepare(
+            `SELECT type FROM categories WHERE user_id = ? AND id = ?`,
+          ).get(userId, catId) as { type?: string } | undefined;
+          catType = c?.type != null ? String(c.type) : null;
+        }
       }
 
       const resolved = await resolveTxAmountsCore({
@@ -772,6 +786,18 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
         enteredCurrency,
       });
       if (!resolved.ok) return sqliteErr(resolved.message);
+
+      // Issue #212 — sign-vs-category invariant. Hard reject before any INSERT.
+      // Stdio has no DEK so the error message uses `category #<id>` as the
+      // category name; the rule itself fires identically across transports.
+      if (catId != null) {
+        const sErr = validateSignVsCategory({
+          amount: resolved.amount,
+          categoryType: catType,
+          categoryName: `category #${catId}`,
+        });
+        if (sErr) return sqliteErr(sErr.message);
+      }
 
       const resolvedAccountInfo = { id: Number(acct.id) };
       const resolvedCategory = catId != null ? { id: Number(catId) } : null;
@@ -860,20 +886,25 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
         return sqliteErr("`category` (name) is refused on stdio after Stream D Phase 4. Pass `category_id` instead.");
       }
       const existing = await sqlite.prepare(`
-        SELECT t.id, t.account_id, t.date, a.currency AS account_currency
+        SELECT t.id, t.account_id, t.category_id, t.amount, t.date, a.currency AS account_currency
           FROM transactions t LEFT JOIN accounts a ON a.id = t.account_id
          WHERE t.id = ? AND t.user_id = ?
-      `).get(id, userId) as { id: number; date: string; account_currency?: string } | undefined;
+      `).get(id, userId) as { id: number; date: string; account_currency?: string; category_id?: number | null; amount?: number | null } | undefined;
       if (!existing) return sqliteErr(`Transaction #${id} not found or not owned by user`);
+      const existingAmountStdio = existing.amount != null ? Number(existing.amount) : null;
+      const existingCategoryIdStdio = existing.category_id != null ? Number(existing.category_id) : null;
 
       let catId: number | undefined;
+      let catTypeStdio: string | null = null;
       let resolvedCategory: { id: number } | null = null;
       if (category_id !== undefined) {
+        // Fetch `type` alongside ownership for issue #212.
         const cat = await sqlite.prepare(
-          `SELECT id FROM categories WHERE user_id = ? AND id = ?`
-        ).get(userId, category_id) as { id: number } | undefined;
+          `SELECT id, type FROM categories WHERE user_id = ? AND id = ?`
+        ).get(userId, category_id) as { id: number; type?: string } | undefined;
         if (!cat) return sqliteErr(`Category #${category_id} not found or not owned by you.`);
         catId = Number(cat.id);
+        catTypeStdio = cat.type != null ? String(cat.type) : null;
         resolvedCategory = { id: catId };
       }
 
@@ -887,6 +918,9 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
         params.push(date);
         fieldsUpdated.push("date");
       }
+      // Track post-merge amount for the issue #212 sign-vs-category check
+      // below. Set in the entered/account-side branches.
+      let postMergeAmountStdio: number | null = existingAmountStdio;
       if (enteredAmount !== undefined) {
         const txDate = date ?? existing.date;
         const resolved = await resolveTxAmountsCore({
@@ -900,10 +934,12 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
         updates.push("amount = ?", "currency = ?", "entered_amount = ?", "entered_currency = ?", "entered_fx_rate = ?");
         params.push(resolved.amount, resolved.currency, resolved.enteredAmount, resolved.enteredCurrency, resolved.enteredFxRate);
         fieldsUpdated.push("amount", "currency", "entered_amount", "entered_currency", "entered_fx_rate");
+        postMergeAmountStdio = resolved.amount;
       } else if (amount !== undefined) {
         updates.push("amount = ?");
         params.push(amount);
         fieldsUpdated.push("amount");
+        postMergeAmountStdio = amount;
       }
       if (payee !== undefined) {
         updates.push("payee = ?");
@@ -926,6 +962,30 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
         fieldsUpdated.push("tags");
       }
       if (!updates.length) return sqliteErr("No fields to update");
+
+      // Issue #212 — sign-vs-category invariant on the post-merge state.
+      // Reuses the existing row's category_id when the patch doesn't touch
+      // it, and the existing amount when the patch doesn't touch amount.
+      // Stdio path: error message degrades to `category #<id>` (no DEK).
+      if (postMergeAmountStdio != null) {
+        const postMergeCatId = catId !== undefined ? catId : existingCategoryIdStdio;
+        let postMergeCatType = catTypeStdio;
+        if (postMergeCatId != null && catId === undefined) {
+          // Patch is not touching category — fetch the existing row's type.
+          const c = await sqlite.prepare(
+            `SELECT type FROM categories WHERE user_id = ? AND id = ?`,
+          ).get(userId, postMergeCatId) as { type?: string } | undefined;
+          postMergeCatType = c?.type != null ? String(c.type) : null;
+        }
+        if (postMergeCatId != null) {
+          const sErr = validateSignVsCategory({
+            amount: postMergeAmountStdio,
+            categoryType: postMergeCatType,
+            categoryName: `category #${postMergeCatId}`,
+          });
+          if (sErr) return sqliteErr(sErr.message);
+        }
+      }
 
       // Issue #28: every UPDATE bumps updated_at. Always appended — `source`
       // stays untouched (INSERT-only).

--- a/mcp-server/register-tools-pg.ts
+++ b/mcp-server/register-tools-pg.ts
@@ -91,6 +91,11 @@ import {
 import { decryptStaged, encryptStaged } from "../src/lib/crypto/staging-envelope";
 import { getHoldingsValueByAccount } from "../src/lib/holdings-value";
 import { sourceTagFor, isFormatTag, type FormatTag } from "../src/lib/tx-source";
+import {
+  validateSignVsCategory,
+  getCategoryTypeMap,
+  SignCategoryMismatchError,
+} from "../src/lib/transactions/sign-category-invariant";
 
 // ─── types ────────────────────────────────────────────────────────────────────
 
@@ -2671,13 +2676,29 @@ export function registerPgTools(
         }
       }
 
-      // Look up the resolved category name once — used by both the dry-run
-      // preview and the success message. Stream D Phase 4: decrypt name_ct.
+      // Look up the resolved category name + type once — used by both the
+      // dry-run preview, the success message, and the issue #212 sign-vs-
+      // category validator. Stream D Phase 4: decrypt name_ct. `type` is
+      // plaintext and DEK-free.
       let catName: string = "uncategorized";
+      let catType: string | null = null;
       if (catId) {
-        const row = (await q(db, sql`SELECT name_ct FROM categories WHERE id = ${catId}`))[0];
+        const row = (await q(db, sql`SELECT name_ct, type FROM categories WHERE id = ${catId}`))[0];
         const ct = row?.name_ct as string | null | undefined;
         catName = (ct && dek ? decryptField(dek, String(ct)) : ct ?? "") || "uncategorized";
+        catType = row?.type != null ? String(row.type) : null;
+      }
+      // Issue #212 — sign-vs-category invariant (HARD REJECT). 'E' must be
+      // ≤ 0; 'I' must be ≥ 0; 'R'/'T' exempt. Runs on resolved.amount AFTER
+      // FX so the rule is evaluated on the value that lands in the DB. dryRun
+      // returns a structured 400-equivalent envelope; non-dryRun never inserts.
+      const sErr = validateSignVsCategory({
+        amount: resolved.amount,
+        categoryType: catType,
+        categoryName: catName,
+      });
+      if (sErr) {
+        return err(sErr.message);
       }
       // Issue #211 Bug h: when both `amount` and `enteredAmount` are
       // passed, surface a structured warning so the caller knows the
@@ -2854,9 +2875,13 @@ export function registerPgTools(
       // accidentally worked because Postgres still had the column; now `c.name` is
       // undefined and the map produced empty strings (resolvedCategory.name was ""
       // in every per-row response — issue #93 follow-up).
-      const rawCats = await q(db, sql`SELECT id, name_ct FROM categories WHERE user_id = ${userId}`);
+      const rawCats = await q(db, sql`SELECT id, name_ct, type FROM categories WHERE user_id = ${userId}`);
       const allCats = decryptNameish(rawCats, dek);
       const catNameById = new Map<number, string>(allCats.map(c => [Number(c.id), String(c.name ?? "")]));
+      // Issue #212 — sign-vs-category invariant. Build (id → type) once for
+      // the per-row validator. `type` is plaintext on `categories` so it
+      // round-trips through `decryptNameish` unchanged.
+      const catTypeById = new Map<number, string>(rawCats.map((c: Row) => [Number(c.id), String(c.type ?? "")]));
       // Cache user-owned holding ids in one SELECT instead of one ownership
       // check per row.
       const ownedHoldings = await q(db, sql`SELECT id FROM portfolio_holdings WHERE user_id = ${userId}`);
@@ -2917,6 +2942,11 @@ export function registerPgTools(
         index: number;
         success: boolean;
         message: string;
+        // Issue #212: per-row failure code so callers can distinguish
+        // sign-vs-category violations from generic resolution errors.
+        // Aligns with the #203 envelope shape (code is set only on
+        // success: false rows; success rows omit it).
+        code?: string;
         resolvedAccount?: { id: number; name: string };
         resolvedCategory?: { id: number; name: string } | null;
         resolvedHolding?: { id: number } | null;
@@ -3054,6 +3084,30 @@ export function registerPgTools(
           if (!resolved.ok) {
             results.push({ index: i, success: false, message: resolved.message, resolvedAccount: resolvedAccountInfo });
             continue;
+          }
+
+          // Issue #212 — sign-vs-category invariant per row. Fail this row
+          // only (matches the #203 unknown-category envelope: results[i]
+          // gets `success: false` + `code: 'sign_category_mismatch'`); the
+          // batch keeps going. The check runs on `resolved.amount` (after
+          // FX) so the rule is evaluated against the value the DB will see.
+          if (catId != null) {
+            const sErr = validateSignVsCategory({
+              amount: resolved.amount,
+              categoryType: catTypeById.get(catId) ?? null,
+              categoryName: catNameById.get(catId) ?? `category #${catId}`,
+            });
+            if (sErr) {
+              results.push({
+                index: i,
+                success: false,
+                message: sErr.message,
+                code: sErr.code,
+                resolvedAccount: resolvedAccountInfo,
+                resolvedCategory: { id: catId, name: catNameById.get(catId) ?? "" },
+              });
+              continue;
+            }
           }
 
           // Issue #211 Bug h: amount-vs-enteredAmount override warning.
@@ -3276,7 +3330,7 @@ export function registerPgTools(
     },
     async ({ id, date, amount, payee, category, note, tags, portfolioHoldingId, portfolioHolding, quantity, enteredAmount, enteredCurrency }) => {
       const existing = await q(db, sql`
-        SELECT t.id, t.account_id, t.date, t.amount, a.currency AS account_currency
+        SELECT t.id, t.account_id, t.category_id, t.date, t.amount, a.currency AS account_currency
           FROM transactions t
           LEFT JOIN accounts a ON a.id = t.account_id
          WHERE t.user_id = ${userId} AND t.id = ${id}
@@ -3285,6 +3339,10 @@ export function registerPgTools(
       const accountCurrency = String(existing[0].account_currency ?? "CAD");
       const txAccountId = existing[0].account_id != null ? Number(existing[0].account_id) : undefined;
       const existingAmount = existing[0].amount != null ? Number(existing[0].amount) : null;
+      // Issue #212 — capture existing category_id for the post-merge
+      // sign-vs-category check below (when the patch only touches amount,
+      // we still need the existing category to evaluate the invariant).
+      const existingCategoryId = existing[0].category_id != null ? Number(existing[0].category_id) : null;
 
       // Stream D: pull `name_ct` and decrypt before resolving. Without this,
       // Phase-3 NULL-plaintext rows end up with `name === null` and
@@ -3354,12 +3412,19 @@ export function registerPgTools(
       // success-message ambiguity that masked silent category drops.
       const fieldsUpdated: string[] = [];
       let postMergeAmount: number | null = existingAmount;
-      if (date !== undefined) {
-        await db.execute(sql`UPDATE transactions SET date = ${date}, updated_at = NOW() WHERE id = ${id} AND user_id = ${userId}`);
-        fieldsUpdated.push("date");
-      }
-      // Entered-side update — re-locks the FX rate at the row's (possibly
-      // updated) date. Triangulates and refuses on fallback.
+      // Pre-compute the post-merge amount when an FX-aware enteredAmount
+      // patch is in flight. This lets us validate the invariant BEFORE any
+      // UPDATE runs (issue #212) — otherwise a sign-vs-category violation
+      // would land on the row partially before being caught.
+      let preResolvedEntered:
+        | {
+            amount: number;
+            currency: string;
+            enteredAmount: number;
+            enteredCurrency: string;
+            enteredFxRate: number;
+          }
+        | null = null;
       if (enteredAmount !== undefined) {
         const txDate = date ?? String(existing[0].date);
         const resolved = await resolveTxAmountsCore({
@@ -3370,23 +3435,63 @@ export function registerPgTools(
           enteredCurrency,
         });
         if (!resolved.ok) return err(resolved.message);
+        preResolvedEntered = {
+          amount: resolved.amount,
+          currency: resolved.currency,
+          enteredAmount: resolved.enteredAmount,
+          enteredCurrency: resolved.enteredCurrency,
+          enteredFxRate: resolved.enteredFxRate,
+        };
+        postMergeAmount = resolved.amount;
+      } else if (amount !== undefined) {
+        postMergeAmount = amount;
+      }
+      // Issue #212 — sign-vs-category invariant on the post-merge state.
+      // Resolve type + name from the post-merge category. When the patch
+      // doesn't touch category, fall back to the existing row's category.
+      // Runs BEFORE every UPDATE so a violation aborts the whole patch
+      // cleanly — no partial application.
+      if (postMergeAmount != null) {
+        const postMergeCategoryId = catId !== undefined ? catId : existingCategoryId;
+        if (postMergeCategoryId != null) {
+          const cat = (await q(db, sql`SELECT id, type, name_ct FROM categories WHERE id = ${postMergeCategoryId} AND user_id = ${userId}`))[0] as Row | undefined;
+          if (cat) {
+            const ct = cat.name_ct as string | null | undefined;
+            const catName =
+              (ct && dek ? decryptField(dek, String(ct)) : ct ?? "") ||
+              `category #${postMergeCategoryId}`;
+            const sErr = validateSignVsCategory({
+              amount: postMergeAmount,
+              categoryType: cat.type as string | null | undefined,
+              categoryName: catName,
+            });
+            if (sErr) return err(sErr.message);
+          }
+        }
+      }
+      if (date !== undefined) {
+        await db.execute(sql`UPDATE transactions SET date = ${date}, updated_at = NOW() WHERE id = ${id} AND user_id = ${userId}`);
+        fieldsUpdated.push("date");
+      }
+      // Entered-side update — uses the pre-resolved values from the
+      // pre-flight pass above. No second resolveTxAmountsCore call.
+      if (preResolvedEntered) {
+        const r = preResolvedEntered;
         await db.execute(sql`
           UPDATE transactions
-             SET amount = ${resolved.amount},
-                 currency = ${resolved.currency},
-                 entered_amount = ${resolved.enteredAmount},
-                 entered_currency = ${resolved.enteredCurrency},
-                 entered_fx_rate = ${resolved.enteredFxRate},
+             SET amount = ${r.amount},
+                 currency = ${r.currency},
+                 entered_amount = ${r.enteredAmount},
+                 entered_currency = ${r.enteredCurrency},
+                 entered_fx_rate = ${r.enteredFxRate},
                  updated_at = NOW()
            WHERE id = ${id} AND user_id = ${userId}
         `);
         fieldsUpdated.push("amount", "currency", "entered_amount", "entered_currency", "entered_fx_rate");
-        postMergeAmount = resolved.amount;
       } else if (amount !== undefined) {
         // Account-side-only update: leave entered_* alone.
         await db.execute(sql`UPDATE transactions SET amount = ${amount}, updated_at = NOW() WHERE id = ${id} AND user_id = ${userId}`);
         fieldsUpdated.push("amount");
-        postMergeAmount = amount;
       }
       if (catId !== undefined) {
         await db.execute(sql`UPDATE transactions SET category_id = ${catId}, updated_at = NOW() WHERE id = ${id} AND user_id = ${userId}`);

--- a/scripts/migrate-fix-receipt-sign-2026-05-09.sql
+++ b/scripts/migrate-fix-receipt-sign-2026-05-09.sql
@@ -1,0 +1,63 @@
+-- Issue #212 — receipt-OCR rows landed positive on E-type categories.
+--
+-- Seven rows on Cash CAD (type='A' asset account) carry a positive `amount`
+-- with a 'Groceries' (type='E') category, which violates the sign-vs-category
+-- invariant the new validator now enforces at every tx-write callsite. This
+-- script flips the sign on those seven historical rows so every downstream
+-- aggregator (income statement, spending trends, account balance, financial
+-- health score, weekly recap, anomalies) reports correct net-negative
+-- expenses again.
+--
+-- Operator playbook (manual, NOT auto-applied via deploy.sh):
+--   1. Replace `<userId>` with the affected user's id.
+--   2. Run the audit SELECT first; eyeball the seven ids match the expected
+--      pattern: account.type='A', category.type='E', amount > 0.
+--   3. Run the BEGIN / UPDATE / COMMIT block.
+--   4. Re-run the audit SELECT; expect zero rows (the `amount > 0` guard
+--      makes the UPDATE idempotent — re-running is a no-op).
+--   5. Confirm via the app: Groceries should now report net-negative across
+--      the audit window.
+--
+-- Audit-trio compliance: bumps `updated_at`, preserves `source`. The cash
+-- account balance auto-recomputes via `SUM(transactions.amount)` — no manual
+-- ledger touch.
+
+-- AUDIT — eyeball before running the UPDATE.
+SELECT t.id, t.date, t.amount, t.entered_amount, t.entered_currency,
+       a.id   AS account_id,  a.type AS account_type,
+       c.type AS category_type, t.source, t.updated_at
+  FROM transactions t
+  JOIN accounts   a ON a.id = t.account_id
+  JOIN categories c ON c.id = t.category_id
+ WHERE t.id IN (35626, 35627, 35632, 35633, 35629, 35628, 35630)
+   AND t.user_id = '<userId>';
+
+BEGIN;
+
+UPDATE transactions
+   SET amount = -amount,
+       entered_amount = CASE
+         WHEN entered_amount IS NULL THEN NULL
+         WHEN entered_amount > 0 THEN -entered_amount
+         ELSE entered_amount       -- already negative; idempotent re-run
+       END,
+       updated_at = NOW()
+ WHERE id IN (35626, 35627, 35632, 35633, 35629, 35628, 35630)
+   AND user_id = '<userId>'
+   AND amount > 0;                 -- idempotency guard
+
+COMMIT;
+
+-- Optional: discover OTHER historical wrong-sign rows beyond the seven the
+-- auditor identified. Operator decides whether to bulk-flip a wider set or
+-- leave them as historical record.
+--
+-- SELECT t.id, t.date, t.amount, c.type AS category_type, a.type AS account_type, t.source
+--   FROM transactions t
+--   JOIN accounts   a ON a.id = t.account_id
+--   JOIN categories c ON c.id = t.category_id
+--  WHERE t.user_id = '<userId>'
+--    AND c.type = 'E'
+--    AND a.type = 'A'
+--    AND t.amount > 0
+--  ORDER BY t.date DESC;

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -9,6 +9,7 @@ import { invalidateUser as invalidateUserTxCache } from "@/lib/mcp/user-tx-cache
 import { buildHoldingResolver } from "@/lib/external-import/portfolio-holding-resolver";
 import { convertToAccountCurrency } from "@/lib/currency-conversion";
 import { InvestmentHoldingRequiredError } from "@/lib/investment-account";
+import { SignCategoryMismatchError } from "@/lib/transactions/sign-category-invariant";
 import { db, schema } from "@/db";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
@@ -476,13 +477,25 @@ export async function POST(request: NextRequest) {
     // Issue #28: hard-code the writer surface at the route boundary rather
     // than relying on the schema default. Defensive against a future writer
     // path that forgets to set it — every entry point is grep-discoverable.
-    const tx = await createTransaction(auth.userId, { ...encrypted, source: "manual" });
+    const tx = await createTransaction(auth.userId, { ...encrypted, source: "manual" }, auth.dek);
     invalidateUserTxCache(auth.userId);
     return NextResponse.json(tx, { status: 201 });
   } catch (error: unknown) {
     if (error instanceof InvestmentHoldingRequiredError) {
       return NextResponse.json(
         { error: error.message, code: error.code, accountId: error.accountId },
+        { status: 400 },
+      );
+    }
+    if (error instanceof SignCategoryMismatchError) {
+      return NextResponse.json(
+        {
+          error: error.message,
+          code: error.code,
+          amount: error.amount,
+          categoryName: error.categoryName,
+          categoryType: error.categoryType,
+        },
         { status: 400 },
       );
     }
@@ -546,13 +559,25 @@ export async function PUT(request: NextRequest) {
     // Phase 5: never persist the legacy text column.
     delete data.portfolioHolding;
     const encrypted = encryptTxWrite(auth.dek, data);
-    const tx = await updateTransaction(id, auth.userId, encrypted);
+    const tx = await updateTransaction(id, auth.userId, encrypted, auth.dek);
     invalidateUserTxCache(auth.userId);
     return NextResponse.json(tx);
   } catch (error: unknown) {
     if (error instanceof InvestmentHoldingRequiredError) {
       return NextResponse.json(
         { error: error.message, code: error.code, accountId: error.accountId },
+        { status: 400 },
+      );
+    }
+    if (error instanceof SignCategoryMismatchError) {
+      return NextResponse.json(
+        {
+          error: error.message,
+          code: error.code,
+          amount: error.amount,
+          categoryName: error.categoryName,
+          categoryType: error.categoryType,
+        },
         { status: 400 },
       );
     }

--- a/src/lib/import-pipeline.ts
+++ b/src/lib/import-pipeline.ts
@@ -7,6 +7,10 @@ import { encryptField, decryptField, tryDecryptField } from "./crypto/envelope";
 import { nameLookup } from "./crypto/encrypted-columns";
 import { buildHoldingResolver } from "./external-import/portfolio-holding-resolver";
 import { getInvestmentAccountIds } from "./investment-account";
+import {
+  validateSignVsCategory,
+  getCategoryTypeMap,
+} from "./transactions/sign-category-invariant";
 import { safeConvertToAccountCurrency } from "./currency-conversion";
 import { prewarmRates } from "./fx-service";
 import {
@@ -564,6 +568,53 @@ export async function executeImport(
   }
   if (rejected.length > 0) {
     const rejectedSet = new Set(rejected);
+    for (let i = toInsert.length - 1; i >= 0; i--) {
+      if (rejectedSet.has(i)) toInsert.splice(i, 1);
+    }
+  }
+
+  // Issue #212 — sign-vs-category invariant pass. Pre-fetch the (id → type)
+  // map once per batch (one SELECT for every distinct categoryId in the
+  // pending rows), then per-row reject violations into importErrors[]. The
+  // legacy investment-account-rejection block above is the canonical
+  // pattern for "fail this row, keep the batch going" and we mirror its
+  // shape exactly.
+  let signRejected: number[] = [];
+  try {
+    const distinctCatIds = new Set<number>();
+    for (const row of toInsert) {
+      if (row.categoryId != null) distinctCatIds.add(row.categoryId);
+    }
+    if (distinctCatIds.size > 0) {
+      const catTypeMap = await getCategoryTypeMap(userId, userDek ?? null, distinctCatIds);
+      signRejected = toInsert
+        .map((row, i) => {
+          if (row.categoryId == null) return -1;
+          const cat = catTypeMap.get(row.categoryId);
+          if (!cat) return -1;
+          const sErr = validateSignVsCategory({
+            amount: row.amount,
+            categoryType: cat.type,
+            categoryName: cat.name,
+          });
+          return sErr ? i : -1;
+        })
+        .filter((i) => i >= 0);
+      for (const idx of signRejected) {
+        const row = toInsert[idx];
+        const cat = catTypeMap.get(row.categoryId!);
+        importErrors.push(
+          `Row ${row.rowIndex + 1}: category "${cat?.name ?? "?"}" (type ${cat?.type ?? "?"}) disagrees with amount sign (${row.amount}). Flip the sign or pick a different category.`,
+        );
+      }
+    }
+  } catch (err) {
+    importErrors.push(
+      `Sign-vs-category check failed: ${err instanceof Error ? err.message : "Unknown error"}`,
+    );
+  }
+  if (signRejected.length > 0) {
+    const rejectedSet = new Set(signRejected);
     for (let i = toInsert.length - 1; i >= 0; i--) {
       if (rejectedSet.has(i)) toInsert.splice(i, 1);
     }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -2,6 +2,7 @@ import { db, schema, getDialect } from "@/db";
 import { eq, and, gte, lte, desc, sql, asc, inArray } from "drizzle-orm";
 import type { SQL, AnyColumn } from "drizzle-orm";
 import { requireHoldingForInvestmentAccount } from "@/lib/investment-account";
+import { validateSignVsCategoryById } from "@/lib/transactions/sign-category-invariant";
 import type { TransactionSource } from "@/lib/tx-source";
 import type { SortableColumnId } from "@/lib/transactions/columns";
 
@@ -318,12 +319,21 @@ export async function createTransaction(userId: string, data: {
   // every other writer (import/MCP/connector/sample-data/restore) sets
   // it explicitly so the surface info is set at the route boundary.
   source?: TransactionSource;
-}) {
+}, dek: Buffer | null = null) {
   // Investment-account constraint: every transaction in a flagged account
   // must reference a portfolio_holdings row. Throws
   // InvestmentHoldingRequiredError when the FK is missing — the route
   // handler maps it to a 400.
   await requireHoldingForInvestmentAccount(userId, data.accountId, data.portfolioHoldingId);
+  // Issue #212 — sign-vs-category invariant. Throws SignCategoryMismatchError
+  // when the category type 'E'/'I' disagrees with the amount sign. The route
+  // handler maps it to a 400 (mirroring the InvestmentHoldingRequiredError
+  // mapping). `dek` is optional so the error message can name the category
+  // when available; without it the message falls back to `category #<id>`.
+  if (data.amount != null) {
+    const sErr = await validateSignVsCategoryById(userId, dek, data.categoryId, data.amount);
+    if (sErr) throw sErr;
+  }
   return db.insert(transactions).values({ ...data, userId }).returning().get();
 }
 
@@ -344,21 +354,28 @@ export async function updateTransaction(id: number, userId: string, data: Partia
   isBusiness: number;
   splitPerson: string;
   splitRatio: number;
-}>) {
+}>, dek: Buffer | null = null) {
   // Investment-account constraint applies to the post-merge state. Touching
   // accountId xor portfolioHoldingId can flip the row in or out of the
   // constraint, so we resolve both against the current row before checking.
   // `data.portfolioHoldingId === undefined` means the caller didn't include
   // the field; an explicit `null` is treated as a clear intent to unlink
   // (and rejected when the resulting account is investment).
-  if (
+  // Issue #212 — sign-vs-category invariant on the post-merge state. Same
+  // pattern: only fetch the existing row when the caller is touching either
+  // amount or categoryId; otherwise the invariant can't change.
+  const needsCurrent =
     data.accountId !== undefined ||
-    Object.prototype.hasOwnProperty.call(data, "portfolioHoldingId")
-  ) {
+    Object.prototype.hasOwnProperty.call(data, "portfolioHoldingId") ||
+    data.amount !== undefined ||
+    data.categoryId !== undefined;
+  if (needsCurrent) {
     const current = await db
       .select({
         accountId: transactions.accountId,
         portfolioHoldingId: transactions.portfolioHoldingId,
+        amount: transactions.amount,
+        categoryId: transactions.categoryId,
       })
       .from(transactions)
       .where(and(eq(transactions.id, id), eq(transactions.userId, userId)))
@@ -369,6 +386,19 @@ export async function updateTransaction(id: number, userId: string, data: Partia
         ? (data.portfolioHoldingId ?? null)
         : current.portfolioHoldingId;
       await requireHoldingForInvestmentAccount(userId, resultingAccountId, resultingHoldingId);
+      if (data.amount !== undefined || data.categoryId !== undefined) {
+        const resultingAmount = data.amount ?? current.amount;
+        const resultingCategoryId = data.categoryId ?? current.categoryId;
+        if (resultingAmount != null) {
+          const sErr = await validateSignVsCategoryById(
+            userId,
+            dek,
+            resultingCategoryId,
+            Number(resultingAmount),
+          );
+          if (sErr) throw sErr;
+        }
+      }
     }
   }
   // Audit-trio (issue #28): every UPDATE bumps updated_at = NOW(). `source`

--- a/src/lib/transactions/sign-category-invariant.ts
+++ b/src/lib/transactions/sign-category-invariant.ts
@@ -1,0 +1,179 @@
+/**
+ * Sign-vs-category invariant — issue #212.
+ *
+ * For every transaction whose category is resolved to one of:
+ *   - 'E' (expense)  → `amount` MUST be ≤ 0 on asset/liability accounts
+ *   - 'I' (income)   → `amount` MUST be ≥ 0
+ *   - 'R' (transfer) → exempt (sign convention varies per leg)
+ *   - 'T' (legacy transfer alias minted by a separate broken `create_category`
+ *          path — treated as transfer-exempt defensively until issue #12 lands
+ *          and any 'T' rows are normalized to 'R'.)
+ *
+ * Liability accounts follow the same rule — an `E` charge on a credit card
+ * still goes in as `amount < 0` from the cardholder's perspective; the live
+ * aggregator math (CLAUDE.md "Account balance for accounts with holdings")
+ * handles the sign flip on display. The single rule covers both account
+ * types; no `accounts.type` branching is needed.
+ *
+ * Uncategorized rows (`categoryId == null`, `categoryType == null`) are
+ * exempt — those are typically receipt-OCR previews or "I'll fix this later"
+ * rows and must remain insertable without category context.
+ *
+ * Bulk callers (bulk_record_transactions, import-pipeline) should fetch
+ * {@link getCategoryTypeMap} once before the loop to avoid N round-trips.
+ *
+ * Stream D Phase 4: `categories.type` is plaintext and does NOT require a
+ * DEK, so the helper works on every transport (HTTP MCP, stdio MCP, REST,
+ * import). When a DEK is available the error message includes the decrypted
+ * category name; without a DEK (stdio) it falls back to `category #<id>`.
+ */
+
+import { db, schema } from "@/db";
+import { and, eq, inArray } from "drizzle-orm";
+import { tryDecryptField } from "@/lib/crypto/envelope";
+
+/** Possible values of `categories.type`. The DB column is plaintext text(),
+ *  not enum-typed; we accept the string and normalize. */
+export type CategoryTypeRaw = string | null | undefined;
+
+export class SignCategoryMismatchError extends Error {
+  code = "sign_category_mismatch" as const;
+  constructor(
+    public amount: number,
+    public categoryName: string,
+    public categoryType: "E" | "I",
+  ) {
+    const direction = categoryType === "E" ? "non-positive (≤ 0)" : "non-negative (≥ 0)";
+    const role = categoryType === "E" ? "expense" : "income";
+    super(
+      `Category "${categoryName}" is type '${categoryType}' (${role}), so amount must be ${direction}; got ${amount}. Flip the sign or pick a different category.`,
+    );
+    this.name = "SignCategoryMismatchError";
+  }
+}
+
+/**
+ * Pure, synchronous validator. Returns a {@link SignCategoryMismatchError}
+ * when the (amount, categoryType) pair violates the invariant, or `null`
+ * when the row is OK / exempt.
+ *
+ * Caller responsibility:
+ *   - resolve the category id → type (via `categories.type`)
+ *   - resolve the category id → display name (decrypt `name_ct` when DEK
+ *     is available; pass `"category #<id>"` when not)
+ *   - throw the returned error (REST routes) or surface it as a structured
+ *     per-row failure (bulk MCP).
+ */
+export function validateSignVsCategory(args: {
+  amount: number;
+  categoryType: CategoryTypeRaw;
+  categoryName: string;
+}): SignCategoryMismatchError | null {
+  if (!args.categoryType) return null; // uncategorized exempt
+  // Defensively treat both 'R' (canonical transfer) and 'T' (legacy alias —
+  // see file header) as transfer-exempt. amount=0 is also exempt because it
+  // satisfies BOTH ≤ 0 and ≥ 0 (and many in-kind / RSU-vest patterns book
+  // amount=0 with a quantity).
+  if (args.categoryType === "R" || args.categoryType === "T") return null;
+  if (args.amount === 0) return null;
+  if (args.categoryType === "E" && args.amount > 0) {
+    return new SignCategoryMismatchError(args.amount, args.categoryName, "E");
+  }
+  if (args.categoryType === "I" && args.amount < 0) {
+    return new SignCategoryMismatchError(args.amount, args.categoryName, "I");
+  }
+  // Any other value of `categoryType` (typo, future-added enum value) is
+  // accepted to avoid false positives.
+  return null;
+}
+
+/**
+ * Resolve a category id to {type, name} for the validator, then call the
+ * pure helper. Returns the same error object (or null) on the same shape.
+ *
+ * - Selects only `id, type, name_ct` (DEK not required to read `type`).
+ * - When the id is null / not found / not owned, returns `null` (exempt).
+ *   Ownership is checked by the caller (route / MCP) earlier — this helper
+ *   only validates the sign rule.
+ */
+export async function validateSignVsCategoryById(
+  userId: string,
+  dek: Buffer | null,
+  categoryId: number | null | undefined,
+  amount: number,
+): Promise<SignCategoryMismatchError | null> {
+  if (categoryId == null) return null;
+  const row = await db
+    .select({
+      id: schema.categories.id,
+      type: schema.categories.type,
+      nameCt: schema.categories.nameCt,
+    })
+    .from(schema.categories)
+    .where(
+      and(
+        eq(schema.categories.id, categoryId),
+        eq(schema.categories.userId, userId),
+      ),
+    )
+    .get();
+  if (!row) return null;
+  const categoryName =
+    (row.nameCt && dek
+      ? tryDecryptField(dek, row.nameCt, "categories.name_ct")
+      : null) ?? `category #${row.id}`;
+  return validateSignVsCategory({
+    amount,
+    categoryType: row.type,
+    categoryName,
+  });
+}
+
+/**
+ * Bulk variant — pre-fetch the (id → {type, name}) map once. Use this from
+ * import-pipeline / bulk_record_transactions where N rows reference up to
+ * N distinct category ids; one SELECT-IN beats N round-trips.
+ *
+ * Pass the user's DEK (or null) so the map's `name` is decrypted when
+ * possible. Without a DEK every name falls back to `category #<id>`.
+ */
+export async function getCategoryTypeMap(
+  userId: string,
+  dek: Buffer | null,
+  categoryIds?: Iterable<number | null | undefined>,
+): Promise<Map<number, { type: string; name: string }>> {
+  const ids = new Set<number>();
+  if (categoryIds) {
+    for (const id of categoryIds) {
+      if (id != null && Number.isFinite(id)) ids.add(Number(id));
+    }
+  }
+  // No ids supplied → return an empty map; caller can fall back to the
+  // single-id helper for any row whose category isn't in the map.
+  if (ids.size === 0) {
+    return new Map();
+  }
+  const rows = await db
+    .select({
+      id: schema.categories.id,
+      type: schema.categories.type,
+      nameCt: schema.categories.nameCt,
+    })
+    .from(schema.categories)
+    .where(
+      and(
+        eq(schema.categories.userId, userId),
+        inArray(schema.categories.id, [...ids]),
+      ),
+    )
+    .all();
+  const out = new Map<number, { type: string; name: string }>();
+  for (const r of rows) {
+    const name =
+      (r.nameCt && dek
+        ? tryDecryptField(dek, r.nameCt, "categories.name_ct")
+        : null) ?? `category #${r.id}`;
+    out.set(Number(r.id), { type: String(r.type ?? ""), name });
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #212

## Summary
- New pure helper `validateSignVsCategory({ amount, categoryType, categoryName })` at `src/lib/transactions/sign-category-invariant.ts` returning a `SignCategoryMismatchError` (`code: sign_category_mismatch`) when an `E`-type category has `amount > 0` or `I`-type has `amount < 0`. `R`/`T` transfers, uncategorized rows, and `amount === 0` are exempt by construction. `categories.type` is plaintext so the rule fires identically across every transport — only the error message degrades to `category #<id>` on stdio.
- Wired into all 6 violating tx-write callsites:
  - REST `createTransaction` + `updateTransaction` (post-merge state) → 400 with structured body
  - MCP HTTP `record_transaction` (hard error) / `bulk_record_transactions` (per-row `results[i]` envelope coordinated with #203) / `update_transaction` (post-merge, hoisted FX pre-flight to make atomicity work)
  - MCP stdio `record_transaction` + `update_transaction` (cash-account branch — investment writes already refused)
  - import-pipeline batch insert (per-row reject into `importErrors[]` after pre-fetching `getCategoryTypeMap` once)
- Transfers (`createTransferPair*`) and the staged-approve transfer-pair / target-bound-transfer branches are exempt (categoryId always resolves to type='R'); cash-bucket staged rows route through `executeImport` so they inherit the protection.
- Manual data-migration playbook `scripts/migrate-fix-receipt-sign-2026-05-09.sql` for the seven historical wrong-sign rows the audit identified — idempotent UPDATE, audit SELECT first, bumps `updated_at`, preserves `source`. NOT in `scripts/migrations/` per the code-FIRST-then-SQL convention.

## Docs updated
- `pf-app/CHANGELOG.md` — top-level entry under 2026-05-09.
- Tool count unchanged (90 HTTP / 86 stdio) — guard inside existing tools, not new tools.

## Promotion to main
- **Migration** — manual: replace `<userId>` in `scripts/migrate-fix-receipt-sign-2026-05-09.sql`, run audit SELECT first, then BEGIN/UPDATE/COMMIT block. Idempotent (`amount > 0` guard), so re-running is a no-op. Cash CAD balance auto-recomputes via `SUM(transactions.amount)` — no ledger touch needed.
- **MCP surface** — `record_transaction` now hard-rejects `(amount=+75, category="Groceries")` patterns. `bulk_record_transactions` per-row failure envelope adds an optional `code` field (existing `success: true` rows unchanged). `update_transaction` validates the post-merge state — patches that violate the invariant abort cleanly with no partial writes.
- **REST** — `POST /api/transactions` and `PUT /api/transactions` return a 400 with `code: sign_category_mismatch` and the offending `amount` / `categoryName` / `categoryType` in the body when the rule fires. UI form-validation paths are unaffected (the existing UX already disallows the violating combinations on the manual-entry form).
- No new env vars / cron / deps / CSP / backfill changes.

## How I tested
- `npx tsc --noEmit` clean for the touched files.
- `npm run build` passes (Next.js production build, ✓ Compiled successfully).
- Validator helper is pure / synchronous — unit-testable without DB; deferred to validator agent for integration smoke against dev (record_transaction with `account_id=<cash>, amount=+75, category="Groceries"` should return `Error: Category "Groceries" is type 'E' (expense)…`; same args with `amount=-75` should succeed).