### PR TITLE
fix(try-demo): build redirect URL from X-Forwarded-* headers

### DIFF
--- a/src/app/try-demo/route.ts
+++ b/src/app/try-demo/route.ts
@@ -172,7 +172,20 @@ export async function GET(request: NextRequest) {
       enqueueUpgradeStagingEncryption(user.id, dek);
     }
 
-    const response = NextResponse.redirect(new URL(next, request.url));
+    // Build the absolute redirect URL from the X-Forwarded-* headers Caddy
+    // sets, NOT from request.url. Behind the reverse proxy the upstream URL
+    // is the systemd-bound 0.0.0.0:3456 form, so `new URL(next, request.url)`
+    // produces a Location header that breaks in the browser
+    // ("ERR_ADDRESS_INVALID"). Forwarded-host headers carry the original
+    // public origin (finlynq.com) and are the standard pattern for routes
+    // behind a reverse proxy.
+    const forwardedHost = request.headers.get("x-forwarded-host");
+    const forwardedProto = request.headers.get("x-forwarded-proto");
+    const host = forwardedHost ?? request.nextUrl.host;
+    const proto =
+      forwardedProto ?? request.nextUrl.protocol.replace(/:$/, "");
+    const redirectUrl = `${proto}://${host}${next}`;
+    const response = NextResponse.redirect(redirectUrl);
     response.cookies.set(AUTH_COOKIE, token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
Hotfix for the /try-demo route shipped in #269. The redirect Location was resolving to the upstream-internal \`https://0.0.0.0:3456/...\` (Caddy doesn't rewrite the upstream Host header), which browsers reject with \`ERR_ADDRESS_INVALID\`.

Now builds the absolute URL from \`x-forwarded-host\` + \`x-forwarded-proto\` (standard Caddy headers) with the original request as fallback.

## Test plan
- [x] Reproduced the bug on prod: \`curl -sI 'https://finlynq.com/try-demo?next=/import/pending'\` returned \`Location: https://0.0.0.0:3456/...\`
- [ ] After merge + deploy: same curl returns \`Location: https://finlynq.com/import/pending\`
- [ ] Browser load of \`finlynq.com/try-demo?next=/import/pending\` lands on the two-pane reconciliation view with the demo session active