### PR TITLE
test: unlock DEK in shared test auth helper (FINLYNQ-7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning: [Semantic Versioning](https://semver.org/)
 - Add public Terms of Service at `/terms` covering the managed cloud service. Required for Anthropic Connectors Directory submission Page 6 attestation. AGPL v3 governs self-hosted use of the source; these Terms govern finlynq.com only.
 - Add Troubleshooting section to public `/mcp-guide` covering connection failures (401/403/423), OAuth stuck, stale data, self-hosted gotchas (`PF_USER_ID`, Stream D Phase 4 stdio refusals). Eight collapsible `<details>` entries lifted from `docs/faq.md` plus a closing GitHub-issues triage line. Required for Anthropic Connectors Directory submission Page 6 documentation attestation — the page now satisfies all three sub-requirements (setup + tool descriptions + troubleshooting).
 
+## 2026-05-17 — test hygiene: shared test auth helper unlocks DEK (FINLYNQ-7)
+
+Test-only change. No production code, schema, or deploy impact.
+
+- **Bucket 1 of the 79-failure triage** ([CHANGELOG.md "Test hygiene — partial triage"](#)): inline `vi.mock("@/lib/auth/require-auth", ...)` stubs across 33 API route tests previously returned an `AuthContext` without `dek` or `sessionId`. Any route wrapped in `requireEncryption()` (which forces a 423 when either field is null) failed the test even when the route logic was correct. Added a non-null `dek` (32 bytes of 0xAA) and `sessionId` (`"test-session-jti"`) to every such mock via a one-shot sed across `tests/api/**/*.test.ts`.
+- **Shared helper added.** New `mockAuthContext()` factory + exported `TEST_DEK` / `TEST_SESSION_ID` constants in [tests/helpers/api-test-utils.ts](tests/helpers/api-test-utils.ts) for any new API route test that wants the same shape without re-typing the literal.
+- **Failure count: 81 → 76** (5 recovered: `import-execute.test.ts` (3) + `transactions.test.ts` (2)). All 8 explicit `"expected 423 to be X"` assertions are gone. The remaining failures in the same files now fail at deeper layers (e.g., the route's resolver call hits a 500 because additional dependencies aren't mocked) — those belong to other buckets (FINLYNQ-8/9/10) and are out of scope for bucket 1.
+
 ## 2026-05-13 — Admin dashboard: restore recent-logins panel + per-user transaction count
 
 Operator-facing only; admin route is behind `requireAdmin`. Two adjacent fixes to the `/admin` dashboard, plus a bundled cleanup of four stale doc / landing-copy lines.

--- a/tests/api/accounts.test.ts
+++ b/tests/api/accounts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetAccounts = vi.fn();

--- a/tests/api/age-of-money.test.ts
+++ b/tests/api/age-of-money.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockCalculateAgeOfMoney = vi.fn();

--- a/tests/api/authz-ownership.test.ts
+++ b/tests/api/authz-ownership.test.ts
@@ -214,7 +214,7 @@ describe("Cross-tenant FK rejection at route boundary (B4 / H-1)", () => {
       vi.doMock("@/lib/auth/require-auth", () => ({
         requireAuth: vi.fn(async () => ({
           authenticated: true,
-          context: { userId: "userA", method: "passphrase" as const, mfaVerified: false },
+          context: { userId: "userA", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" },
         })),
       }));
       const { POST } = await import("@/app/api/snapshots/route");
@@ -238,7 +238,7 @@ describe("Cross-tenant FK rejection at route boundary (B4 / H-1)", () => {
       vi.doMock("@/lib/auth/require-auth", () => ({
         requireAuth: vi.fn(async () => ({
           authenticated: true,
-          context: { userId: "userA", method: "passphrase" as const, mfaVerified: false },
+          context: { userId: "userA", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" },
         })),
       }));
       vi.doMock("@/lib/queries", () => ({
@@ -296,7 +296,7 @@ describe("Cross-tenant FK rejection at route boundary (B4 / H-1)", () => {
       vi.doMock("@/lib/auth/require-auth", () => ({
         requireAuth: vi.fn(async () => ({
           authenticated: true,
-          context: { userId: "userA", method: "passphrase" as const, mfaVerified: false },
+          context: { userId: "userA", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" },
         })),
       }));
       vi.doMock("@/lib/auth/require-encryption", () => ({
@@ -317,7 +317,7 @@ describe("Cross-tenant FK rejection at route boundary (B4 / H-1)", () => {
       vi.doMock("@/lib/auth/require-auth", () => ({
         requireAuth: vi.fn(async () => ({
           authenticated: true,
-          context: { userId: "userA", method: "passphrase" as const, mfaVerified: false },
+          context: { userId: "userA", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" },
         })),
       }));
       vi.doMock("@/lib/auth/require-encryption", () => ({

--- a/tests/api/budget-templates.test.ts
+++ b/tests/api/budget-templates.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetBudgetTemplates = vi.fn();

--- a/tests/api/budgets.test.ts
+++ b/tests/api/budgets.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 // B4 — verifyOwnership runs a real DB query in the route. These existing

--- a/tests/api/categories.test.ts
+++ b/tests/api/categories.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetCategories = vi.fn();

--- a/tests/api/chat.test.ts
+++ b/tests/api/chat.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockProcessMessage = vi.fn();

--- a/tests/api/dashboard.test.ts
+++ b/tests/api/dashboard.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetAccountBalances = vi.fn();

--- a/tests/api/data.test.ts
+++ b/tests/api/data.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 import { DELETE } from "@/app/api/data/route";

--- a/tests/api/fire.test.ts
+++ b/tests/api/fire.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 import { POST } from "@/app/api/fire/route";

--- a/tests/api/forecast.test.ts
+++ b/tests/api/forecast.test.ts
@@ -19,7 +19,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 vi.mock("@/lib/recurring-detector", () => ({

--- a/tests/api/fx.test.ts
+++ b/tests/api/fx.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetAccountBalances = vi.fn();

--- a/tests/api/goals.test.ts
+++ b/tests/api/goals.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/tests/api/health-score.test.ts
+++ b/tests/api/health-score.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetAccountBalances = vi.fn();

--- a/tests/api/import-execute.test.ts
+++ b/tests/api/import-execute.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockExecuteImport = vi.fn();

--- a/tests/api/insights.test.ts
+++ b/tests/api/insights.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetMonthlySpending = vi.fn();

--- a/tests/api/loans.test.ts
+++ b/tests/api/loans.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGenerateAmortization = vi.fn();

--- a/tests/api/monte-carlo.test.ts
+++ b/tests/api/monte-carlo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockRunSimulation = vi.fn();

--- a/tests/api/notifications-await.test.ts
+++ b/tests/api/notifications-await.test.ts
@@ -29,7 +29,7 @@ vi.mock("@/db", () => ({
   },
 }));
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "user-1", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "user-1", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 vi.mock("drizzle-orm", () => ({ eq: vi.fn(), desc: vi.fn(), sql: vi.fn(), and: vi.fn() }));
 

--- a/tests/api/notifications.test.ts
+++ b/tests/api/notifications.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 vi.mock("drizzle-orm", () => ({ eq: vi.fn(), desc: vi.fn(), sql: vi.fn(), and: vi.fn() }));
 

--- a/tests/api/onboarding.test.ts
+++ b/tests/api/onboarding.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 import { POST as completeOnboarding } from "@/app/api/onboarding/complete/route";

--- a/tests/api/rebalancing.test.ts
+++ b/tests/api/rebalancing.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 vi.mock("drizzle-orm", () => ({ eq: vi.fn() }));
 

--- a/tests/api/recap.test.ts
+++ b/tests/api/recap.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGenerateWeeklyRecap = vi.fn();

--- a/tests/api/recurring.test.ts
+++ b/tests/api/recurring.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 vi.mock("@/lib/recurring-detector", () => ({

--- a/tests/api/reports-trends.test.ts
+++ b/tests/api/reports-trends.test.ts
@@ -18,7 +18,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn(), and: vi.fn(), gte: vi.fn(), lte: vi.fn(), sql: vi.fn(),

--- a/tests/api/reports.test.ts
+++ b/tests/api/reports.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 vi.mock("@/lib/fx-service", () => ({

--- a/tests/api/rules.test.ts
+++ b/tests/api/rules.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 vi.mock("drizzle-orm", () => ({ eq: vi.fn(), asc: vi.fn(), and: vi.fn(), inArray: vi.fn() }));
 

--- a/tests/api/scenarios.test.ts
+++ b/tests/api/scenarios.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockCalcMonthly = vi.fn((..._args: unknown[]) => 500);

--- a/tests/api/snapshots.test.ts
+++ b/tests/api/snapshots.test.ts
@@ -20,7 +20,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 vi.mock("drizzle-orm", () => ({ eq: vi.fn(), desc: vi.fn(), and: vi.fn(), inArray: vi.fn() }));
 

--- a/tests/api/spotlight.test.ts
+++ b/tests/api/spotlight.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetSpotlightItems = vi.fn();

--- a/tests/api/subscriptions.test.ts
+++ b/tests/api/subscriptions.test.ts
@@ -22,7 +22,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 vi.mock("@/lib/recurring-detector", () => ({

--- a/tests/api/tax.test.ts
+++ b/tests/api/tax.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 vi.mock("@/lib/tax-optimizer", () => ({

--- a/tests/api/transactions.test.ts
+++ b/tests/api/transactions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/auth/require-auth", () => ({
-  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false } })),
+  requireAuth: vi.fn(async () => ({ authenticated: true, context: { userId: "default", method: "passphrase" as const, mfaVerified: false, dek: Buffer.alloc(32, 0xaa), sessionId: "test-session-jti" } })),
 }));
 
 const mockGetTransactions = vi.fn();

--- a/tests/helpers/api-test-utils.ts
+++ b/tests/helpers/api-test-utils.ts
@@ -2,6 +2,38 @@ import { vi } from "vitest";
 import { NextRequest } from "next/server";
 
 /**
+ * Default test DEK — 32 bytes of 0xAA. Routes that call `requireEncryption()`
+ * pull `dek` + `sessionId` out of the `requireAuth()` AuthContext; if either
+ * is null the route returns 423 Locked.
+ *
+ * Use {@link mockAuthContext} to mint an AuthContext-shaped object for inline
+ * `vi.mock("@/lib/auth/require-auth", ...)` stubs in API route tests.
+ */
+export const TEST_DEK = Buffer.alloc(32, 0xaa);
+export const TEST_SESSION_ID = "test-session-jti";
+
+/**
+ * Build a fully-populated AuthContext for use in `requireAuth` mocks. Includes
+ * a non-null `dek` + `sessionId` so routes wrapped in `requireEncryption()` do
+ * not return 423 under test. Spread `...overrides` to customize `userId` etc.
+ */
+export function mockAuthContext(overrides?: {
+  userId?: string;
+  method?: "passphrase" | "account" | "api_key" | "oauth";
+  mfaVerified?: boolean;
+  dek?: Buffer | null;
+  sessionId?: string | null;
+}) {
+  return {
+    userId: overrides?.userId ?? "default",
+    method: overrides?.method ?? ("passphrase" as const),
+    mfaVerified: overrides?.mfaVerified ?? false,
+    dek: overrides?.dek === undefined ? TEST_DEK : overrides.dek,
+    sessionId: overrides?.sessionId === undefined ? TEST_SESSION_ID : overrides.sessionId,
+  };
+}
+
+/**
  * Create a mock NextRequest for API route testing.
  */
 export function createMockRequest(


### PR DESCRIPTION
Tracks DevManager **FINLYNQ-7** ("Test bucket 1: routes gaining requireEncryption() w/o DEK on test auth context").

## Summary

Test-only change. Bucket 1 of the 79-test failure triage. The inline `vi.mock("@/lib/auth/require-auth", ...)` stubs in 33 API route tests returned an `AuthContext` with `dek: undefined` and `sessionId: undefined`. Any route wrapped in `requireEncryption()` (which 423s when either field is null) failed even when the route logic itself was correct. Each stub now provides a non-null `dek` + `sessionId`. Adds a `mockAuthContext()` factory in `tests/helpers/api-test-utils.ts` for future tests.

## Test plan

- Local: `npm test` failure count **81 → 76** (5 recovered in `import-execute.test.ts` and `transactions.test.ts`).
- All 8 explicit `"expected 423 to be X"` assertions are gone (zero 423-due-to-no-DEK failures remaining).
- `npx tsc --noEmit` ✓ clean
- `npm run build` ✓ passes
- Remaining failures in the same files now fail at deeper layers (route resolvers hitting 500 because additional dependencies aren't mocked) — those belong to other buckets (FINLYNQ-8/9/10), out of scope here.

## Scope guardrails honored

- No production code touched (no `src/lib/crypto/**`, no `mcp-server/**`, no `src/lib/external-import/**`, no routes, no migrations).
- All edits are under `tests/api/**` and `tests/helpers/api-test-utils.ts`.

## Promotion to main — required steps

- [x] Test-only change. Plain `git merge dev` is sufficient — no schema, no runtime impact.