### PR TITLE
Promote dev → main: backfill review polish + scroll fix

### DIFF
--- a/src/app/(app)/settings/backfill/[runId]/page.tsx
+++ b/src/app/(app)/settings/backfill/[runId]/page.tsx
@@ -140,8 +140,8 @@ export default function BackfillReviewPage({ params }: { params: Promise<{ runId
   const [error, setError] = useState<string>("");
   const [info, setInfo] = useState<string>("");
 
-  async function loadProposals() {
-    setLoading(true);
+  async function loadProposals(opts: { silent?: boolean } = {}) {
+    if (!opts.silent) setLoading(true);
     try {
       const res = await fetch(`/api/settings/backfill/${runId}`);
       const data = await res.json();
@@ -158,7 +158,7 @@ export default function BackfillReviewPage({ params }: { params: Promise<{ runId
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load proposals");
     }
-    setLoading(false);
+    if (!opts.silent) setLoading(false);
   }
 
   useEffect(() => { loadProposals(); }, [runId]);
@@ -194,7 +194,7 @@ export default function BackfillReviewPage({ params }: { params: Promise<{ runId
       setError(err?.error ?? `HTTP ${res.status}`);
       return false;
     }
-    await loadProposals();
+    await loadProposals({ silent: true });
     return true;
   }
 


### PR DESCRIPTION
## Summary

Rolling promotion of 4 commits currently on `dev`:

- `c5b15de` **fix(backfill):** silent refetch on proposal PATCH so the review page keeps scroll position (no more snap-to-top after every checkbox / Approve / Reject click)
- `7273d72` **chore:** gitignore `docs/architecture/` so internal design docs stay out of the public repo
- `0dea11b` **feat(backfill):** show WILL-BECOME preview for `dividend_reinvestment` proposals
- `bf7454b` **feat(backfill):** kind override on refused `orphan_stock_leg` — pair-less branch + richer rows + Canonical column

## Test plan

- [ ] `/settings/backfill/<runId>`: scroll halfway, toggle a checkbox — page stays in place
- [ ] Same page: click **Approve** on a selected proposal — scroll preserved
- [ ] Initial load + **Apply N approved** + **Undo** still show the full-page "Loading…" spinner (intentional)
- [ ] `dividend_reinvestment` proposal — WILL-BECOME preview renders for both `cash_dividend` and `drip` variants
- [ ] Refused `orphan_stock_leg` proposal — kind override picker offers the 5 pair-less kinds, apply succeeds
- [ ] `/transactions` Canonical column toggles on, three states (canonical / pending / —) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)