### PR TITLE
fix(mcp): delete_account decrypts before fuzzy + adds accountId param (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## 2026-05-10 — [HOTFIX] MCP delete_account resolves wrong account id (#230)
+
+Hotfix for a data-loss-risk bug class. The HTTP MCP `delete_account` handler called `fuzzyFind` on rows that only carried encrypted `name_ct` / `alias_ct` (Stream D Phase 4) without first running `decryptNameish`. Every row had `o.name === undefined`, so `fuzzyFind`'s last-resort `lo.includes(String(o.name ?? "").toLowerCase())` step collapsed to `lo.includes("")` (unconditionally true) and silently returned the FIRST account in the SELECT result. With `force=true` and FK CASCADE on `accounts → transactions / holding_accounts / goal_accounts`, a wrong-target call would have wiped every transaction, every holding pairing, and every goal link belonging to the wrong account. The live dev-MCP repro (verbatim from the audit): `delete_account(account="_VERIFY_EUR_ACCOUNT_", force=true)` resolved to a different, high-value asset account; the DELETE only failed because that wrong-target account had FK references blocking it. Same bug class as the closed #211 (`delete_budget` / `delete_loan`) and #214 (`create_rule`) — the resolver-class regression-prevention story now has tests.
+
+- **Schema** — `accountId: number?` added (preferred, exact match, works without DEK). `account: string?` is now optional. Either is required; both is allowed only when they resolve to the same id.
+- **Resolver** — id branch SELECTs by `id + user_id`; name branch refuses without an unlocked DEK (matches stdio's existing refusal at `register-core-tools.ts:1322-1326`) and runs `decryptNameish` BEFORE `fuzzyFind`. Mismatch between an `accountId` and a `account`-resolved id fails loud (`Account mismatch: "<name>" resolves to #<id>, but accountId=<id> was supplied`) and does NOT delete.
+- **Messages** — every error/success echo now includes both `#<id>` and `("<name>")` (or `("<encrypted>")` when no DEK is in scope on the id-only path). The literal `Account 'undefined'` from the audit is gone.
+- **Cache invariant** — `invalidateUserTxCache(userId)` now runs after a successful DELETE, matching the `delete_budget` precedent and the CLAUDE.md "every MCP tx-mutating write must call `invalidateUser(userId)`" gotcha.
+- **FK CASCADE** preserved at the DB level — no application-layer child DELETEs. A code comment names the three cascade paths so the next reader doesn't second-guess.
+- **Stdio** — already correct (refuses `account`, accepts `account_id`); only the help-crib was edited.
+- **Tests** — NEW [tests/mcp/delete-account.test.ts](tests/mcp/delete-account.test.ts) with 11 cases covering all 8 acceptance-criteria branches plus an adversarial-order regression that pins the live #230 repro shape (matching account is NOT first in the SELECT result; the resolver must still hit the correct id).
+- **MCP server version** stays 3.0.0 (bug fix; the only surface change is one new optional `accountId` param). Tool count stays 90 HTTP / 86 stdio.
+- **Files touched** — [mcp-server/register-tools-pg.ts](mcp-server/register-tools-pg.ts) (`delete_account` handler + `finlynq_help` crib), [mcp-server/register-core-tools.ts](mcp-server/register-core-tools.ts) (stdio `finlynq_help` crib only), NEW [tests/mcp/delete-account.test.ts](tests/mcp/delete-account.test.ts), [CHANGELOG.md](CHANGELOG.md), [../CLAUDE.md](../CLAUDE.md).
+- **Validator hint** — live MCP probes on dev: `delete_account(accountId=<id>)` succeeds without a DEK; `delete_account(account="_UNKNOWN_")` returns "Did you mean ...?" with no false-match; `delete_account(accountId=A, account="<name of B>")` returns the explicit mismatch error and does NOT delete; `delete_account(account="<known>")` echoes both name and id in the success message.
+
+Verification: `npx tsc --noEmit` clean (existing repo state), `npm run build` passes, `vitest run tests/mcp/delete-account.test.ts` 11/11 passes.
+
 ## 2026-05-10 — Data fixes: receipt-OCR sign flip + FX-reval rounding (#229)
 
 One-time historical data migration — non-destructive UPDATE-in-place fixes for residual rows that pre-date the pipeline guards from PR #225 (issue #212, sign-vs-category validator) and PR #221 (issue #208, IEEE-754 rounding hygiene). Forward-going writers are confirmed clean ([src/lib/currency-conversion.ts](src/lib/currency-conversion.ts) `round2()` at line 39 + 87, and [src/lib/cron/settle-future-fx.ts](src/lib/cron/settle-future-fx.ts) routes through `convertToAccountCurrency` which round2()s the amount). Tracked migration auto-applied by `deploy.sh`; loose destructive bucket not used (operation is non-destructive UPDATE-in-place, idempotent, globally scoped).

--- a/mcp-server/register-core-tools.ts
+++ b/mcp-server/register-core-tools.ts
@@ -1717,7 +1717,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
           delete_budget: "delete_budget(category, month)",
           add_account: "add_account(name, type, group?, currency?, note?) — type: 'A'=asset, 'L'=liability.",
           update_account: "update_account(account, name?, group?, currency?, note?)",
-          delete_account: "delete_account(account, force?)",
+          delete_account: "delete_account(account_id, force?) — stdio refuses `account` (name) post Stream D Phase 4; pass account_id (numeric).",
           add_goal: "add_goal(name, type, target_amount, deadline?, account?)",
           update_goal: "update_goal(goal, target_amount?, deadline?, status?, name?)",
           delete_goal: "delete_goal(goal)",

--- a/mcp-server/register-tools-pg.ts
+++ b/mcp-server/register-tools-pg.ts
@@ -4145,26 +4145,106 @@ export function registerPgTools(
   );
 
   // ── delete_account ─────────────────────────────────────────────────────────
+  // Issue #230 (HOTFIX, 2026-05-10): the previous handler called `fuzzyFind`
+  // on rows that only carried `name_ct` / `alias_ct` (Stream D Phase 4) and
+  // never decrypted them. With every `o.name === undefined`, `fuzzyFind`'s
+  // last-resort `lo.includes(String(o.name ?? "").toLowerCase())` waterfall
+  // step collapsed to `lo.includes("")` — unconditionally true — and quietly
+  // returned the FIRST account in the SELECT result. Combined with `force=true`
+  // and FK CASCADE on `accounts → transactions / holding_accounts /
+  // goal_accounts`, the wrong-target was a data-loss-risk class. Same bug
+  // class as #211 (delete_budget / delete_loan) and #214 (create_rule).
+  //
+  // Fix: add an `accountId` (numeric, exact) param, mark `account` optional,
+  // require exactly one. Refuse the name path without an unlocked DEK (stdio
+  // already does this — `register-core-tools.ts` lines 1322-1326). Decrypt
+  // BEFORE fuzzy-matching. Echo both id + name in success/error messages so
+  // the caller can verify the resolved target.
+  //
+  // FK CASCADE remains DB-side: deleting an account drops its `transactions`,
+  // `holding_accounts`, and `goal_accounts` rows automatically — no
+  // application-layer child DELETEs needed.
   server.tool(
     "delete_account",
-    "Delete an account (only if it has no transactions)",
+    "Delete an account (only if it has no transactions). Pass exactly ONE of `accountId` (preferred, exact) or `account` (name/alias, fuzzy). Supplying both is allowed only when they resolve to the same account — a mismatch fails loud and does NOT delete.",
     {
-      account: z.string().describe("Account name or alias (fuzzy matched against name; exact match on alias)"),
-      force: z.boolean().optional().describe("Delete even if transactions exist (moves them to uncategorized)"),
+      accountId: z.number().int().positive().optional().describe("Account FK (accounts.id). Exact match — preferred and the only way to delete an account when the user's DEK is not unlocked."),
+      account: z.string().optional().describe("Account name or alias (fuzzy matched against name; exact match on alias). Requires an unlocked DEK because account names live in encrypted columns post Stream D Phase 4. Pass `accountId` instead when no DEK is available."),
+      force: z.boolean().optional().describe("Delete even if transactions exist. FK CASCADE removes the account's transactions, holding_accounts, and goal_accounts rows — irreversible."),
     },
-    async ({ account, force }) => {
-      const allAccounts = await q(db, sql`SELECT id, name_ct, alias_ct FROM accounts WHERE user_id = ${userId}`);
-      const acct = fuzzyFind(account, allAccounts);
-      if (!acct) return err(`Account "${account}" not found`);
-
-      const txnCount = await q(db, sql`SELECT COUNT(*) as cnt FROM transactions WHERE user_id = ${userId} AND account_id = ${acct.id}`);
-      const count = Number(txnCount[0]?.cnt ?? 0);
-      if (count > 0 && !force) {
-        return err(`Account "${acct.name}" has ${count} transaction(s). Pass force=true to delete anyway.`);
+    async ({ accountId, account, force }) => {
+      if (accountId == null && (account == null || account === "")) {
+        return err("Pass `accountId` (numeric) or `account` (name/alias) to identify the account.");
       }
 
-      await db.execute(sql`DELETE FROM accounts WHERE id = ${acct.id} AND user_id = ${userId}`);
-      return text({ success: true, message: `Account "${acct.name}" deleted${count > 0 ? ` (${count} transactions also removed)` : ""}` });
+      // Resolve via id first when supplied — the safe path that never depends
+      // on the DEK. SELECT both encrypted columns so we can echo a name on
+      // success when a DEK happens to be available.
+      let acct: Row | null = null;
+      if (accountId != null) {
+        const rows = await q(db, sql`
+          SELECT id, name_ct, alias_ct FROM accounts WHERE user_id = ${userId} AND id = ${accountId}
+        `);
+        if (!rows.length) return err(`Account #${accountId} not found.`);
+        acct = decryptNameish(rows, dek)[0];
+      }
+
+      // Resolve via name (fuzzy). Refuses without a DEK — same shape as the
+      // stdio counterpart's refusal at register-core-tools.ts:1322-1326.
+      let resolvedByName: Row | null = null;
+      if (account != null && account !== "") {
+        if (!dek) {
+          return err("Cannot resolve account by name without an unlocked DEK (Stream D Phase 4). Pass `accountId` instead.");
+        }
+        const rawAccounts = await q(db, sql`
+          SELECT id, name_ct, alias_ct FROM accounts WHERE user_id = ${userId}
+        `);
+        const allAccounts = decryptNameish(rawAccounts, dek);
+        resolvedByName = fuzzyFind(account, allAccounts);
+        if (!resolvedByName) {
+          return err(`Account "${account}" not found. Did you mean: ${suggestionList(account, allAccounts)}?`);
+        }
+      }
+
+      // When BOTH params supplied, fail loud on mismatch — never silently
+      // prefer one. (Matching ids: pick the id-resolved row so the success
+      // message uses its decrypted name.)
+      if (acct && resolvedByName) {
+        if (Number(acct.id) !== Number(resolvedByName.id)) {
+          return err(`Account mismatch: "${account}" resolves to #${Number(resolvedByName.id)}, but accountId=${Number(acct.id)} was supplied.`);
+        }
+        // Same row — id branch already populated `acct`, keep it.
+      } else if (!acct && resolvedByName) {
+        acct = resolvedByName;
+      }
+
+      if (!acct) {
+        // Defense in depth — the input-shape guard above should have caught this.
+        return err("Pass `accountId` (numeric) or `account` (name/alias) to identify the account.");
+      }
+
+      const acctName = (acct.name as string | undefined) ?? "<encrypted>";
+      const acctId = Number(acct.id);
+
+      const txnCount = await q(db, sql`SELECT COUNT(*) as cnt FROM transactions WHERE user_id = ${userId} AND account_id = ${acctId}`);
+      const count = Number(txnCount[0]?.cnt ?? 0);
+      if (count > 0 && !force) {
+        return err(`Account #${acctId} ("${acctName}") has ${count} transaction(s). Pass force=true to delete anyway.`);
+      }
+
+      // FK CASCADE: this DELETE drops `transactions`, `holding_accounts`, and
+      // `goal_accounts` rows for this account in the same DB transaction. No
+      // application-layer child DELETEs needed (CLAUDE.md "wipe-account is
+      // single-transaction" gotcha).
+      await db.execute(sql`DELETE FROM accounts WHERE id = ${acctId} AND user_id = ${userId}`);
+      // CLAUDE.md invariant: every MCP tx-mutating write must invalidate the
+      // per-user tx cache. Mirrors `delete_budget` precedent at line ~4089.
+      invalidateUserTxCache(userId);
+      return text({
+        success: true,
+        accountId: acctId,
+        message: `Account #${acctId} ("${acctName}") deleted${count > 0 ? ` (${count} transactions also removed)` : ""}`,
+      });
     }
   );
 
@@ -4493,7 +4573,7 @@ export function registerPgTools(
           delete_budget: "delete_budget(category, month) — Remove budget entry.",
           add_account: "add_account(name, type, group?, currency?, note?, alias?) — type: 'A'=asset, 'L'=liability. alias is a short shorthand (e.g. last 4 digits of a card) used when receipts/imports reference the account by a non-canonical name.",
           update_account: "update_account(account, name?, group?, currency?, note?, alias?) — Fuzzy account name or alias. Pass empty alias to clear.",
-          delete_account: "delete_account(account, force?) — force=true to delete with transactions.",
+          delete_account: "delete_account(accountId? OR account?, force?) — accountId for exact match (preferred, works without DEK); account is name/alias fuzzy (requires unlocked DEK). Pass exactly one. force=true deletes even if transactions exist.",
           add_goal: "add_goal(name, type, target_amount, deadline?, account?, account_ids?) — type: savings|debt_payoff|investment|emergency_fund. account_ids: number[] for multi-account linking (issue #130).",
           update_goal: "update_goal(goal, target_amount?, deadline?, status?, name?, account_ids?) — status: active|completed|paused. account_ids: replace linked-account set ([] = unlink all).",
           delete_goal: "delete_goal(goal) — Fuzzy goal name.",

--- a/tests/mcp/delete-account.test.ts
+++ b/tests/mcp/delete-account.test.ts
@@ -1,0 +1,359 @@
+/**
+ * Regression tests for the issue #230 hotfix on MCP HTTP `delete_account`.
+ *
+ * The bug class: post Stream D Phase 4 the `accounts` table only carries
+ * `name_ct` / `alias_ct` (no plaintext). The previous handler called
+ * `fuzzyFind` on the raw rows without first running `decryptNameish`, so
+ * every row had `o.name === undefined`. `fuzzyFind`'s last-resort waterfall
+ * step `lo.includes(String(o.name ?? "").toLowerCase())` collapsed to
+ * `lo.includes("")` (unconditionally true) and silently returned the FIRST
+ * row in the SELECT result. With `force=true` and FK CASCADE on
+ * `accounts → transactions / holding_accounts / goal_accounts`, the
+ * wrong-target was a data-loss-risk class. Same shape as the closed bugs
+ * #211 (delete_budget / delete_loan) and #214 (create_rule).
+ *
+ * What this file gates against:
+ *
+ *   1. Name-fuzzy resolution targets the correct id, NOT the first SELECT row.
+ *   2. Name-fuzzy without an unlocked DEK refuses cleanly (NOT a silent miss).
+ *   3. Unknown-name returns a "did you mean ..." suggestion list.
+ *   4. `accountId` exact-id path succeeds without a DEK and echoes
+ *      `<encrypted>` instead of literal `undefined`.
+ *   5. Mismatched `accountId` + `account` fails loud and does NOT delete.
+ *   6. Neither param returns the dual-param hint.
+ *   7. Adversarial-order test: when the encrypted-name SELECT lists the wrong
+ *      account first, querying by the second account's name still hits the
+ *      second account's id. (This is the live data-loss repro shape.)
+ *   8. Successful delete invalidates the per-user tx cache (matches
+ *      `delete_budget` precedent and the CLAUDE.md invariant).
+ */
+
+import { describe, it, expect } from "vitest";
+import { randomBytes } from "node:crypto";
+
+// Stable env so the auth/encryption modules don't blow up at import time.
+process.env.PF_JWT_SECRET = "test-jwt-secret-for-vitest-32chars!!";
+process.env.PF_PEPPER = process.env.PF_PEPPER ?? "test-pepper-32chars-for-vitest-only!!";
+process.env.PF_STAGING_KEY = process.env.PF_STAGING_KEY ?? "test-staging-key-32chars-for-vitest!";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerPgTools } from "../../mcp-server/register-tools-pg";
+import { encryptField } from "../../src/lib/crypto/envelope";
+
+type CapturedQuery = { text: string; params: unknown[] };
+type FixtureRow = Record<string, unknown>;
+type RowsetFn = (text: string) => FixtureRow[] | undefined;
+
+/**
+ * Walk a Drizzle `sql` template and return the SQL text. Same approach as
+ * `tests/api/mcp-http-smoke.test.ts`.
+ */
+function serializeSqlTemplate(q: unknown): string {
+  if (!q || typeof q !== "object") return String(q);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const sqlObj = q as any;
+  try {
+    const dialect = { escapeName: (n: string) => `"${n}"`, escapeParam: () => "?" };
+    const result = sqlObj.toQuery?.(dialect);
+    if (result && typeof result.sql === "string") return result.sql;
+  } catch {
+    // fall through
+  }
+  const chunks = sqlObj.queryChunks ?? sqlObj.chunks ?? [];
+  let out = "";
+  for (const c of chunks) {
+    if (c && typeof c === "object" && Array.isArray((c as { value?: unknown[] }).value)) {
+      out += (c as { value: string[] }).value.join("");
+    } else if (typeof c === "string") {
+      out += c;
+    }
+  }
+  return out;
+}
+
+/**
+ * Fixture DB: every test wires a `RowsetFn` that maps SQL substrings to a
+ * canned rowset. Captures every issued query so tests can assert on the
+ * shape of the DELETE.
+ */
+function makeFixtureDb(matcher: RowsetFn): {
+  db: { execute: (q: unknown) => Promise<unknown> };
+  queries: CapturedQuery[];
+} {
+  const queries: CapturedQuery[] = [];
+  const db = {
+    execute: async (q: unknown) => {
+      const text = serializeSqlTemplate(q);
+      queries.push({ text, params: [] });
+      const rows = matcher(text);
+      return { rows: rows ?? [], rowCount: rows?.length ?? 0 };
+    },
+  };
+  return { db, queries };
+}
+
+/**
+ * Pull `delete_account`'s handler off a freshly-registered server.
+ */
+function getDeleteAccountTool(
+  db: { execute: (q: unknown) => Promise<unknown> },
+  dek: Buffer | null,
+) {
+  const server = new McpServer({ name: "delete-account-test", version: "0.0.0" });
+  registerPgTools(server, db, "test-user", dek);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tools = (server as any)._registeredTools as Record<
+    string,
+    { handler: (args: unknown, extra: unknown) => Promise<unknown> }
+  >;
+  const tool = tools["delete_account"];
+  if (!tool) throw new Error("delete_account tool not registered");
+  return tool;
+}
+
+/**
+ * Pull the `text` field out of the MCP tool envelope.
+ */
+function envelopeText(result: unknown): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const r = result as any;
+  return r?.content?.[0]?.text ?? "";
+}
+
+/**
+ * Build a fake `accounts` row whose `name_ct` column is real ciphertext under
+ * `dek`. `decryptNameish` will hydrate `o.name` from this.
+ */
+function fakeAccountRow(id: number, name: string, dek: Buffer): FixtureRow {
+  return { id, name_ct: encryptField(dek, name), alias_ct: null };
+}
+
+describe("MCP HTTP delete_account (issue #230 hotfix)", () => {
+  it("rejects when neither `accountId` nor `account` is provided", async () => {
+    const { db, queries } = makeFixtureDb(() => []);
+    const tool = getDeleteAccountTool(db, randomBytes(32));
+    const result = await tool.handler({}, {});
+    const text = envelopeText(result);
+    expect(text).toMatch(/Pass `accountId` \(numeric\) or `account` \(name\/alias\)/);
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(0);
+  });
+
+  it("refuses the name path with a clear error when no DEK is present", async () => {
+    const { db, queries } = makeFixtureDb(() => []);
+    const tool = getDeleteAccountTool(db, null);
+    const result = await tool.handler({ account: "Anything" }, {});
+    const text = envelopeText(result);
+    expect(text).toMatch(/Cannot resolve account by name without an unlocked DEK/);
+    expect(text).toMatch(/Pass `accountId` instead/);
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(0);
+  });
+
+  it("returns a `did you mean` suggestion list on unknown name", async () => {
+    const dek = randomBytes(32);
+    const { db, queries } = makeFixtureDb((sqlText) => {
+      if (/FROM accounts WHERE user_id/i.test(sqlText)) {
+        return [
+          fakeAccountRow(601, "Wealthsimple TFSA", dek),
+          fakeAccountRow(686, "Verify EUR Account", dek),
+        ];
+      }
+      return [];
+    });
+    const tool = getDeleteAccountTool(db, dek);
+    const result = await tool.handler({ account: "_UNKNOWN_NAME_" }, {});
+    const text = envelopeText(result);
+    expect(text).toMatch(/Account "_UNKNOWN_NAME_" not found/);
+    // Any one of the candidates should appear in the suggestion list.
+    expect(text).toMatch(/Wealthsimple TFSA|Verify EUR Account/);
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(0);
+  });
+
+  it("targets the correct account id when the matching name is NOT first in the SELECT (the live #230 repro)", async () => {
+    const dek = randomBytes(32);
+    // Adversarial order: id 601 is first; the user wants to delete id 686.
+    // Pre-fix this returned id 601 (data-loss class). Post-fix it must
+    // resolve to id 686 because exact-name match wins over the first-row
+    // fallthrough.
+    const accounts = [
+      fakeAccountRow(601, "Wealthsimple TFSA", dek),
+      fakeAccountRow(686, "_VERIFY_EUR_ACCOUNT_", dek),
+    ];
+    const { db, queries } = makeFixtureDb((sqlText) => {
+      if (/FROM accounts WHERE user_id/i.test(sqlText) && !/AND id = /i.test(sqlText)) {
+        return accounts;
+      }
+      // tx-count gate: zero so DELETE proceeds without `force`.
+      if (/COUNT\(\*\)/i.test(sqlText) && /FROM transactions/i.test(sqlText)) {
+        return [{ cnt: 0 }];
+      }
+      return [];
+    });
+    const tool = getDeleteAccountTool(db, dek);
+    const result = await tool.handler({ account: "_VERIFY_EUR_ACCOUNT_" }, {});
+    const text = envelopeText(result);
+    // The text is JSON-stringified by `text()` so quotes are escaped (\").
+    // Match on the unescaped substring.
+    expect(text).toMatch(/Account #686/);
+    expect(text).toMatch(/_VERIFY_EUR_ACCOUNT_/);
+    expect(text).toMatch(/deleted/);
+    expect(text).not.toMatch(/#601/);
+    const deletes = queries.filter((q) => /DELETE FROM accounts/i.test(q.text));
+    expect(deletes).toHaveLength(1);
+  });
+
+  it("succeeds via `accountId` even when no DEK is present (id-only path)", async () => {
+    const { db, queries } = makeFixtureDb((sqlText) => {
+      if (/FROM accounts WHERE user_id/i.test(sqlText) && /AND id = /i.test(sqlText)) {
+        // Real ciphertext we cannot decrypt because dek=null. Handler
+        // should fall back to `<encrypted>` in the success message.
+        return [{ id: 686, name_ct: "v1:abcd:efgh:ijkl", alias_ct: null }];
+      }
+      if (/COUNT\(\*\)/i.test(sqlText) && /FROM transactions/i.test(sqlText)) {
+        return [{ cnt: 0 }];
+      }
+      return [];
+    });
+    const tool = getDeleteAccountTool(db, null);
+    const result = await tool.handler({ accountId: 686 }, {});
+    const text = envelopeText(result);
+    expect(text).toMatch(/Account #686/);
+    // No literal "undefined" — that was part of the bug.
+    expect(text).not.toMatch(/undefined/);
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(1);
+  });
+
+  it("returns 404-style error when `accountId` does not match any row", async () => {
+    const { db, queries } = makeFixtureDb((sqlText) => {
+      if (/FROM accounts WHERE user_id/i.test(sqlText) && /AND id = /i.test(sqlText)) {
+        return []; // not found
+      }
+      return [];
+    });
+    const tool = getDeleteAccountTool(db, randomBytes(32));
+    const result = await tool.handler({ accountId: 99999 }, {});
+    const text = envelopeText(result);
+    expect(text).toMatch(/Account #99999 not found/);
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(0);
+  });
+
+  it("fails loud and does NOT delete when `accountId` and `account` resolve to different accounts", async () => {
+    const dek = randomBytes(32);
+    const accounts = [
+      fakeAccountRow(601, "Wealthsimple TFSA", dek),
+      fakeAccountRow(686, "_VERIFY_EUR_ACCOUNT_", dek),
+    ];
+    const { db, queries } = makeFixtureDb((sqlText) => {
+      if (/FROM accounts WHERE user_id/i.test(sqlText) && /AND id = /i.test(sqlText)) {
+        // accountId=601 path
+        return [accounts[0]];
+      }
+      if (/FROM accounts WHERE user_id/i.test(sqlText)) {
+        return accounts;
+      }
+      return [];
+    });
+    const tool = getDeleteAccountTool(db, dek);
+    const result = await tool.handler(
+      { accountId: 601, account: "_VERIFY_EUR_ACCOUNT_" },
+      {},
+    );
+    const text = envelopeText(result);
+    expect(text).toMatch(/Account mismatch/);
+    expect(text).toMatch(/_VERIFY_EUR_ACCOUNT_/);
+    expect(text).toMatch(/#686/);
+    expect(text).toMatch(/accountId=601/);
+    // No DELETE was issued.
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(0);
+  });
+
+  it("succeeds when `accountId` and `account` both resolve to the same account", async () => {
+    const dek = randomBytes(32);
+    const accounts = [
+      fakeAccountRow(601, "Wealthsimple TFSA", dek),
+      fakeAccountRow(686, "_VERIFY_EUR_ACCOUNT_", dek),
+    ];
+    const { db, queries } = makeFixtureDb((sqlText) => {
+      if (/FROM accounts WHERE user_id/i.test(sqlText) && /AND id = /i.test(sqlText)) {
+        return [accounts[1]]; // id=686
+      }
+      if (/FROM accounts WHERE user_id/i.test(sqlText)) {
+        return accounts;
+      }
+      if (/COUNT\(\*\)/i.test(sqlText) && /FROM transactions/i.test(sqlText)) {
+        return [{ cnt: 0 }];
+      }
+      return [];
+    });
+    const tool = getDeleteAccountTool(db, dek);
+    const result = await tool.handler(
+      { accountId: 686, account: "_VERIFY_EUR_ACCOUNT_" },
+      {},
+    );
+    const text = envelopeText(result);
+    expect(text).toMatch(/Account #686/);
+    expect(text).toMatch(/_VERIFY_EUR_ACCOUNT_/);
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(1);
+  });
+
+  it("blocks delete with a tx-count error when transactions exist and `force` is false", async () => {
+    const dek = randomBytes(32);
+    const { db, queries } = makeFixtureDb((sqlText) => {
+      if (/FROM accounts WHERE user_id/i.test(sqlText) && /AND id = /i.test(sqlText)) {
+        return [{ id: 686, name_ct: encryptField(dek, "_BUSY_"), alias_ct: null }];
+      }
+      if (/COUNT\(\*\)/i.test(sqlText) && /FROM transactions/i.test(sqlText)) {
+        return [{ cnt: 5 }];
+      }
+      return [];
+    });
+    const tool = getDeleteAccountTool(db, dek);
+    const result = await tool.handler({ accountId: 686 }, {});
+    const text = envelopeText(result);
+    expect(text).toMatch(/Account #686/);
+    expect(text).toMatch(/_BUSY_/);
+    expect(text).toMatch(/has 5 transaction\(s\). Pass force=true/);
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(0);
+  });
+
+  it("proceeds with `force=true` when transactions exist (FK CASCADE handles children)", async () => {
+    const dek = randomBytes(32);
+    const { db, queries } = makeFixtureDb((sqlText) => {
+      if (/FROM accounts WHERE user_id/i.test(sqlText) && /AND id = /i.test(sqlText)) {
+        return [{ id: 686, name_ct: encryptField(dek, "_FORCE_"), alias_ct: null }];
+      }
+      if (/COUNT\(\*\)/i.test(sqlText) && /FROM transactions/i.test(sqlText)) {
+        return [{ cnt: 5 }];
+      }
+      return [];
+    });
+    const tool = getDeleteAccountTool(db, dek);
+    const result = await tool.handler({ accountId: 686, force: true }, {});
+    const text = envelopeText(result);
+    expect(text).toMatch(/Account #686/);
+    expect(text).toMatch(/5 transactions also removed/);
+    expect(queries.filter((q) => /DELETE FROM accounts/i.test(q.text))).toHaveLength(1);
+  });
+
+  it("source verification: handler invokes invalidateUserTxCache after a successful DELETE", async () => {
+    // Behavioural assertions above can't reach the in-memory cache through
+    // the imported binding. This test pins the source string instead — the
+    // CLAUDE.md invariant "every MCP tx-mutating write must call
+    // invalidateUser(userId)" is verified by ensuring the call is in the
+    // handler. Locks against an accidental future removal.
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const file = path.join(__dirname, "../../mcp-server/register-tools-pg.ts");
+    const src = await fs.readFile(file, "utf8");
+    const idx = src.indexOf('"delete_account"');
+    expect(idx).toBeGreaterThan(0);
+    // Slice from the tool definition to the next tool boundary; assert
+    // the cache-invalidation call is in there.
+    const sliceEnd = src.indexOf("// ── update_goal", idx);
+    expect(sliceEnd).toBeGreaterThan(idx);
+    const handler = src.slice(idx, sliceEnd);
+    expect(handler).toMatch(/invalidateUserTxCache\(userId\)/);
+    // FK CASCADE comment present so future readers don't add redundant
+    // child-row DELETEs.
+    expect(handler).toMatch(/CASCADE/);
+  });
+});


### PR DESCRIPTION
Closes #230

## Summary

HOTFIX for a data-loss-risk bug class: HTTP MCP `delete_account` silently resolved an arbitrary first-row instead of the named account because it called `fuzzyFind` on rows carrying only encrypted `name_ct` / `alias_ct` (Stream D Phase 4) without first running `decryptNameish`. Every row had `o.name === undefined`, so the waterfall's last step `lo.includes(String(o.name ?? "").toLowerCase())` collapsed to `lo.includes("")` and returned `options[0]`. With `force=true` and FK CASCADE on `accounts → transactions / holding_accounts / goal_accounts`, a wrong-target call would have wiped every transaction, holding pairing, and goal link belonging to the wrong account.

Fix shape mirrors the closed #211 (`delete_budget` / `delete_loan`) and #214 (`create_rule`):
- New `accountId: number?` exact-match param (preferred; works without a DEK).
- Name path refuses without an unlocked DEK; runs `decryptNameish` BEFORE `fuzzyFind`.
- Mismatched `accountId` + `account` fails loud and does NOT delete.
- Success/error messages echo both `#<id>` and `("<name>")` — no more literal `Account 'undefined'`.
- `invalidateUserTxCache(userId)` after the DELETE, matching the `delete_budget` precedent.
- 11 new vitest cases including an adversarial-order regression that pins the live #230 repro.

## Docs updated

- CHANGELOG.md (always)
- CLAUDE.md "Auto-categorize SQL filters..." load-bearing gotcha extended with the audited resolver-class callsites (note: CLAUDE.md lives outside the repo at `C:/Users/halaw/Projects/PF/CLAUDE.md` so the edit is local-only, consistent with prior fixes #211 / #214 in this codebase).

## Promotion to main — required steps

- [x] Code-only change. Plain git merge dev is sufficient.
- [ ] MCP tool surface change is additive — `delete_account` gains one optional `accountId` param. Tool count unchanged at 90 HTTP / 86 stdio. Server version stays 3.0.0. After promotion, smoke `delete_account(accountId=<known>)` and `delete_account(account="_UNKNOWN_NAME_")` on prod MCP HTTP to confirm the new-param path is live and the suggestion-list error fires on misses.
- [ ] No new env var, cron, npm dep, CSP/middleware change, UI change, or backfill.
- [ ] Suggested smoke check on dev: confirm no unexpected production-side deletions hit since the regression deploy (the audit notes that the wrong-target id was deterministic per-session; a single user calling the tool repeatedly may have hit the same wrong id). Worth a quick `audit_log` / `transactions` count diff vs. last week's snapshot for the small set of users that have used the tool.

## How I tested

- `npx tsc --noEmit` clean
- `npm run build` passes
- `npx vitest run tests/mcp/delete-account.test.ts` — 11/11 pass