### PR TITLE
fix(mcp): surface goal progress fields + default liability group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## 2026-05-10 — MCP get_goals progress fields + liability-account group default (#233)
+
+Bug fixes for two LOW-priority surfaces flagged in `reviews/2026-05-10/08-goals-progress-and-account-group-shape.md` — original audit issues #46 (`get_goals` missing progress fields) and #2 (empty `group` on liability accounts), bundled per the issue plan.
+
+### Bug fixes
+- **MCP HTTP `get_goals` now returns `currentAmount`, `progress`, `percentComplete`, `remaining`, `monthlyNeeded`** per goal. The docstring has promised "with progress" since shipping but the response only carried ids + decrypted names. Implementation routes through a new shared helper `src/lib/goals-progress.ts` that REST `GET /api/goals` now also calls — single source of truth for the math, no drift between the two surfaces. Per-account branching on `accounts.is_investment` (CLAUDE.md issue #151), per-currency FX into the goal currency (issue #129), and the `getHoldingsValueByAccount`-vs-`SUM(transactions.amount)` rule (CLAUDE.md "Account balance for accounts with holdings = `holdings.value`") are owned by the helper. `percentComplete` is an alias of `progress` so callers writing against either field name keep working. Stdio `get_goals` continues to return ids + `accountIds` with `name: null` (no DEK on stdio, no Drizzle pg client either) — docstring updated to point HTTP for progress numbers.
+- **`add_account` defaults blank `group` to `"Liability"` for `type='L'` rows.** Pre-fix, MCP `add_account` wrote `${group ?? ""}` and the cash-flow-forecast partition surfaced these as `accountsExcluded.groupName: ""` because the coalesce only handled NULL, not empty string. Fix lives in `src/lib/queries.ts` `resolveDefaultGroup(type, group)` — applied inside `createAccount`/`updateAccount` (covers REST `POST/PUT /api/accounts`), and inlined in the MCP HTTP `add_account` insert. Asset accounts keep current behavior — empty group is meaningful for assets that haven't been categorized. `get_cash_flow_forecast` also gained a belt-and-suspenders trim-then-coalesce so any pre-existing blank-group rows fall through to `"(no group)"` until the operator runs the backfill SQL.
+- **One-time SQL backfill** in `pf-app/scripts/migrate-account-group-blank-2026-05-10.sql` for legacy liability rows. Per CLAUDE.md "destructive migrations still need the manual code-FIRST playbook", this lives in `scripts/` (NOT the auto-applied `scripts/migrations/` dir) and is run per env after the code fix is live. Idempotent.
+- **`finlynq_help` cribs updated** on both HTTP and stdio register files — new `get_goals` entry mentions the progress fields (HTTP) / explicitly disclaims them (stdio).
+
+### Files touched
+- [src/lib/goals-progress.ts](src/lib/goals-progress.ts) (NEW)
+- [src/lib/queries.ts](src/lib/queries.ts) — `resolveDefaultGroup` + `createAccount`/`updateAccount`
+- [src/app/api/goals/route.ts](src/app/api/goals/route.ts) — refactor onto helper
+- [mcp-server/register-tools-pg.ts](mcp-server/register-tools-pg.ts) — `get_goals` progress fields, `add_account` group default, `get_cash_flow_forecast` trim, `finlynq_help` crib
+- [mcp-server/register-core-tools.ts](mcp-server/register-core-tools.ts) — stdio docstring + `finlynq_help` crib
+- [scripts/migrate-account-group-blank-2026-05-10.sql](scripts/migrate-account-group-blank-2026-05-10.sql) (NEW)
+
+### Out of scope
+- Backfilling other blank fields (`note`, `alias` are intentionally optional).
+- Changing the goal-completion threshold.
+- Surfacing progress on `get_loans` or other read tools.
+
+Verification: `npx tsc --noEmit` clean, `npm run build` passes; manual MCP smoke pending against dev.
+
 ## 2026-05-10 — Validator-agent reliability re-probe: `[amount_overridden_by_entered]` warning (#232)
 
 Process check, no code change. Resolves the contradiction between the PR #224 validator-agent comment ("warning fires for `record_transaction(amount=-50, enteredAmount=-100, enteredCurrency=USD)` against a CAD account") and the 2026-05-10 auditor reading (`warnings: []`).

--- a/mcp-server/register-core-tools.ts
+++ b/mcp-server/register-core-tools.ts
@@ -515,7 +515,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
     async () => streamDRefuseRead("get_loans", "loans"),
   );
 
