### PR TITLE
db: fix transaction_rules.is_active migration default cast (FINLYNQ-12)

### DIFF
--- a/scripts/migrations/20260518_transaction_rules_is_active_boolean.sql
+++ b/scripts/migrations/20260518_transaction_rules_is_active_boolean.sql
@@ -2,17 +2,26 @@
 --
 -- The column has stored 0/1 since the initial schema; the new Drizzle column
 -- definition is BOOLEAN. PostgreSQL requires an explicit USING clause to cast
--- INTEGER → BOOLEAN; `is_active::int <> 0` is safe whether the underlying
--- column is INTEGER (0/1 → false/true) or already BOOLEAN on a re-deploy
+-- INTEGER -> BOOLEAN; `is_active::int <> 0` is safe whether the underlying
+-- column is INTEGER (0/1 -> false/true) or already BOOLEAN on a re-deploy
 -- (BOOLEAN::int <> 0 round-trips identity).
 --
--- Default flipped from 1 to TRUE in the same statement so freshly-inserted
--- rules continue to default to "active".
+-- Order matters:
+--   1. DROP the existing DEFAULT (integer 1) — PostgreSQL evaluates the
+--      stored default against the new column type BEFORE applying any new
+--      default, so the cast fails with "default for column cannot be cast
+--      automatically to type boolean" if we leave it in place.
+--   2. Change the column type via USING.
+--   3. SET the new BOOLEAN default.
+--   4. Re-assert NOT NULL (it was already NOT NULL; this is a defense-in-depth
+--      no-op since SET NOT NULL is idempotent).
 --
 -- Code-side changes ship in the same commit (Drizzle schema + all read/write
 -- callsites swept from `is_active = 1` / `: 1` to `= true` / `: true`).
 -- Backup-restore coerces legacy 0/1 numeric values on import for back-compat
 -- with pre-migration backups.
+ALTER TABLE transaction_rules ALTER COLUMN is_active DROP DEFAULT;
 ALTER TABLE transaction_rules
-  ALTER COLUMN is_active TYPE BOOLEAN USING (is_active::int <> 0),
-  ALTER COLUMN is_active SET DEFAULT TRUE;
+  ALTER COLUMN is_active TYPE BOOLEAN USING (is_active::int <> 0);
+ALTER TABLE transaction_rules ALTER COLUMN is_active SET DEFAULT TRUE;
+ALTER TABLE transaction_rules ALTER COLUMN is_active SET NOT NULL;


### PR DESCRIPTION
Follow-up to PR #264.

## Failure on dev deploy
Migration `20260518_transaction_rules_is_active_boolean.sql` rolled back with:
\`\`\`
psql:...20260518_transaction_rules_is_active_boolean.sql:18: ERROR:  default for column \"is_active\" cannot be cast automatically to type boolean
\`\`\`

PostgreSQL evaluates the existing DEFAULT (integer 1) against the new column type BEFORE applying the new DEFAULT, so the cast fails even though the explicit `USING (is_active::int <> 0)` clause handled the column data correctly.

## Fix
Split into four discrete ALTERs:
1. DROP DEFAULT (frees Postgres from re-casting the integer 1 default into boolean)
2. ALTER TYPE BOOLEAN USING (...)
3. SET DEFAULT TRUE (now applied against the boolean column)
4. SET NOT NULL (idempotent defense-in-depth)

## No prod/dev impact
- deploy.sh runs migrations inside `--single-transaction` so the failed migration fully rolled back. It was never recorded in `schema_migrations`.
- Restart happens AFTER migrations succeed, so the running app on dev stayed on the old INTEGER-reading release.
- Re-editing the same migration filename is safe; the runner picks it up exactly once per env on next deploy.

## How I tested
- Read the failure log from run 26013656929 to confirm the rollback semantics.
- The corrected SQL mirrors the standard PostgreSQL idiom for INTEGER→BOOLEAN with a default; no code changes are needed (the code-side commit in #264 already shipped to dev — the migration was the only failing step).