### PR TITLE
fix(mcp): get_investment_insights full-portfolio scoping + valuationGL + label fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Versioning: [Semantic Versioning](https://semver.org/)
 
 ## [Unreleased]
 
+## 2026-05-10 — MCP `get_investment_insights`: full-portfolio scoping + valuationGL fall-through + label fix (#236)
+
+Three residual defects in MCP HTTP `get_investment_insights` after PR #228 (issue #209) — all surfaced by the auditor's reviews/2026-05-10/04-portfolio-analysis-fullscope-and-label-fixes.md.
+
+### Bug fixes
+
+- **Drop the `buysOnly` SQL pre-filter from `aggregateHoldings()`.** The `mode='patterns'` and `mode='rebalancing'` branches of `get_investment_insights` previously called `aggregateHoldings(..., { buysOnly: true })`, which pre-filtered `t.amount < 0`. That violated the four-aggregator alignment invariant (CLAUDE.md "Portfolio aggregator: qty>0 is a buy regardless of amount sign") and silently dropped every WP-imported buy row (Finlynq-native is `amt<0+qty>0`, WP convention is `amt>0+qty>0`). Symptom: `summary.totalInvested` reported the subset of holdings whose buy rows happened to have `amount < 0` ($32,678.92 in the audit repro) against ~$580k of additional WP-imported holdings the user actually owns. Fix removes the opt entirely from the function signature so it can't be re-introduced; the buy-bucket semantic is preserved by `accumulate()`'s `qty > 0` branch — `a.buy_amount` only accumulates from rows where `qty > 0`. After the fix, `totalInvested` reduces over the FULL `positions` array and reconciles to `get_portfolio_analysis.summary.lifetimeCostBasisReporting` for the same user. The rebalancing `untargetedHoldings` block is preserved and now reports the correct count + book value of genuinely-untargeted holdings.
+
+- **`unrealized.accounts[].valuationGL` start==end fall-through.** When `start.marketValueNative === end.marketValueNative` AND `start.costBasisNative === end.costBasisNative`, both `*AtDate` values equal `(market - cost) * fx` and the period delta rounds to 0. For inactive holdings whose cost basis ≠ market value (audit repro: account id 612, costBasis 2920.27, marketValue 2918.04, expected `valuationGL ≈ -2.23`), the open UGL was being silently dropped. The period semantic now falls through to the cumulative-since-acquisition figure when `Math.abs(period delta) < 0.005 AND Math.abs(end.valuationGLAtDate) >= 0.005`. Each per-account row carries a new `valuationGLBasis: 'period' | 'cumulative'` field that discloses which semantic produced the value, so consumers can reconcile. Brand-new holdings near par (cumulative ~ 0 too) keep `valuationGL: 0` with `basis: 'period'` — only the start==end-but-non-zero-cumulative edge is rerouted.
+
+- **`unrealized.accounts[].accountCurrency` label drift (non-breaking).** Every monetary field on the per-account row (`costBasis` / `marketValue` / `valuationGL` / `fxGL` / `totalGL` / `startMarketValue` / `endMarketValue`) is FX-converted to the reporting currency by `roundMoney(..., reporting)`, but the row was labeled with the underlying account's ISO code (e.g. `accountCurrency: 'USD'` while the values were CAD-converted). The new authoritative field is `reportingCurrency: a.displayCurrency`; `accountCurrency` is kept as a deprecated alias for one release with a JSDoc warning. The full BREAKING rename will land alongside the 3.x envelope unification (issue #237) — coordinate any consumer migration to read `reportingCurrency` first to avoid a hard cutover.
+
+### Docs
+
+- **CLAUDE.md "Portfolio aggregator" load-bearing paragraph extended** — appended a note that `get_investment_insights` (HTTP-only, modes `patterns` + `rebalancing`) is the fifth caller of the canonical aggregator and inherits the invariant. **DO NOT pre-filter `t.amount < 0` in `aggregateHoldings()` SQL or any new aggregator path** — buy-classification is `accumulate()`'s job, keying on `qty > 0` direction. Adding the filter back silently drops WP-imported buys.
+
+### Files touched
+
+- `pf-app/mcp-server/register-tools-pg.ts` — `aggregateHoldings()` signature + SQL (drop `buysOnly`); two `aggregateHoldings(...)` callsites in `get_investment_insights`; `unrealized.accounts[]` response shape (add `reportingCurrency` + `valuationGLBasis`, mark `accountCurrency` deprecated)
+- `pf-app/src/lib/unrealized-pnl.ts` — `UnrealizedPnL` type (add `valuationGLBasis`); `computeAllAccountsUnrealizedPnL` (start==end fall-through)
+- `pf-app/CHANGELOG.md` — this entry
+- `CLAUDE.md` — extend "Portfolio aggregator" load-bearing paragraph
+
 ## 2026-05-10 — MCP read tools: financial-health math, recurring staleness, cash-flow attribution (#235)
 
 Fixes the residual math + UX defects in three MCP aggregator tools that PR #228 (issue #210) didn't touch. Auditor file: `reviews/2026-05-10/07-readtool-aggregator-math-and-staleness.md`.

--- a/mcp-server/register-tools-pg.ts
+++ b/mcp-server/register-tools-pg.ts
@@ -868,11 +868,19 @@ async function aggregateHoldings(
   db: DbLike,
   userId: string,
   dek: Buffer | null,
-  opts?: { buysOnly?: boolean; since?: string; dividendsCategoryId?: number | null }
+  opts?: { since?: string; dividendsCategoryId?: number | null }
 ): Promise<(HoldingAggRow & { tx_count: number; net_quantity: number; last_activity: string | null; holding_id: number | null; currency: string })[]> {
-  const buysFilter = opts?.buysOnly
-    ? sql`AND t.amount < 0`
-    : sql``;
+  // Issue #236 (2026-05-10): the legacy `buysOnly: true` opt SQL-prefiltered
+  // `t.amount < 0`, which silently dropped every WP-imported buy row
+  // (Finlynq-native is `amt<0+qty>0`, WP convention is `amt>0+qty>0`). Buy
+  // classification is `accumulate()`'s job — keying off `qty>0` per the
+  // CLAUDE.md "Portfolio aggregator" invariant — and consumers that want
+  // only the buy bucket read `a.buy_amount` (which `accumulate()` only
+  // populates for `qty > 0` rows). Removing the opt entirely is safer than
+  // leaving a footgun: a future caller passing `buysOnly: true` would
+  // re-introduce the WP-drop bug. The patterns + rebalancing modes of
+  // `get_investment_insights` (the only previous callers) now use the
+  // canonical aggregator and reconcile against `get_portfolio_analysis`.
   const dateFilter = opts?.since ? sql`AND t.date >= ${opts.since}` : sql``;
   const dividendsCategoryId = opts?.dividendsCategoryId ?? null;
 
@@ -934,7 +942,6 @@ async function aggregateHoldings(
      AND COALESCE(cash.quantity, 0) = 0
     WHERE t.user_id = ${userId}
       AND t.portfolio_holding_id IS NOT NULL
-      ${buysFilter}
       ${dateFilter}
   `);
 
@@ -1468,12 +1475,27 @@ export function registerPgTools(
             .map((a) => ({
               accountId: a.accountId,
               accountName: a.accountName,
+              // Issue #236 (2026-05-10): every monetary field on this row
+              // is converted to the reporting currency by `roundMoney(...,
+              // reporting)`, but the legacy field name was `accountCurrency`
+              // which suggested they were in the account's native currency.
+              // The label drift is fixed non-breakingly: `reportingCurrency`
+              // is the new authoritative label, `accountCurrency` is kept
+              // as a deprecated alias for one release. Future bumps may
+              // rename in 3.x BREAKING (see issue #237).
+              reportingCurrency: a.displayCurrency,
+              /** @deprecated since 2026-05-10 (issue #236) — use `reportingCurrency`. The values are in reporting currency, NOT this account's native currency. Will be removed in a future BREAKING release. */
               accountCurrency: a.accountCurrency,
               // periodEnd snapshot for context — already in reporting ccy
               costBasis: roundMoney(a.end.costBasis, reporting),
               marketValue: roundMoney(a.end.marketValue, reporting),
-              // Period delta = end_snapshot - start_snapshot, what moved
+              // Period delta = end_snapshot - start_snapshot, what moved.
+              // Issue #236: when start==end AND cost basis ≠ market value,
+              // `valuationGL` falls through to the cumulative open UGL so
+              // inactive holdings still surface a non-zero figure.
+              // `valuationGLBasis` discloses which semantic was used.
               valuationGL: roundMoney(a.valuationGL, reporting),
+              valuationGLBasis: a.valuationGLBasis,
               fxGL: roundMoney(a.fxGL, reporting),
               totalGL: roundMoney(a.totalGL, reporting),
               startMarketValue: roundMoney(a.start.marketValue, reporting),
@@ -6570,7 +6592,11 @@ export function registerPgTools(
 
       if (m === "rebalancing") {
         if (!targets?.length) return err("targets is required when mode='rebalancing'");
-        const aggs = await aggregateHoldings(db, userId, dek, { buysOnly: true });
+        // Issue #236: drop the `buysOnly: true` SQL pre-filter — it silently
+        // dropped WP-imported buys (`amt>0+qty>0`). `accumulate()` already
+        // populates `buy_amount` only for `qty > 0` rows, so the buy-bucket
+        // semantic is preserved.
+        const aggs = await aggregateHoldings(db, userId, dek);
         // Convert each holding's book_value to reporting currency before
         // building the allocation map — otherwise mixing CAD + USD book
         // values produces nonsense percentages.
@@ -6794,7 +6820,9 @@ export function registerPgTools(
         .slice(-12)
         .map(([month, invested]) => ({ month, invested: Math.round(invested * 100) / 100 }));
 
-      const aggs = await aggregateHoldings(db, userId, dek, { buysOnly: true });
+      // Issue #236: drop the `buysOnly: true` SQL pre-filter — see the
+      // mode='rebalancing' branch above for the full rationale.
+      const aggs = await aggregateHoldings(db, userId, dek);
       // Issue #86: aggregator now returns one row per holding_id. For the
       // top-positions display, sum book_value across same-name rows so
       // VUN.TO across TFSA + RRSP shows as a single "VUN.TO" line item with

--- a/src/lib/unrealized-pnl.ts
+++ b/src/lib/unrealized-pnl.ts
@@ -59,6 +59,16 @@ export type UnrealizedPnL = {
   fxGL: number;
   totalGL: number;
 
+  // Issue #236 (2026-05-10): when the period delta rounds to 0 but the
+  // cumulative-since-acquisition UGL is non-zero (an "inactive holding"
+  // whose cost basis ≠ market value AND the price didn't move in the
+  // window), `valuationGL` falls through to the cumulative figure so the
+  // open UGL surfaces in income-statement reports. `valuationGLBasis`
+  // discloses which semantic produced the value:
+  //   "period"     — strict end - start delta (default; non-zero deltas)
+  //   "cumulative" — delta rounded to 0, fell through to end.valuationGLAtDate
+  valuationGLBasis: "period" | "cumulative";
+
   hasHoldings: boolean;
   costBasisMissing: boolean;
 };
@@ -187,7 +197,22 @@ export async function computeAllAccountsUnrealizedPnL(
 
     // Period delta — what the user asked for: "this period - last period".
     // Valuation: cumulative UGL moved between snapshots.
-    const valuationGL = end.valuationGLAtDate - start.valuationGLAtDate;
+    let valuationGL = end.valuationGLAtDate - start.valuationGLAtDate;
+    let valuationGLBasis: "period" | "cumulative" = "period";
+    // Issue #236 (2026-05-10): when the period delta rounds to 0 but the
+    // cumulative-since-acquisition UGL is non-zero (an inactive holding
+    // whose cost basis ≠ market value AND the price didn't move during the
+    // window), surface the cumulative figure so income-statement consumers
+    // can see open UGL. Without this fall-through, a holding like the audit
+    // repro (cost 2920.27, mv 2918.04 with start==end) reported
+    // `valuationGL: 0` even though there is a real -2.23 unrealized loss
+    // sitting on the books. Conjunctive guard so legitimate quiescent
+    // holdings (cumulative ~ 0 too, e.g. brand-new buy at par) keep
+    // `valuationGL: 0` with basis="period".
+    if (Math.abs(valuationGL) < 0.005 && Math.abs(end.valuationGLAtDate) >= 0.005) {
+      valuationGL = end.valuationGLAtDate;
+      valuationGLBasis = "cumulative";
+    }
     // FX: holding the same balance over the period × the FX move. This
     // captures "how much CAD value of a USD account changed because USD/CAD
     // moved", independent of price changes.
@@ -214,6 +239,7 @@ export async function computeAllAccountsUnrealizedPnL(
       valuationGL,
       fxGL,
       totalGL,
+      valuationGLBasis,
       hasHoldings,
       costBasisMissing,
     });


### PR DESCRIPTION
Closes #236

## Summary

Three residual defects in MCP HTTP `get_investment_insights` after PR #228 (closed parent #209):

- **§A — `mode='patterns'` / `mode='rebalancing'` were calling `aggregateHoldings(..., { buysOnly: true })`**, which SQL-prefiltered `t.amount < 0` and silently dropped every WP-imported buy row (WP convention is `amt>0+qty>0`). Violates the four-aggregator alignment invariant in CLAUDE.md ("Portfolio aggregator: `qty>0` is a buy regardless of amount sign"). The opt is removed entirely from the function signature so it can't be re-introduced; the buy-bucket semantic is preserved by `accumulate()`'s `qty > 0` branch — `a.buy_amount` only accumulates from `qty > 0` rows. After the fix, `summary.totalInvested` (patterns) and `totalPortfolioValue` (rebalancing) reduce over the FULL portfolio and reconcile against `get_portfolio_analysis.summary.lifetimeCostBasisReporting`.
- **§C — `unrealized.accounts[].valuationGL` start==end fall-through.** When the period delta rounds to 0 but the cumulative-since-acquisition UGL is non-zero (inactive holding whose cost basis ≠ market value AND price didn't move during the window), the open UGL was being silently dropped (audit repro: account 612, costBasis 2920.27, mv 2918.04, expected `valuationGL ≈ -2.23`). New behaviour falls through to the cumulative figure when `Math.abs(period delta) < 0.005 AND Math.abs(end.valuationGLAtDate) >= 0.005`. Each row now carries `valuationGLBasis: 'period' | 'cumulative'` to disclose which semantic produced the value.
- **§D — `unrealized.accounts[].accountCurrency` label drift (non-breaking).** Every monetary field on the row was FX-converted to reporting currency, but the row was labeled with the account's ISO code (e.g. `accountCurrency: 'USD'` while values were CAD-converted). New authoritative field is `reportingCurrency: a.displayCurrency`; `accountCurrency` kept as deprecated alias for one release. The full BREAKING rename will land alongside the 3.x envelope unification (issue #237).

## Docs updated

- CHANGELOG.md (always)
- CLAUDE.md "Portfolio aggregator" load-bearing paragraph — appended an explicit DO-NOT-pre-filter rule for `aggregateHoldings()` so future contributors don't re-introduce the WP-drop bug

## Promotion to main — required steps

- [x] **MCP tool surface unchanged** — same 90 HTTP / 86 stdio tools. Response shape changes are additive (new `reportingCurrency` + `valuationGLBasis` fields) plus one deprecation; no consumer migration is forced this release.
- [x] No env var, cron, npm dep, CSP/middleware, UI, or data-backfill changes.
- [x] Plain `git merge dev` is sufficient.

## How I tested

- `npx tsc --noEmit` ✓ (clean)
- `npm run build` ✓
- Verified `aggregateHoldings()` has no other callers passing `buysOnly: true` (Grep — only the two `get_investment_insights` sites; they now pass no opts at all).
- Verified `valuationGLBasis` is propagated from helper through to MCP response shape; non-MCP REST `/api/reports` consumer still compiles (new field is optional consumption).