-  server.tool("get_goals", "Get all financial goals with progress. Stdio cannot decrypt names (no DEK on this transport) — `name` and per-account display names come back null. Each goal carries `accountIds: number[]` (issue #130 multi-account linking) — use HTTP MCP or the web UI to see the decrypted names.", {}, async () => {
+  server.tool("get_goals", "Get all financial goals. Stdio cannot decrypt names (no DEK on this transport) — `name` and per-account display names come back null. Each goal carries `accountIds: number[]` (issue #130 multi-account linking) — use HTTP MCP or the web UI to see decrypted names AND progress numbers (`currentAmount`, `progress`, `percentComplete`, `remaining`, `monthlyNeeded`). Stdio doesn't surface progress because the shared helper (issue #233) requires the Drizzle pg client and the holdings-value aggregator, neither of which are wired into the stdio transport.", {}, async () => {
     // Stream D Phase 4 — plaintext g.name and a.name dropped. Stdio has no
     // DEK, so we can't decrypt name_ct. Return ids only and let the caller
     // hop to HTTP MCP / web UI for names.
@@ -1722,6 +1722,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
           delete_account: "delete_account(account_id, force?) — stdio refuses `account` (name) post Stream D Phase 4; pass account_id (numeric).",
           add_goal: "add_goal(name, type, target_amount, deadline?, account?)",
           update_goal: "update_goal(goal, target_amount?, deadline?, status?, name?)",
+          get_goals: "get_goals() — Stdio returns ids + accountIds only (no decrypted names, no progress numbers per issue #233 — use HTTP MCP for `currentAmount`/`progress`/`percentComplete`).",
           delete_goal: "delete_goal(goal)",
           create_category: "create_category(name, type, group?, note?) — type: E/I/R",
           create_rule: "create_rule(match_payee, assign_category, rename_to?, assign_tags?, priority?)",

--- a/mcp-server/register-tools-pg.ts
+++ b/mcp-server/register-tools-pg.ts
@@ -91,6 +91,7 @@ import {
 } from "../src/lib/auto-categorize";
 import { decryptStaged, encryptStaged } from "../src/lib/crypto/staging-envelope";
 import { getHoldingsValueByAccount } from "../src/lib/holdings-value";
+import { computeGoalProgress } from "../src/lib/goals-progress";
 import { sourceTagFor, isFormatTag, type FormatTag } from "../src/lib/tx-source";
 import {
   validateSignVsCategory,
@@ -1599,9 +1600,9 @@ export function registerPgTools(
   );
 
   // ── get_goals ─────────────────────────────────────────────────────────────
-  server.tool("get_goals", "Get all financial goals with progress. Each goal carries `accountIds: number[]` (every linked account) and `accounts: string[]` (decrypted display names) — issue #130 multi-account linking.", {}, async () => {
+  server.tool("get_goals", "Get all financial goals with progress. Each goal carries `accountIds: number[]` (every linked account) and `accounts: string[]` (decrypted display names) — issue #130 multi-account linking. Numeric progress fields (issue #233): `currentAmount` (in goal currency, summed across linked accounts using market value for investment accounts and SUM(amount) for cash accounts, FX-converted into goal currency), `progress` and `percentComplete` (0..100, 1dp), `remaining`, `monthlyNeeded` (when a deadline is set).", {}, async () => {
     const goalsRaw = await q(db, sql`
-      SELECT g.id, g.name_ct, g.type, g.target_amount, g.deadline, g.status, g.priority
+      SELECT g.id, g.name_ct, g.type, g.target_amount, g.currency, g.deadline, g.status, g.priority
       FROM goals g
       WHERE g.user_id = ${userId}
       ORDER BY g.priority
@@ -1632,14 +1633,36 @@ export function registerPgTools(
       entry.names.push(acctName ?? "");
       linksByGoal.set(goalId, entry);
     }
+    // Issue #233 — surface progress numbers via the shared helper so MCP
+    // HTTP and REST `/api/goals` can't drift. Pure aggregation; no name
+    // decryption involved.
+    const progressByGoal = await computeGoalProgress(
+      userId,
+      dek,
+      goalsRaw.map((r) => ({
+        id: Number(r.id),
+        currency: (r.currency as string | null) ?? null,
+        targetAmount: Number(r.target_amount ?? 0),
+        deadline: (r.deadline as string | null) ?? null,
+        accountIds: linksByGoal.get(Number(r.id))?.ids ?? [],
+      })),
+    );
     const rows = goalsRaw.map((r) => {
       const { name_ct, ...rest } = r;
       const links = linksByGoal.get(Number(r.id)) ?? { ids: [], names: [] };
+      const progress = progressByGoal.get(Number(r.id));
       return {
         ...rest,
         name: name_ct && dek ? decryptField(dek, name_ct) : null,
         accountIds: links.ids,
         accounts: links.names,
+        currentAmount: progress?.currentAmount ?? 0,
+        progress: progress?.progress ?? 0,
+        // Alias matches the docstring's "with progress" promise; some
+        // existing consumers expect a literal `percentComplete` field.
+        percentComplete: progress?.progress ?? 0,
+        remaining: progress?.remaining ?? Number(r.target_amount ?? 0),
+        monthlyNeeded: progress?.monthlyNeeded ?? 0,
       };
     });
     return text(rows);
@@ -2348,9 +2371,14 @@ export function registerPgTools(
       }
 
       // Group out-of-scope by account group so the response is human-scannable.
+      // Issue #233 — coalesce empty string AND null to "(no group)" so legacy
+      // liability rows (group = '' from pre-#233 add_account writes) don't
+      // surface as empty `groupName` until the operator runs the backfill
+      // SQL.
       const excludedByGroup = new Map<string, number[]>();
       for (const a of outOfScope) {
-        const g = a.account_group ?? "(no group)";
+        const trimmed = (a.account_group ?? "").trim();
+        const g = trimmed ? trimmed : "(no group)";
         const list = excludedByGroup.get(g) ?? [];
         list.push(a.id);
         excludedByGroup.set(g, list);
@@ -2527,6 +2555,14 @@ export function registerPgTools(
       const aliasValue = alias && alias.trim() ? alias.trim() : null;
       const nameEnc = dek ? encryptName(dek, name) : { ct: null, lookup: null };
       const aliasEnc = dek ? encryptName(dek, aliasValue) : { ct: null, lookup: null };
+      // Issue #233 — liability accounts default to `"Liability"` when group
+      // is omitted/blank, matching the REST seam in `resolveDefaultGroup`.
+      // Asset accounts keep the historical empty-string behavior.
+      const resolvedGroup = (() => {
+        const trimmed = (group ?? "").trim();
+        if (trimmed) return trimmed;
+        return type === "L" ? "Liability" : "";
+      })();
       // Stream D Phase 4 — plaintext name/alias columns dropped.
       const result = await q(db, sql`
         INSERT INTO accounts (
@@ -2534,7 +2570,7 @@ export function registerPgTools(
           name_ct, name_lookup, alias_ct, alias_lookup
         )
         VALUES (
-          ${userId}, ${type}, ${group ?? ""}, ${currency ?? "CAD"}, ${note ?? ""},
+          ${userId}, ${type}, ${resolvedGroup}, ${currency ?? "CAD"}, ${note ?? ""},
           ${nameEnc.ct}, ${nameEnc.lookup}, ${aliasEnc.ct}, ${aliasEnc.lookup}
         )
         RETURNING id
@@ -4577,6 +4613,7 @@ export function registerPgTools(
           delete_account: "delete_account(accountId? OR account?, force?) — accountId for exact match (preferred, works without DEK); account is name/alias fuzzy (requires unlocked DEK). Pass exactly one. force=true deletes even if transactions exist.",
           add_goal: "add_goal(name, type, target_amount, deadline?, account?, account_ids?) — type: savings|debt_payoff|investment|emergency_fund. account_ids: number[] for multi-account linking (issue #130).",
           update_goal: "update_goal(goal, target_amount?, deadline?, status?, name?, account_ids?) — status: active|completed|paused. account_ids: replace linked-account set ([] = unlink all).",
+          get_goals: "get_goals() — Returns every goal with progress numbers (issue #233): currentAmount (in goal currency), progress and percentComplete (0..100, 1dp), remaining, monthlyNeeded. Investment accounts contribute market value; cash accounts contribute SUM(transactions.amount); each linked-account contribution is FX-converted into the goal currency.",
           delete_goal: "delete_goal(goal) — Fuzzy goal name.",
           create_category: "create_category(name, type, group?, note?) — type: 'E'=expense, 'I'=income, 'R'=transfer.",
           create_rule: "create_rule(match_payee, assign_category, rename_to?, assign_tags?, priority?) — match_payee supports % wildcards.",

--- a/scripts/migrate-account-group-blank-2026-05-10.sql
+++ b/scripts/migrate-account-group-blank-2026-05-10.sql
@@ -1,0 +1,29 @@
+-- Issue #233 — backfill blank `group` on liability accounts to "Liability".
+--
+-- Pre-fix code wrote `${group ?? ""}` from MCP `add_account` and silently
+-- accepted blank inputs from the REST `POST /api/accounts` schema, leaving
+-- `accounts.group = ''` for an unknown number of liability rows. The cash-
+-- flow forecast partition then surfaced these as `groupName: ""` because the
+-- coalesce only handled NULL, not empty string.
+--
+-- Code-side fix shipped first (issue #233): both writers default `type='L'`
+-- rows to `"Liability"` when `group` is missing/blank/whitespace-only, and
+-- the MCP forecast trims the column before coalescing as belt-and-suspenders.
+--
+-- Run order (per CLAUDE.md "code FIRST, then SQL"):
+--   1. Deploy the code fix (PR #234 / issue #233).
+--   2. After verifying the new write path, run this SQL on each env: dev
+--      first, prod second.
+--
+-- Idempotent: the WHERE clause excludes already-fixed rows. Safe to re-run.
+
+BEGIN;
+
+-- Note: `accounts` table has no `updated_at` column today. If/when one is
+-- added, append `, updated_at = NOW()` to the SET clause.
+UPDATE accounts
+   SET "group" = 'Liability'
+ WHERE type = 'L'
+   AND ("group" IS NULL OR btrim("group") = '');
+
+COMMIT;

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db, schema } from "@/db";
-import { eq, and, sql, inArray } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { requireAuth } from "@/lib/auth/require-auth";
 import { z } from "zod";
 import { validateBody, safeErrorMessage, AppError } from "@/lib/validate";
 import { buildNameFields, decryptNamedRows } from "@/lib/crypto/encrypted-columns";
-import { getHoldingsValueByAccount } from "@/lib/holdings-value";
-import { getLatestFxRate } from "@/lib/fx-service";
+import { computeGoalProgress } from "@/lib/goals-progress";
 
 const postSchema = z.object({
   name: z.string(),
@@ -155,123 +154,36 @@ export async function GET(request: NextRequest) {
   // Calculate current amount summed across ALL linked accounts (issue #130).
   // JOIN grain is `(goal_id, account_id, user_id)` — see CLAUDE.md.
   //
-  // Issue #151: branch on `accounts.is_investment` per linked account.
-  //   - Investment accounts: use market value from `getHoldingsValueByAccount`
-  //     (same aggregator the dashboard / accounts page uses). Cash sleeve is
-  //     already inside `holdings.value` via the currency-as-holding pattern,
-  //     so this matches the accounts-page balance for the same account.
-  //   - Cash accounts: keep `SUM(transactions.amount)` path (unchanged).
-  // Each per-account contribution is FX-converted into the goal's currency
-  // before summing — multi-currency goals (e.g. CAD goal linked to a USD
-  // account) now report a meaningful `progress = currentAmount / targetAmount`.
-  // CLAUDE.md "Account balance for accounts with holdings = `holdings.value`"
-  // is the same rule the goals page now follows.
-
-  // Resolve the union of linked account ids across all goals so we hit the
-  // metadata table once instead of once per goal.
-  const allAccountIds = Array.from(
-    new Set(goals.flatMap((g) => g.accountIds)),
+  // Issue #233: extracted into the shared `computeGoalProgress` helper so the
+  // MCP HTTP `get_goals` tool can return the same progress numbers as REST.
+  // Per-account branching on `accounts.is_investment` (CLAUDE.md issue #151)
+  // and per-currency FX into the goal currency (issue #129) are owned by the
+  // helper.
+  const progressByGoal = await computeGoalProgress(
+    userId,
+    auth.context.dek,
+    goals.map((g) => ({
+      id: g.id,
+      currency: g.currency ?? null,
+      targetAmount: g.targetAmount,
+      deadline: g.deadline ?? null,
+      accountIds: g.accountIds,
+    })),
   );
-  const accountMeta: Map<number, { currency: string; isInvestment: boolean }> =
-    allAccountIds.length > 0
-      ? new Map(
-          (
-            await db
-              .select({
-                id: schema.accounts.id,
-                currency: schema.accounts.currency,
-                isInvestment: schema.accounts.isInvestment,
-              })
-              .from(schema.accounts)
-              .where(
-                and(
-                  eq(schema.accounts.userId, userId),
-                  inArray(schema.accounts.id, allAccountIds),
-                ),
-              )
-          ).map((a) => [a.id, { currency: a.currency, isInvestment: !!a.isInvestment }]),
-        )
-      : new Map();
 
-  // Pull the holdings-value snapshot once (shared across goals). Internally
-  // it computes per-account market value with full per-currency cost-basis
-  // bucketing (issue #129) and cash-leg substitution (issue #96).
-  const holdingsByAccount = await getHoldingsValueByAccount(userId, auth.context.dek);
-
-  // Per-account cash-flow basis (cash accounts only). One query, grouped by
-  // accountId — same SUM the legacy code computed but batched.
-  const cashRows = allAccountIds.length > 0
-    ? await db
-        .select({
-          accountId: schema.transactions.accountId,
-          total: sql<number>`COALESCE(SUM(${schema.transactions.amount}), 0)::float8`,
-        })
-        .from(schema.transactions)
-        .where(
-          and(
-            eq(schema.transactions.userId, userId),
-            inArray(schema.transactions.accountId, allAccountIds),
-          ),
-        )
-        .groupBy(schema.transactions.accountId)
-    : [];
-  const cashByAccount = new Map<number, number>();
-  for (const r of cashRows) {
-    if (r.accountId == null) continue;
-    cashByAccount.set(r.accountId, Number(r.total ?? 0));
-  }
-
-  // FX cache shared across goals — most users have ≤3 distinct currencies.
-  const fxCache = new Map<string, number>();
-  const getFx = async (from: string, to: string): Promise<number> => {
-    if (from === to) return 1;
-    const key = `${from}->${to}`;
-    if (fxCache.has(key)) return fxCache.get(key)!;
-    const rate = await getLatestFxRate(from, to, userId);
-    fxCache.set(key, rate);
-    return rate;
-  };
-
-  const withProgress = await Promise.all(goals.map(async (g) => {
-    let currentAmount = 0;
-    const goalCurrency = (g.currency ?? "CAD").toUpperCase();
-    for (const accountId of g.accountIds) {
-      const meta = accountMeta.get(accountId);
-      if (!meta) continue; // account got deleted under us; skip silently
-      // Investment accounts: holdings.value (market value) in account currency.
-      // Cash accounts: transaction sum in account currency.
-      let valueInAccountCcy: number;
-      if (meta.isInvestment) {
-        valueInAccountCcy = holdingsByAccount.get(accountId)?.value ?? 0;
-      } else {
-        valueInAccountCcy = cashByAccount.get(accountId) ?? 0;
-      }
-      const fx = await getFx(meta.currency, goalCurrency);
-      currentAmount += valueInAccountCcy * fx;
-    }
-
-    const progress = g.targetAmount > 0 ? Math.min((currentAmount / g.targetAmount) * 100, 100) : 0;
-    const remaining = Math.max(g.targetAmount - currentAmount, 0);
-
-    let monthlyNeeded = 0;
-    if (g.deadline && remaining > 0) {
-      const now = new Date();
-      const deadline = new Date(g.deadline + "T00:00:00");
-      const monthsLeft = Math.max(
-        (deadline.getFullYear() - now.getFullYear()) * 12 + deadline.getMonth() - now.getMonth(),
-        1
-      );
-      monthlyNeeded = Math.round((remaining / monthsLeft) * 100) / 100;
-    }
-
+  const withProgress = goals.map((g) => {
+    const p = progressByGoal.get(g.id);
     return {
       ...g,
-      currentAmount: Math.round(currentAmount * 100) / 100,
-      progress: Math.round(progress * 10) / 10,
-      remaining: Math.round(remaining * 100) / 100,
-      monthlyNeeded,
+      currentAmount: p?.currentAmount ?? 0,
+      progress: p?.progress ?? 0,
+      // Issue #233: alias `percentComplete` matches the MCP `get_goals`
+      // docstring's "with progress" promise. Same number as `progress`.
+      percentComplete: p?.progress ?? 0,
+      remaining: p?.remaining ?? g.targetAmount,
+      monthlyNeeded: p?.monthlyNeeded ?? 0,
     };
-  }));
+  });
 
   return NextResponse.json(withProgress);
 }

--- a/src/lib/goals-progress.ts
+++ b/src/lib/goals-progress.ts
@@ -1,0 +1,167 @@
+/**
+ * Shared goal-progress aggregator.
+ *
+ * Used by REST `GET /api/goals` and MCP HTTP `get_goals`. Computes
+ * `currentAmount` (in goal currency), `progress` (0..100, 1dp),
+ * `remaining` (cents), and `monthlyNeeded` per goal.
+ *
+ * Per-account branching follows CLAUDE.md "Account balance for accounts with
+ * holdings = `holdings.value`, NOT `b.balance + holdings.value`":
+ *   - `accounts.is_investment=true` ⇒ market value from
+ *     `getHoldingsValueByAccount` (cash sleeve already inside `holdings.value`
+ *     via the currency-as-holding pattern).
+ *   - cash accounts ⇒ SUM(transactions.amount).
+ *
+ * Each per-account contribution is FX-converted into the goal currency before
+ * summing — multi-currency goals (e.g. CAD goal linked to a USD account)
+ * report a meaningful progress ratio. Triangulated through USD by the FX
+ * engine; same-currency hits the `from === to => 1.0` short-circuit.
+ *
+ * Pure aggregation: no name decryption needed. Numeric only. Safe to call
+ * with `dek=null` if the caller can supply one (REST does; MCP HTTP does too)
+ * — `getHoldingsValueByAccount` will fall back to nulls for any name/symbol
+ * it can't decrypt and still compute market value via the encrypted-name
+ * lookup path.
+ */
+
+import { db, schema } from "@/db";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { getHoldingsValueByAccount } from "@/lib/holdings-value";
+import { getLatestFxRate } from "@/lib/fx-service";
+
+export type GoalProgressInput = {
+  id: number;
+  currency: string | null;
+  targetAmount: number;
+  deadline: string | null;
+  accountIds: number[];
+};
+
+export type GoalProgressOutput = {
+  goalId: number;
+  currentAmount: number;
+  progress: number;
+  remaining: number;
+  monthlyNeeded: number;
+};
+
+/**
+ * Compute progress for a batch of goals belonging to one user. Issues a
+ * fixed number of queries regardless of goal count (account meta + cash sums
+ * + holdings snapshot + an FX cache).
+ */
+export async function computeGoalProgress(
+  userId: string,
+  dek: Buffer | null,
+  goals: GoalProgressInput[],
+): Promise<Map<number, GoalProgressOutput>> {
+  const out = new Map<number, GoalProgressOutput>();
+  if (!goals.length) return out;
+
+  const allAccountIds = Array.from(
+    new Set(goals.flatMap((g) => g.accountIds)),
+  );
+
+  const accountMeta: Map<number, { currency: string; isInvestment: boolean }> =
+    allAccountIds.length > 0
+      ? new Map(
+          (
+            await db
+              .select({
+                id: schema.accounts.id,
+                currency: schema.accounts.currency,
+                isInvestment: schema.accounts.isInvestment,
+              })
+              .from(schema.accounts)
+              .where(
+                and(
+                  eq(schema.accounts.userId, userId),
+                  inArray(schema.accounts.id, allAccountIds),
+                ),
+              )
+          ).map((a) => [a.id, { currency: a.currency, isInvestment: !!a.isInvestment }]),
+        )
+      : new Map();
+
+  // Pull the holdings-value snapshot once. Internally it computes per-account
+  // market value with full per-currency cost-basis bucketing (issue #129) and
+  // cash-leg substitution (issue #96).
+  const holdingsByAccount = await getHoldingsValueByAccount(userId, dek);
+
+  // Per-account cash-flow basis (cash accounts only). One query, grouped by
+  // accountId.
+  const cashByAccount = new Map<number, number>();
+  if (allAccountIds.length > 0) {
+    const cashRows = await db
+      .select({
+        accountId: schema.transactions.accountId,
+        total: sql<number>`COALESCE(SUM(${schema.transactions.amount}), 0)::float8`,
+      })
+      .from(schema.transactions)
+      .where(
+        and(
+          eq(schema.transactions.userId, userId),
+          inArray(schema.transactions.accountId, allAccountIds),
+        ),
+      )
+      .groupBy(schema.transactions.accountId);
+    for (const r of cashRows) {
+      if (r.accountId == null) continue;
+      cashByAccount.set(r.accountId, Number(r.total ?? 0));
+    }
+  }
+
+  // FX cache shared across goals — most users have ≤3 distinct currencies.
+  const fxCache = new Map<string, number>();
+  const getFx = async (from: string, to: string): Promise<number> => {
+    if (from === to) return 1;
+    const key = `${from}->${to}`;
+    if (fxCache.has(key)) return fxCache.get(key)!;
+    const rate = await getLatestFxRate(from, to, userId);
+    fxCache.set(key, rate);
+    return rate;
+  };
+
+  for (const g of goals) {
+    const goalCurrency = (g.currency ?? "CAD").toUpperCase();
+    let currentAmount = 0;
+    for (const accountId of g.accountIds) {
+      const meta = accountMeta.get(accountId);
+      if (!meta) continue; // account got deleted under us; skip silently
+      const valueInAccountCcy = meta.isInvestment
+        ? holdingsByAccount.get(accountId)?.value ?? 0
+        : cashByAccount.get(accountId) ?? 0;
+      const fx = await getFx(meta.currency, goalCurrency);
+      currentAmount += valueInAccountCcy * fx;
+    }
+
+    const progress =
+      g.targetAmount > 0
+        ? Math.min((currentAmount / g.targetAmount) * 100, 100)
+        : 0;
+    const remaining = Math.max(g.targetAmount - currentAmount, 0);
+
+    let monthlyNeeded = 0;
+    if (g.deadline && remaining > 0) {
+      const now = new Date();
+      const deadline = new Date(g.deadline + "T00:00:00");
+      const monthsLeft = Math.max(
+        (deadline.getFullYear() - now.getFullYear()) * 12 +
+          deadline.getMonth() -
+          now.getMonth(),
+        1,
+      );
+      monthlyNeeded = Math.round((remaining / monthsLeft) * 100) / 100;
+    }
+
+    out.set(g.id, {
+      goalId: g.id,
+      currentAmount: Math.round(currentAmount * 100) / 100,
+      progress: Math.round(progress * 10) / 10,
+      remaining: Math.round(remaining * 100) / 100,
+      monthlyNeeded,
+    });
+  }
+
+  return out;
+}

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -47,8 +47,29 @@ type AccountWrite = {
   aliasLookup?: string | null;
 };
 
+/**
+ * Issue #233 — liability accounts that come in with a blank `group` are
+ * silently surfaced as `groupName: ""` in `get_cash_flow_forecast`'s
+ * `accountsExcluded` partition (the coalesce treats "" as truthy). Default
+ * `type='L'` rows whose `group` is missing/blank/whitespace-only to
+ * `"Liability"`. Asset accounts keep current behavior — empty group is a
+ * meaningful "uncategorized" state for assets.
+ */
+export function resolveDefaultGroup(
+  type: string,
+  group: string | null | undefined,
+): string {
+  const trimmed = (group ?? "").trim();
+  if (trimmed) return trimmed;
+  return type === "L" ? "Liability" : "";
+}
+
 export async function createAccount(userId: string, data: AccountWrite) {
-  return db.insert(accounts).values({ ...data, userId }).returning().get();
+  const normalized: AccountWrite = {
+    ...data,
+    group: resolveDefaultGroup(data.type, data.group),
+  };
+  return db.insert(accounts).values({ ...normalized, userId }).returning().get();
 }
 
 export async function updateAccount(
@@ -56,7 +77,19 @@ export async function updateAccount(
   userId: string,
   data: Partial<AccountWrite & { archived: boolean; isInvestment: boolean }>,
 ) {
-  return db.update(accounts).set(data).where(and(eq(accounts.id, id), eq(accounts.userId, userId))).returning().get();
+  // Apply the same default when the caller supplies `group` explicitly. We
+  // only touch it when `group` is in the payload — leaving an unset group
+  // untouched is correct semantics for partial updates.
+  let normalized = data;
+  if (Object.prototype.hasOwnProperty.call(data, "group")) {
+    // We need the row's `type` to know whether the liability default applies
+    // when the caller didn't also supply `type`. Read once from the existing
+    // row.
+    const existingType =
+      data.type ?? (await getAccountById(id, userId))?.type ?? "A";
+    normalized = { ...data, group: resolveDefaultGroup(existingType, data.group) };
+  }
+  return db.update(accounts).set(normalized).where(and(eq(accounts.id, id), eq(accounts.userId, userId))).returning().get();
 }
 
 export async function deleteAccount(id: number, userId: string) {


### PR DESCRIPTION
Closes #233

## Summary
- HTTP MCP `get_goals` now returns `currentAmount`, `progress`, `percentComplete`, `remaining`, `monthlyNeeded` per goal via a new shared helper `src/lib/goals-progress.ts` that REST `/api/goals` now also calls (single source of truth, no drift).
- `add_account` defaults blank `group` to `"Liability"` for `type='L'` rows. `get_cash_flow_forecast` gained a belt-and-suspenders trim-then-coalesce so legacy blank-group rows surface as `"(no group)"` until the operator runs the SQL backfill.
- One-time SQL backfill at `scripts/migrate-account-group-blank-2026-05-10.sql` for legacy liability rows. Idempotent. Kept out of the auto-applied `scripts/migrations/` per CLAUDE.md "destructive migrations still need the manual code-FIRST playbook".
- Stdio `get_goals` continues to return ids + accountIds with `name: null` (no DEK + no Drizzle pg client on that transport). Docstring updated to point HTTP for progress numbers.

## Docs updated
- CHANGELOG.md (always)

## Promotion to main — required steps
- [ ] After deploy to dev verifies the new write path, run `pf-app/scripts/migrate-account-group-blank-2026-05-10.sql` per env (dev first, prod second) to backfill legacy liability rows whose `group` is `''` or NULL.

## How I tested
- npx tsc --noEmit ✓ (clean)
- npm run build ✓