### PR TITLE
Hotfix: reorder migration 20260525_portfolio_ops_phase1 — partial unique index AFTER consolidation

### DIFF
--- a/scripts/migrations/20260525_portfolio_ops_phase1.sql
+++ b/scripts/migrations/20260525_portfolio_ops_phase1.sql
@@ -114,17 +114,17 @@ ALTER TABLE portfolio_holdings
   ADD COLUMN IF NOT EXISTS is_cash BOOLEAN NOT NULL DEFAULT FALSE;
 
 -- Uniqueness invariant per user: at most one cash sleeve per (account,
--- currency). Enforced via partial unique index — non-cash holdings (the
--- vast majority) are unaffected. The migration's consolidation step below
--- merges existing duplicates before this index lands.
+-- currency). The CREATE UNIQUE INDEX is at the BOTTOM of this migration,
+-- intentionally AFTER the backfill + consolidation steps below — prod
+-- has pre-existing duplicate cash holdings from the pre-Stream-D era
+-- that the consolidation merges before the constraint becomes enforceable.
+-- Creating the index here (before the backfill) caused prod deploy
+-- 26349930535 to fail with `duplicate key value violates unique constraint`.
 --
 -- Note: account_id can be NULL on portfolio_holdings (legacy column;
 -- holding_accounts is the M:N join). The partial index treats NULL
 -- account_ids as distinct per Postgres semantics, which is acceptable —
 -- unaccounted cash sleeves are an edge case.
-CREATE UNIQUE INDEX IF NOT EXISTS portfolio_holdings_one_cash_per_account_currency
-  ON portfolio_holdings (user_id, account_id, currency)
-  WHERE is_cash = TRUE;
 
 -- ─── Backfill: tag existing cash sleeves with is_cash = TRUE ─────────────
 --
@@ -281,6 +281,14 @@ WITH ranked_cash AS (
 )
 DELETE FROM portfolio_holdings
  WHERE id IN (SELECT id FROM ranked_cash WHERE rn > 1);
+
+-- Duplicates now consolidated — safe to add the partial unique index.
+-- Moved from the top of the file (where it caused prod deploy 26349930535
+-- to fail with "duplicate key value violates unique constraint" before the
+-- consolidation could run).
+CREATE UNIQUE INDEX IF NOT EXISTS portfolio_holdings_one_cash_per_account_currency
+  ON portfolio_holdings (user_id, account_id, currency)
+  WHERE is_cash = TRUE;
 
 -- ─── Backfill: tag existing portfolio rows with kind by qty sign ─────────
 --


### PR DESCRIPTION
## Why

Prior PR #273 merged to main but the prod deploy (run 26349930535) failed during migration with:

\`\`\`
ERROR: duplicate key value violates unique constraint "portfolio_holdings_one_cash_per_account_currency"
DETAIL: Key (user_id, account_id, currency)=(6c4f164a-..., 614, CAD) already exists.
\`\`\`

Root cause: in \`20260525_portfolio_ops_phase1.sql\` the CREATE UNIQUE INDEX ran BEFORE the UPDATE that sets \`is_cash=TRUE\`. Prod has pre-Stream-D duplicate cash holdings per \`(user, account, currency)\` that the migration's own consolidation block was designed to merge — but consolidation only runs AFTER the UPDATE, which itself was failing because the unique constraint was already enforced.

## What

Moved the CREATE UNIQUE INDEX to the bottom of the file, after the DELETE that removes the duplicate rows. Dev already has this migration applied via \`schema_migrations\`, so this change is a no-op there; prod will retry from scratch on the next deploy with the corrected order.

## Verification

- Dev deploy 26350004699 succeeded with the corrected migration (no-op on dev — schema_migrations already had this row).
- Prod will see the migration run for the first time with the corrected order: ADD column → UPDATE backfill → consolidate duplicates → CREATE UNIQUE INDEX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)