### PR TITLE
docs: lead README with dual deployment offering (FINLYNQ-31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning: [Semantic Versioning](https://semver.org/)
 - Add public Terms of Service at `/terms` covering the managed cloud service. Required for Anthropic Connectors Directory submission Page 6 attestation. AGPL v3 governs self-hosted use of the source; these Terms govern finlynq.com only.
 - Add Troubleshooting section to public `/mcp-guide` covering connection failures (401/403/423), OAuth stuck, stale data, self-hosted gotchas (`PF_USER_ID`, Stream D Phase 4 stdio refusals). Eight collapsible `<details>` entries lifted from `docs/faq.md` plus a closing GitHub-issues triage line. Required for Anthropic Connectors Directory submission Page 6 documentation attestation — the page now satisfies all three sub-requirements (setup + tool descriptions + troubleshooting).
 
+## 2026-05-17 — docs: README leads with dual deployment offering (FINLYNQ-31)
+
+- Rewrote `pf-app/README.md` (the README GitHub renders on github.com/finlynq/finlynq) so the first paragraph names both the managed cloud (finlynq.com/cloud) and self-host modes explicitly. Mitigates the Gemini-misread-as-self-host-only issue where an LLM quoting only the opening lines of an AGPL OSS README defaulted to "self-host only". Feature bullets mirror landing-page `PLAN_FEATS`; the Docker quick start uses the verbatim snippet from `src/app/self-hosted/page.tsx`. No code changes; pure docs.
+
 ## 2026-05-17 — test hygiene: shared test auth helper unlocks DEK (FINLYNQ-7)
 
 Test-only change. No production code, schema, or deploy impact.

--- a/README.md
+++ b/README.md
@@ -1,307 +1,73 @@
-# Finlynq — Personal Finance App
+# Finlynq
+
+Two ways to use Finlynq: a free managed cloud at [finlynq.com/cloud](https://finlynq.com/cloud), or self-host with Docker.
+
+Open-source personal finance with a first-party MCP server (91 HTTP / 87 stdio tools) so Claude, ChatGPT, Cursor, etc. can query and manage your finances.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-An open-source personal finance web app with a first-party MCP server. Track income, expenses, budgets, investments, loans, and goals — then query your financial data from Claude, Cursor, Windsurf, or any MCP-compatible AI assistant.
-
-**"Track your money here, analyze it anywhere."**
-
-> **License:** AGPL v3 · **Repo:** [github.com/finlynq/finlynq](https://github.com/finlynq/finlynq) · **Support:** [GitHub Sponsors](https://github.com/sponsors/finlynq) · [Ko-fi](https://ko-fi.com/finlynq)
+> Track your money here, analyze it anywhere.
 
 ---
 
-## Try the Demo
+## Quick start — hosted
 
-No signup needed — a public demo account is always available on production:
+[**finlynq.com/cloud**](https://finlynq.com/cloud) — click, register, import a CSV. No infra to manage.
 
-- **URL:** [finlynq.com](https://finlynq.com)
-- **Username:** `demo` (or email `demo@finlynq.com` — login accepts either)
-- **Password:** `finlynq-demo`
+A public demo lives at the same URL (username `demo` / password `finlynq-demo`, resets nightly). Connect it to Claude by pasting `https://finlynq.com/mcp` into Claude → Customize → Connectors.
 
-Comes preloaded with 6 months of sample transactions, accounts, budgets, investments, and goals. Data resets nightly at 03:00 UTC, so feel free to change anything.
-
-**Connect it to Claude:** in Claude → Customize → Connectors → "+" and paste `https://finlynq.com/mcp`. OAuth handles the rest — no config file.
-
----
-
-## Running Locally (Windows)
-
-### Prerequisites
-
-- [Node.js 18+](https://nodejs.org/)
-- PostgreSQL 14+ installed and running (the Windows service `postgresql-x64-*` should start automatically)
-- Git
-
-### 1. Clone & install
+## Quick start — self-hosted
 
 ```bash
-git clone https://github.com/finlynq/finlynq.git
-cd finlynq/pf-app
-npm install
-```
-
-### 2. Create your `.env` file
-
-Copy `.env.example` to `.env` and fill in the values:
-
-```bash
-cp .env.example .env
-```
-
-Minimum required values for local dev:
-
-```env
-NODE_ENV=development
-APP_URL=http://localhost:3000
-DATABASE_URL=postgres://<user>:<password>@localhost:5432/finlynq
-PF_JWT_SECRET=<run: openssl rand -hex 32>
-```
-
-> **Windows tip:** If you know a working PostgreSQL user from another project (e.g. `epm:epm_dev_password`), use those credentials — you just need a user with `CREATEDB` privilege.
-
-### 3. Create the database
-
-Open PowerShell in the `pf-app` directory and run:
-
-```powershell
-# Set your psql path (adjust version number as needed)
-$psql = "C:\Program Files\PostgreSQL\16\bin\psql.exe"
-$env:PGPASSWORD = "<your-db-password>"
-
-# Create the finlynq database (connect to an existing DB first, e.g. epm_agent_v3 or postgres)
-"CREATE DATABASE finlynq;" | & $psql -U <your-user> -h 127.0.0.1 -p 5432 -d <existing-db>
-```
-
-Or open **pgAdmin 4** and run:
-```sql
-CREATE DATABASE finlynq;
-```
-
-### 4. Push the schema
-
-```powershell
-powershell -ExecutionPolicy Bypass -Command "npm run db:push:pg"
-```
-
-> **Note:** On Windows, running `npm` directly in PowerShell may fail with a script execution policy error. Always prefix with `powershell -ExecutionPolicy Bypass -Command "..."` or run from Git Bash / Command Prompt.
-
-### 5. Start the dev server
-
-```powershell
-powershell -ExecutionPolicy Bypass -Command "npm run dev"
-```
-
-App will be available at **http://localhost:3000**
-
-### 6. Create your account
-
-Navigate to **http://localhost:3000/cloud** and click **Create Account**. Pick a username (3–254 chars, lowercase letters / digits / `. @ + _ -`) — email is optional.
-
-> Heads up: Finlynq encrypts everything with your password. There's no recovery key — if you forget your password, all data is wiped on reset. Adding an email lets you trigger a reset; without one you have no way to regain access.
-
----
-
-## Running Locally (macOS / Linux)
-
-### Prerequisites
-
-- Node.js 18+
-- PostgreSQL 14+ (`brew install postgresql@16` on macOS, or `apt install postgresql` on Ubuntu)
-
-### Steps
-
-```bash
-# Clone
-git clone https://github.com/finlynq/finlynq.git
-cd finlynq/pf-app
-
-# Install dependencies
-npm install
-
-# Configure environment
-cp .env.example .env
-# Edit .env — set DATABASE_URL and PF_JWT_SECRET
-
-# Create the database (assuming default postgres superuser)
-psql -U postgres -c "CREATE DATABASE finlynq;"
-
-# Push schema
-npm run db:push:pg
-
-# Start dev server
-npm run dev
-```
-
-App will be available at **http://localhost:3000**
-
----
-
-## Docker (Self-hosted)
-
-The easiest way to run Finlynq with zero manual setup:
-
-```bash
-git clone https://github.com/finlynq/finlynq.git
-cd finlynq/pf-app
-
-# Copy and configure env
-cp .env.example .env
-# Edit .env — at minimum set PF_JWT_SECRET
-
-# Start app + PostgreSQL
+curl -O https://raw.githubusercontent.com/finlynq/finlynq/main/pf-app/docker-compose.yml
 docker compose up -d
 ```
 
-App will be available at **http://localhost:3000**
-
-The Docker Compose file starts both the app and a PostgreSQL 16 container. Data is persisted in a named volume (`postgres_data`).
+Then open [http://localhost:3000](http://localhost:3000) and register. App + PostgreSQL run in Docker; sensitive fields are encrypted at rest with a per-user key derived from the account password. Remember to change the default PostgreSQL password and `PF_JWT_SECRET` before exposing the container to anything but localhost. Full setup notes at [finlynq.com/self-hosted](https://finlynq.com/self-hosted).
 
 ---
 
-## Environment Variables
+## Features
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `DATABASE_URL` | ✅ | PostgreSQL connection string — activates managed mode |
-| `PF_JWT_SECRET` | ✅ | 64-char hex secret for JWT signing (`openssl rand -hex 32`) |
-| `NODE_ENV` | | `development` or `production` |
-| `APP_URL` | | Public URL of the app (used in email links) |
-| `PF_SMTP_HOST` | | SMTP host for password reset emails (leave blank to disable) |
-| `NEXT_PUBLIC_GITHUB_REPO` | | Link to your fork (shown in donation banner) |
-
----
-
-## Tech Stack
-
-| Layer | Technology |
-|-------|-----------|
-| Framework | Next.js 16 (App Router, Turbopack) + TypeScript |
-| Database | PostgreSQL 16 + Drizzle ORM (22 tables) |
-| UI | Tailwind CSS + shadcn/ui v4 (`@base-ui/react`) |
-| Charts | Recharts + custom Sankey SVG |
-| Animations | Framer Motion |
-| Theming | next-themes (dark/light/system) |
-| MCP | @modelcontextprotocol/sdk (86 tools, Streamable HTTP + stdio) |
-| Auth | OAuth 2.1 + DCR (MCP), session-cookie + Bearer API key (REST) |
-| Prices | Yahoo Finance API + CoinGecko (crypto) — both free, no key needed |
+- 90 MCP tools (HTTP) · 86 (stdio) — read & write
+- AES-256-GCM envelope encryption · scrypt-derived KEK
+- CSV, Excel, OFX/QFX, PDF import
+- Budgets, portfolio, goals, loans
+- Natural-language AI chat
+- FIRE calculator & Monte Carlo sim
+- Rules & auto-categorize
+- Self-host or managed cloud
+- REST API + MCP (HTTP & stdio · OAuth 2.1 + DCR)
+- Dark mode, mobile-friendly UI
 
 ---
 
-## MCP Server
+## MCP server
 
-Finlynq includes a first-party MCP server with 86 tools for querying and managing your financial data from AI assistants — accounts, transactions, budgets, goals, loans, portfolio, subscriptions, FX rates, rules, splits, bulk edits, and CSV/OFX file imports.
+First-party Model Context Protocol server with 91 HTTP / 87 stdio tools covering accounts, transactions, budgets, goals, loans, portfolio, subscriptions, FX rates, rules, splits, bulk edits, and file imports.
 
-### Connect via Claude Desktop (stdio)
+- **Claude Web / Mobile / Cursor / Windsurf** — OAuth 2.1 + Dynamic Client Registration. Paste `https://finlynq.com/mcp` into the connector setup; no config file.
+- **Claude Desktop (stdio)** — point at `mcp-server/index.ts` with `PF_USER_ID` in the env block.
+- **Bearer API key** — generate a `pf_*` token in Settings → API Keys for scripts and REST clients.
 
-Add to `~/.claude/claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "finlynq": {
-      "command": "npx",
-      "args": ["tsx", "/path/to/pf-app/mcp-server/index.ts"],
-      "env": {
-        "DATABASE_URL": "postgres://epm:epm_dev_password@localhost:5432/finlynq"
-      }
-    }
-  }
-}
-```
-
-### Connect via Claude Web / Mobile (HTTP)
-
-1. Go to **Settings > API Keys** in the app and generate a key (prefix `pf_`)
-2. Add the MCP server URL in your AI assistant: `https://your-domain.com/api/mcp`
-3. Use Bearer token auth with your generated key
-
-The `.well-known/mcp.json` server card at the root enables auto-discovery.
+Submitted to the [Anthropic Connectors Directory](https://www.anthropic.com/news/connectors-directory) on 2026-05-09. Full architecture, tool catalog, and the brokerage-statement recipe live in [docs/architecture/mcp.md](docs/architecture/mcp.md).
 
 ---
 
-## Import Your Data
+## License
 
-Go to `/import` in the app. Supported formats:
+[AGPL v3](LICENSE). If you run a modified version as a network service, you owe your users the source. The hosted offering at finlynq.com/cloud runs the same code as this repo.
 
-| Format | Notes |
-|--------|-------|
-| CSV | Preview with column mapping + deduplication |
-| Excel (.xlsx/.xls) | Visual column mapper |
-| PDF | Bank statement table extraction |
-| OFX / QFX | fitId-based deduplication |
-
-All imports include a deduplication engine that fingerprints transactions to prevent duplicates.
+Donation-based. No paid tiers. If Finlynq is useful to you, [GitHub Sponsors](https://github.com/sponsors/finlynq) or [Ko-fi](https://ko-fi.com/finlynq) keep it shipping.
 
 ---
 
-## Pages
+## Docs
 
-| Page | Path | Description |
-|------|------|-------------|
-| Dashboard | `/dashboard` | Net worth, health score, sparklines, weekly recap, spotlight alerts |
-| Transactions | `/transactions` | Full list with filters, bulk edit, splits |
-| Budgets | `/budgets` | Monthly budgets with envelope-style rollover |
-| Goals | `/goals` | Financial goals with progress tracking |
-| Accounts | `/accounts` | All accounts grouped by type |
-| Portfolio | `/portfolio` | Holdings, allocation, benchmarking, crypto |
-| Loans | `/loans` | Amortization schedules, payoff scenarios |
-| Reports | `/reports` | Income statement, balance sheet, Sankey, YoY |
-| Tax | `/tax` | TFSA/RRSP/RESP room + RRSP vs TFSA calculator |
-| Chat | `/chat` | Natural language financial queries with inline charts |
-| Subscriptions | `/subscriptions` | Recurring subscription tracker with auto-detection |
-| Calendar | `/calendar` | Monthly bill calendar |
-| Scenarios | `/scenarios` | What-if modeling (home, savings, debt, income) |
-| FIRE | `/fire` | FIRE/retirement calculator + Monte Carlo simulation |
-| Import | `/import` | Multi-format import |
-| MCP Guide | `/mcp-guide` | Setup guide (Claude Desktop / Web / Mobile / API) |
-| API Docs | `/api-docs` | Developer API documentation |
-| Settings | `/settings` | Categories, API keys, backup/restore |
-
----
-
-## Scripts
-
-| Script | Description |
-|--------|-------------|
-| `npm run dev` | Start dev server at http://localhost:3000 |
-| `npm run build` | Production build |
-| `npm run build:mcp` | Build MCP server |
-| `npm run db:push:pg` | Push schema to PostgreSQL |
-| `npm run db:generate:pg` | Generate Drizzle PG migrations |
-
----
-
-## Project Structure
-
-```
-pf-app/
-  src/
-    app/               # 21 pages + 50+ API routes
-    components/        # Nav, unlock gate, setup wizard, sparkline, sankey, shadcn/ui
-    db/                # Schema (22 tables), PostgreSQL adapter, Drizzle ORM
-    lib/               # Business logic (parsers, calculators, AI chat engine, MCP tools)
-  mcp-server/          # MCP server v3 (86 tools, stdio + Streamable HTTP)
-  drizzle-pg/          # PostgreSQL migration files
-  mobile/              # React Native (Expo) mobile app
-  docs/                # Getting started, FAQ, mobile setup guide
-```
-
----
-
-## Contributing
-
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first.
-
-- Bug reports → [GitHub Issues](https://github.com/finlynq/finlynq/issues)
-- Feature requests → [GitHub Discussions](https://github.com/finlynq/finlynq/discussions)
-- Pull requests → fork, branch, PR against `main`
-
----
-
-## Support the Project
-
-Finlynq is free and open-source (AGPL v3). If it's useful to you, consider supporting development:
-
-- ⭐ Star the repo
-- 💛 [GitHub Sponsors](https://github.com/sponsors/finlynq)
-- ☕ [Ko-fi](https://ko-fi.com/finlynq)
+- [CHANGELOG.md](CHANGELOG.md) — reverse-chronological log of every shipped change
+- [docs/getting-started.md](docs/getting-started.md) — first-run setup walkthrough
+- [docs/faq.md](docs/faq.md) — common questions
+- [docs/architecture/](docs/architecture/) — encryption, MCP internals, database, migrations
+- [docs/import-connectors.md](docs/import-connectors.md) — adding a new file-import provider
+- [CONTRIBUTING.md](CONTRIBUTING.md) — branching, commit style, PR flow
+- [SECURITY.md](SECURITY.md) — vulnerability disclosure


### PR DESCRIPTION
Tracks DevManager FINLYNQ-31.

## Summary
Rewrites `pf-app/README.md` (the README GitHub renders on github.com/finlynq/finlynq) so the first paragraph names both the managed cloud (finlynq.com/cloud) and self-host modes explicitly. Mitigates the Gemini-misread-as-self-host-only issue where the LLM quoting only the opening lines defaulted to the AGPL training-data pattern. Feature bullets mirror landing-page `PLAN_FEATS`; Docker quick start uses the verbatim snippet from `src/app/self-hosted/page.tsx`.

## Acceptance checklist
- [x] First paragraph mentions both 'managed cloud' and 'self-host' explicitly
- [x] Links to finlynq.com/cloud and finlynq.com/self-hosted both present
- [x] No 'PF' or 'SQLCipher' references
- [x] No Plaid-style bank-syncing claim (file-import only today)
- [x] Will render cleanly on github.com/finlynq/finlynq after promotion to main

## Docs updated
- pf-app/README.md (rewrite, lead with hero paragraph)
- pf-app/CHANGELOG.md
- C:/Users/halaw/Projects/PF/README.md also mirrored at workspace root per item body's explicit path (outside git, not in this PR)

## Promotion to main — required steps
- [x] Docs-only change. Plain \`git merge dev\` is sufficient — README on main is what GitHub shows on the public repo landing.
- [ ] After ~24h, re-ask Gemini 'Does Finlynq offer a hosted service?' — answer should affirmatively name finlynq.com/cloud.

## How I tested
- Visual scan of rendered Markdown
- Confirmed the docker compose snippet is verbatim from src/app/self-hosted/page.tsx
- Confirmed PLAN_FEATS bullets mirror src/app/page.tsx lines 76–87