### PR TITLE
Promote dev → main: live mobile apps on the site + em-dash humanization sweep

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -10,14 +10,14 @@ import {
 import { MCP_TOOL_COUNTS, MCP_SERVER_VERSION } from "@/lib/mcp/tool-counts";
 
 export const metadata: Metadata = {
-  title: "What is Finlynq? — open-source personal finance app with first-party MCP",
+  title: "What is Finlynq? Open-source personal finance app with first-party MCP",
   description:
-    "Finlynq is an open-source (AGPL v3) personal finance web app with a first-party Model Context Protocol (MCP) server. Track income, expenses, budgets, investments, loans, and goals — then query your financial data from Claude, Cursor, Windsurf, or any MCP-compatible AI assistant. Not affiliated with Finq.com (forex broker) or Finlync (B2B treasury software).",
+    "Finlynq is an open-source (AGPL v3) personal finance web app with a first-party Model Context Protocol (MCP) server. Track income, expenses, budgets, investments, loans, and goals, then query your financial data from Claude, Cursor, Windsurf, or any MCP-compatible AI assistant. Not affiliated with Finq.com (forex broker) or Finlync (B2B treasury software).",
   alternates: {
     canonical: "/about",
   },
   openGraph: {
-    title: "What is Finlynq? — open-source personal finance with first-party MCP",
+    title: "What is Finlynq? Open-source personal finance with first-party MCP",
     description:
       "Open-source (AGPL v3) personal finance app with a first-party MCP server. Self-hostable, per-user envelope encryption, Canadian tax accounts, 109 MCP tools. Not affiliated with Finq.com or Finlync.",
     url: "/about",
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "What is Finlynq? — open-source personal finance with first-party MCP",
+    title: "What is Finlynq? Open-source personal finance with first-party MCP",
     description:
       "Open-source self-hostable PFM with first-party MCP, per-user envelope encryption, and Canadian tax tracking.",
   },
@@ -35,55 +35,55 @@ export const metadata: Metadata = {
 const faqItems: { q: string; a: string }[] = [
   {
     q: "What is Finlynq?",
-    a: "Finlynq is an open-source (AGPL v3) personal finance web application with a built-in Model Context Protocol (MCP) server. It lets you track income, expenses, budgets, investments, loans, subscriptions, and financial goals — and query that data in natural language from any MCP-compatible AI assistant including Claude, Cursor, Windsurf, and ChatGPT custom GPTs. Finlynq runs as a managed cloud at finlynq.com or as a self-hosted Docker + PostgreSQL deployment, with the same feature set in both modes.",
+    a: "Finlynq is an open-source (AGPL v3) personal finance web application with a built-in Model Context Protocol (MCP) server. You track income, expenses, budgets, investments, loans, subscriptions, and financial goals, then ask about that data in plain language from any MCP-compatible AI assistant: Claude, Cursor, Windsurf, and ChatGPT custom GPTs all work. Run it on our managed cloud at finlynq.com, or self-host with Docker and PostgreSQL. You get the same features either way.",
   },
   {
     q: "Is Finlynq the same as Finq.com?",
-    a: "No. Finq.com is a forex / CFD trading broker that has no relationship with Finlynq. Finlynq is an open-source personal finance application focused on budgeting, expense tracking, and investment portfolio management. Finlynq is not a broker, does not execute trades, and does not hold customer funds.",
+    a: "No. Finq.com is a forex / CFD trading broker, and it has no relationship with Finlynq. Finlynq is an open-source personal finance app for budgeting, expense tracking, and investment portfolio management. It isn't a broker, doesn't execute trades, and never holds customer funds.",
   },
   {
     q: "Is Finlynq the same as Finlync?",
-    a: "No. Finlync is a corporate treasury and banking-connectivity B2B platform for enterprise finance teams. Finlynq is an open-source personal finance application for individuals and households. The two projects are unrelated; the similar names are coincidental.",
+    a: "No. Finlync is a corporate treasury and banking-connectivity B2B platform built for enterprise finance teams. Finlynq is an open-source personal finance app for individuals and households. The two projects are unrelated. The similar names are just a coincidence.",
   },
   {
     q: "Who builds Finlynq?",
-    a: "Finlynq is an independent open-source project hosted at github.com/finlynq/finlynq under the GNU AGPL v3 license. It is bootstrapped and donation-funded (GitHub Sponsors, Ko-fi) — there are no paid tiers, no advertising, and no sale of user data. The complete source code, including the encryption implementation and the MCP server, is publicly auditable.",
+    a: "Finlynq is an independent open-source project hosted at github.com/finlynq/finlynq under the GNU AGPL v3 license. It's bootstrapped and donation-funded (GitHub Sponsors, Ko-fi). No paid tiers, no advertising, and no selling your data. The complete source, including the encryption code and the MCP server, is right there for anyone to audit.",
   },
   {
     q: "How is Finlynq different from Monarch Money, YNAB, or Simplifi?",
-    a: "Monarch, YNAB, and Simplifi are polished closed-source hosted SaaS products with mature US bank-aggregation via Plaid. Finlynq is open-source and self-hostable with a first-party MCP server (109 HTTP / 93 stdio tools) and per-user envelope encryption that excludes even the operator from reading your data. Finlynq does not yet have first-party Plaid bank sync — it imports from CSV, OFX, QFX, and email today, with the SnapTrade brokerage integration on the roadmap. Side-by-side comparison at finlynq.com/vs/monarch.",
+    a: "Monarch, YNAB, and Simplifi are polished closed-source hosted SaaS products with mature US bank-aggregation via Plaid. Finlynq is open-source and self-hostable, with a first-party MCP server (109 HTTP / 93 stdio tools) and per-user envelope encryption that keeps even the operator from reading your data. The catch: Finlynq doesn't have first-party Plaid bank sync yet. For now it imports from CSV, OFX, QFX, and email, with the SnapTrade brokerage integration on the roadmap. There's a side-by-side comparison at finlynq.com/vs/monarch.",
   },
   {
     q: "How is Finlynq different from Firefly III or Actual Budget?",
-    a: "Firefly III and Actual Budget are both open-source self-hostable PFMs. Firefly III is mature double-entry accounting with PSD2 bank sync for EU/UK users; Actual Budget is local-first envelope budgeting. Finlynq's specific differentiators are: a first-party MCP server (the others rely on community wrappers or have none), per-user envelope encryption that excludes the operator, native multi-currency investment tracking with lot-tracked cost basis, and Canadian tax-account support (RRSP / TFSA / RESP). Side-by-side comparison at finlynq.com/vs/firefly-iii.",
+    a: "Firefly III and Actual Budget are both open-source self-hostable PFMs. Firefly III is mature double-entry accounting with PSD2 bank sync for EU/UK users. Actual Budget is local-first envelope budgeting. So what sets Finlynq apart? A first-party MCP server (the others rely on community wrappers or have none), per-user envelope encryption that locks out the operator, native multi-currency investment tracking with lot-tracked cost basis, and Canadian tax-account support (RRSP / TFSA / RESP). There's a side-by-side comparison at finlynq.com/vs/firefly-iii.",
   },
   {
     q: "How is Finlynq different from Era?",
-    a: "Era is a closed-source hosted AI-native PFM that launched with first-party MCP in May 2026. Finlynq's specific differentiators vs Era: AGPL v3 open source (Era is closed), self-hostable on your own infrastructure (Era is hosted-only), per-user envelope encryption with keys derived from your password (Era holds the keys for AES-256-at-rest), and a 109 HTTP / 93 stdio tool MCP surface (v3.3.0) vs Era's 27. Era has stronger US bank sync and shared household features. Side-by-side comparison at finlynq.com/vs/era.",
+    a: "Era is a closed-source hosted AI-native PFM that launched with first-party MCP in May 2026. Here's where Finlynq parts ways: AGPL v3 open source (Era is closed), self-hostable on your own infrastructure (Era is hosted-only), per-user envelope encryption with keys derived from your password (Era holds the keys for its AES-256-at-rest), and a 109 HTTP / 93 stdio tool MCP surface (v3.3.0) against Era's 27. To be fair, Era has stronger US bank sync and shared household features. There's a side-by-side comparison at finlynq.com/vs/era.",
   },
   {
     q: "Does Finlynq sync with my bank automatically?",
-    a: "Not yet via Plaid or MX. Finlynq currently imports transactions from CSV, OFX, QFX, and email (with template detection and a staging-review pipeline). SnapTrade integration for brokerage accounts is on the near-term roadmap; bank-sync aggregator integration is a tracked future item.",
+    a: "Not yet, at least not through Plaid or MX. For now Finlynq imports transactions from CSV, OFX, QFX, and email, with template detection and a staging-review pipeline so you check things before they land. SnapTrade for brokerage accounts is on the near-term roadmap, and bank-sync aggregator integration is a tracked future item.",
   },
   {
     q: "Does Finlynq have a mobile app?",
-    a: "Yes. Finlynq has native iOS and Android apps, free on the App Store and Google Play. They cover Dashboard, Transactions, Import, Budgets, and Settings, and sign in to your Finlynq web server, whether that is the managed cloud or your own self-hosted box. They are newer than mature apps like Monarch's, so not everything has caught up yet, but they handle your everyday tracking on the go. The full story is at finlynq.com/blog/finlynq-mobile-app.",
+    a: "Yep. Finlynq has native iOS and Android apps, free on the App Store and Google Play. They cover Dashboard, Transactions, Import, Budgets, and Settings, and they sign in to your Finlynq web server, whether that's the managed cloud or your own self-hosted box. They're newer than mature apps like Monarch's, so not everything has caught up yet, but they handle your everyday tracking on the go just fine. The full story is at finlynq.com/blog/finlynq-mobile-app.",
   },
   {
     q: "What AI assistants does Finlynq work with?",
-    a: "Any AI assistant that supports the Model Context Protocol (MCP). Tested clients include Claude (Claude.ai web, Claude Desktop, Claude Code), Cursor, Windsurf, and custom Anthropic SDK agents. Finlynq's MCP server supports three transports: Streamable HTTP with OAuth 2.1 + Dynamic Client Registration, HTTP with Bearer API key, and stdio. Finlynq also has a built-in AI chat UI for users who don't want to set up an external MCP client.",
+    a: "Any AI assistant that speaks the Model Context Protocol (MCP). We've tested Claude (Claude.ai web, Claude Desktop, Claude Code), Cursor, Windsurf, and custom Anthropic SDK agents. Finlynq's MCP server supports three transports: Streamable HTTP with OAuth 2.1 + Dynamic Client Registration, HTTP with a Bearer API key, and stdio. And if you'd rather not set up an external MCP client at all, there's a built-in AI chat UI right in the app.",
   },
   {
     q: "Is Finlynq free?",
-    a: "Yes. The self-hosted Docker version is fully free with the same features as the managed cloud. The managed cloud at finlynq.com is also free, supported by voluntary donations via GitHub Sponsors and Ko-fi. There are no paid tiers, no feature gates, no upsells.",
+    a: "Yes. The self-hosted Docker version is completely free, with the same features as the managed cloud. The managed cloud at finlynq.com is free too, kept running by voluntary donations through GitHub Sponsors and Ko-fi. No paid tiers, no feature gates, no upsells.",
   },
   {
     q: "How does Finlynq protect my data?",
-    a: "Finlynq uses per-user envelope encryption (AES-256-GCM with a scrypt-derived KEK) on six tables containing user-named data (transaction payees, notes, tags, account names, category names, and budget names). The KEK is derived from your password and a server-side pepper, so even the operator cannot decrypt these fields without your password. Trade-off: if you lose your password without a recovery backup, the encrypted fields are unrecoverable. Full details at finlynq.com/privacy.",
+    a: "Finlynq uses per-user envelope encryption (AES-256-GCM with a scrypt-derived KEK) on six tables that hold user-named data: transaction payees, notes, tags, account names, category names, and budget names. The KEK comes from your password plus a server-side pepper, so even the operator can't decrypt those fields without your password. There's a trade-off to be honest about: lose your password without a recovery backup and the encrypted fields are gone for good. Full details at finlynq.com/privacy.",
   },
   {
     q: "Does Finlynq support Canadian tax accounts?",
-    a: "Yes. Finlynq tracks RRSP, TFSA, and RESP contribution room using CRA-published limits, with asset-location advice (bonds in RRSP, stocks in TFSA, growth assets in TFSA). FHSA and RRIF support are tracked roadmap items.",
+    a: "Yes. Finlynq tracks RRSP, TFSA, and RESP contribution room against CRA-published limits, and it offers asset-location advice (bonds in RRSP, stocks in TFSA, growth assets in TFSA). FHSA and RRIF support are on the roadmap.",
   },
 ];
 
@@ -120,8 +120,8 @@ export default function AboutPage() {
           <p className="mt-4 text-base leading-relaxed text-muted-foreground">
             Finlynq is an open-source (AGPL v3) personal finance web application
             with a first-party Model Context Protocol (MCP) server. Track your
-            money here, analyze it anywhere — from Claude, Cursor, Windsurf, or
-            any MCP-compatible AI assistant.
+            money here, analyze it anywhere: Claude, Cursor, Windsurf, or any
+            MCP-compatible AI assistant.
           </p>
           <p className="mt-3 text-xs text-muted-foreground">
             Last updated: 2026-06-11
@@ -134,9 +134,9 @@ export default function AboutPage() {
           </h2>
           <p>
             Finlynq lets you track income, expenses, budgets, investments,
-            loans, and financial goals — then query that data in natural
+            loans, and financial goals, then ask about that data in plain
             language from any AI assistant that supports MCP. Self-host with
-            Docker + PostgreSQL, or use our managed cloud at{" "}
+            Docker and PostgreSQL, or use our managed cloud at{" "}
             <code>finlynq.com</code>. Same features either way.
           </p>
           <p>
@@ -149,8 +149,8 @@ export default function AboutPage() {
             >
               github.com/finlynq/finlynq
             </a>
-            . It&apos;s bootstrapped and donation-funded — no paid tiers, no
-            advertising, no sale of user data.
+            . It&apos;s bootstrapped and donation-funded. No paid tiers, no
+            advertising, no selling your data.
           </p>
 
           <div className="not-prose my-8 rounded-2xl border border-yellow-500/30 bg-yellow-500/5 p-6">
@@ -159,16 +159,16 @@ export default function AboutPage() {
             </h3>
             <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
               <li>
-                <strong className="text-foreground">Finq.com</strong> — a forex
+                <strong className="text-foreground">Finq.com</strong>: a forex
                 and CFD trading broker. No relationship with Finlynq. Finlynq
-                is not a broker, does not execute trades, and does not hold
-                customer funds.
+                isn&apos;t a broker, doesn&apos;t execute trades, and never
+                holds customer funds.
               </li>
               <li>
-                <strong className="text-foreground">Finlync</strong> — a
+                <strong className="text-foreground">Finlync</strong>: a
                 corporate treasury and banking-connectivity B2B platform for
-                enterprise finance teams. Unrelated project; similar name is
-                coincidental.
+                enterprise finance teams. Unrelated project, and the similar
+                name is just a coincidence.
               </li>
             </ul>
           </div>
@@ -180,9 +180,9 @@ export default function AboutPage() {
             <li>
               <strong className="text-foreground">First-party MCP server.</strong>{" "}
               {MCP_TOOL_COUNTS.http} HTTP tools and {MCP_TOOL_COUNTS.stdio} stdio
-              tools at v{MCP_SERVER_VERSION} — built into the project, not a
+              tools at v{MCP_SERVER_VERSION}, built into the project, not a
               community wrapper. OAuth 2.1 + Dynamic Client Registration, Bearer
-              API keys, and stdio transports all supported.
+              API keys, and stdio transports are all supported.
             </li>
             <li>
               <strong className="text-foreground">
@@ -201,17 +201,17 @@ export default function AboutPage() {
                 Native investment tracking.
               </strong>{" "}
               Lot-tracked cost basis, dividends, multi-currency support with
-              per-currency cost-basis bucketing, historical FX lookups.
+              per-currency cost-basis bucketing, and historical FX lookups.
             </li>
             <li>
               <strong className="text-foreground">Canadian tax accounts.</strong>{" "}
-              RRSP, TFSA, and RESP contribution-room tracking with
-              CRA-published limits. Asset-location advice (bonds in RRSP,
+              RRSP, TFSA, and RESP contribution-room tracking against
+              CRA-published limits, plus asset-location advice (bonds in RRSP,
               stocks in TFSA).
             </li>
             <li>
               <strong className="text-foreground">In-app AI chat.</strong> Built
-              directly into the UI — you can use Finlynq&apos;s AI features
+              right into the UI, so you can use Finlynq&apos;s AI features
               without setting up Claude or another external MCP client.
             </li>
             <li>
@@ -285,7 +285,8 @@ export default function AboutPage() {
             </h3>
             <p className="mt-2 text-sm text-muted-foreground">
               Free, open source, AGPL v3. Run it on our managed cloud or
-              self-host with one Docker Compose file. Same features either way.
+              self-host with a single Docker Compose file. Same features either
+              way.
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <Link

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -59,7 +59,7 @@ const faqItems: { q: string; a: string }[] = [
   },
   {
     q: "How is Finlynq different from Era?",
-    a: "Era is a closed-source hosted AI-native PFM that launched with first-party MCP in May 2026. Finlynq's specific differentiators vs Era: AGPL v3 open source (Era is closed), self-hostable on your own infrastructure (Era is hosted-only), per-user envelope encryption with keys derived from your password (Era holds the keys for AES-256-at-rest), and a 109 HTTP / 93 stdio tool MCP surface (v3.3.0) vs Era's 27. Era has stronger US bank sync, native iOS/Android, and shared household features. Side-by-side comparison at finlynq.com/vs/era.",
+    a: "Era is a closed-source hosted AI-native PFM that launched with first-party MCP in May 2026. Finlynq's specific differentiators vs Era: AGPL v3 open source (Era is closed), self-hostable on your own infrastructure (Era is hosted-only), per-user envelope encryption with keys derived from your password (Era holds the keys for AES-256-at-rest), and a 109 HTTP / 93 stdio tool MCP surface (v3.3.0) vs Era's 27. Era has stronger US bank sync and shared household features. Side-by-side comparison at finlynq.com/vs/era.",
   },
   {
     q: "Does Finlynq sync with my bank automatically?",
@@ -67,7 +67,7 @@ const faqItems: { q: string; a: string }[] = [
   },
   {
     q: "Does Finlynq have a mobile app?",
-    a: "Almost. Finlynq has a React Native (Expo) mobile app with Dashboard, Transactions, Import, Budgets, and Settings screens that connects to your Finlynq web server (managed cloud or self-hosted). The Android app is in final testing on Google Play, with iOS to follow. It is not yet at parity with mature consumer mobile apps like Monarch's iOS/Android. Read the announcement at finlynq.com/blog/finlynq-mobile-app.",
+    a: "Yes. Finlynq has native iOS and Android apps, free on the App Store and Google Play. They cover Dashboard, Transactions, Import, Budgets, and Settings, and sign in to your Finlynq web server, whether that is the managed cloud or your own self-hosted box. They are newer than mature apps like Monarch's, so not everything has caught up yet, but they handle your everyday tracking on the go. The full story is at finlynq.com/blog/finlynq-mobile-app.",
   },
   {
     q: "What AI assistants does Finlynq work with?",
@@ -217,8 +217,7 @@ export default function AboutPage() {
             <li>
               <strong className="text-foreground">Mobile app.</strong> React
               Native (Expo) covering Dashboard, Transactions, Import, Budgets,
-              and Settings. The Android app is in final testing on Google Play,
-              with iOS to follow.{" "}
+              and Settings. Available now on the App Store and Google Play.{" "}
               <Link
                 href="/blog/finlynq-mobile-app"
                 className="underline underline-offset-2 hover:text-primary"

--- a/src/app/account-deletion/page.tsx
+++ b/src/app/account-deletion/page.tsx
@@ -2,12 +2,12 @@ import Link from "next/link";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Delete your Finlynq account & data — Finlynq",
+  title: "Delete your Finlynq account & data | Finlynq",
   description:
     "How to delete your Finlynq account and associated data, what gets removed, what is briefly retained, and how to request deletion by email.",
   alternates: { canonical: "/account-deletion" },
   openGraph: {
-    title: "Delete your Finlynq account & data — Finlynq",
+    title: "Delete your Finlynq account & data | Finlynq",
     description:
       "How to delete your Finlynq account and associated data, what gets removed, what is briefly retained, and how to request deletion by email.",
     url: "/account-deletion",
@@ -37,16 +37,16 @@ export default function AccountDeletionPage() {
           <p className="text-base">
             This page explains how to delete your <strong>Finlynq</strong> account
             (the Finlynq personal-finance app, developer Finlynq) and all of the
-            data associated with it. You can do this yourself at any time — no
-            request to us is required — or you can ask us to do it for you.
+            data tied to it. You can do this yourself at any time, with no request
+            to us needed, or you can ask us to do it for you.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
-            Option 1 — Delete it yourself (recommended, immediate)
+            Option 1: delete it yourself (recommended, immediate)
           </h2>
           <p>
-            Account deletion is performed from the Finlynq web app. It applies to
-            your whole account regardless of whether you also use the Android app.
+            You delete your account from the Finlynq web app. It applies to your
+            whole account, whether or not you also use the Android app.
           </p>
           <ol className="list-decimal pl-6 space-y-1.5">
             <li>
@@ -70,7 +70,7 @@ export default function AccountDeletionPage() {
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
-            Option 2 — Ask us to delete it
+            Option 2: ask us to delete it
           </h2>
           <p>
             If you can&apos;t sign in, email{" "}
@@ -81,8 +81,8 @@ export default function AccountDeletionPage() {
               privacy@finlynq.com
             </a>{" "}
             from the email address on your account (or include your username) and
-            ask us to delete your account. We verify ownership and complete the
-            deletion within 30 days.
+            ask us to delete your account. We&apos;ll verify ownership and finish
+            the deletion within 30 days.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -93,7 +93,7 @@ export default function AccountDeletionPage() {
             <code>Settings → Data</code> (and throughout the app) you can delete
             individual accounts, transactions, budgets, investments, goals, loans,
             and uploaded files, or export everything first. These changes take
-            effect immediately.
+            effect right away.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">What gets deleted</h2>
@@ -129,7 +129,7 @@ export default function AccountDeletionPage() {
             </li>
           </ul>
           <p>
-            After these windows pass, no copy of your account data remains.
+            Once these windows pass, no copy of your account data remains.
           </p>
 
           <p className="mt-12 text-xs text-muted-foreground">

--- a/src/app/blog/finlynq-mobile-app/page.tsx
+++ b/src/app/blog/finlynq-mobile-app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { AnalyticsConsent } from "@/components/analytics-consent";
+import { StoreBadges } from "@/components/store-badges";
 import {
   JsonLd,
   articleSchema,
@@ -11,23 +12,23 @@ const SLUG = "finlynq-mobile-app";
 const PUBLISHED = "2026-06-01";
 
 export const metadata: Metadata = {
-  title: "Finlynq is going mobile: Android coming soon, iOS to follow",
+  title: "Finlynq is now on iOS and Android",
   description:
-    "Finlynq now has a native mobile app. The Android version is in final testing on Google Play, with iOS to follow. Check balances, budgets, your portfolio, and net worth on the go, add transactions, import statements, all with the same encryption as the web app.",
+    "Finlynq's native mobile app is here, available on the App Store and Google Play. Check balances, budgets, your portfolio, and net worth on the go, add transactions, import statements, all with the same encryption as the web app.",
   alternates: { canonical: `/blog/${SLUG}` },
   openGraph: {
-    title: "Finlynq is going mobile: Android coming soon, iOS to follow",
+    title: "Finlynq is now on iOS and Android",
     description:
-      "A native companion app for the open-source, MCP-first personal finance app. Android in final testing now, iOS to follow.",
+      "A native companion app for the open-source, MCP-first personal finance app, now on the App Store and Google Play.",
     type: "article",
     url: `/blog/${SLUG}`,
     siteName: "Finlynq",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Finlynq is going mobile",
+    title: "Finlynq is now on iOS and Android",
     description:
-      "Android app in final testing on Google Play, iOS to follow. Same data, same encryption, now in your pocket.",
+      "On the App Store and Google Play now. Same data, same encryption, now in your pocket.",
   },
 };
 
@@ -37,9 +38,9 @@ export default function FinlynqMobileAppPage() {
       <AnalyticsConsent />
       <JsonLd
         data={articleSchema({
-          title: "Finlynq is going mobile: Android coming soon, iOS to follow",
+          title: "Finlynq is now on iOS and Android",
           description:
-            "Finlynq now has a native mobile app. The Android version is in final testing on Google Play, with iOS to follow.",
+            "Finlynq's native mobile app is available now on the App Store and Google Play.",
           path: `/blog/${SLUG}`,
           datePublished: PUBLISHED,
         })}
@@ -48,7 +49,7 @@ export default function FinlynqMobileAppPage() {
         data={breadcrumbSchema([
           { name: "Home", path: "/" },
           { name: "Blog", path: "/blog" },
-          { name: "Finlynq is going mobile", path: `/blog/${SLUG}` },
+          { name: "Finlynq is now on iOS and Android", path: `/blog/${SLUG}` },
         ])}
       />
       <div className="mx-auto max-w-3xl px-6 py-16">
@@ -60,22 +61,24 @@ export default function FinlynqMobileAppPage() {
             ← Finlynq blog
           </Link>
           <h1 className="mt-4 text-4xl font-bold tracking-tight">
-            Finlynq is going mobile: Android coming soon, iOS to follow
+            Finlynq is now on iOS and Android
           </h1>
           <p className="mt-3 text-sm text-muted-foreground">
-            A native companion app for your money · Published 2026-06-01
+            A native companion app for your money · Published 2026-06-01 ·
+            Updated 2026-06-24
           </p>
         </header>
 
         <article className="prose prose-invert max-w-none space-y-6 text-[15px] leading-relaxed">
           <p className="text-base">
             Finlynq has always been two things: a web app where you track your
-            money, and an MCP server that lets your AI assistant query and manage
-            it. There was a gap: when you were away from your desk, you had to
-            open a browser. That gap is closing. Finlynq now has a native mobile
-            app. The Android version is in final testing on Google Play right
-            now, and iOS will follow.
+            money, and an MCP server that lets your AI assistant dig into it. The
+            catch was that the moment you stepped away from your desk, you had to
+            open a browser. Not anymore. Finlynq now has a real native app, and
+            it is live today on both the App Store and Google Play.
           </p>
+
+          <StoreBadges className="not-prose" />
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
             What you can do in the app
@@ -162,12 +165,12 @@ export default function FinlynqMobileAppPage() {
           </h2>
 
           <p>
-            The Android app is built and uploaded to Google Play, currently in a
-            closed testing track while we work through Google&apos;s pre-launch
-            review and a round of real-device testing. A public release on the
-            Play Store is the next step. After that, the iOS build follows: the
-            app is written once in React Native, so the iOS version is a matter
-            of the Apple build and review process, not a rewrite.
+            Both apps are live now: iOS on the App Store, Android on Google
+            Play, built from a single React Native codebase. What comes next is
+            not more platforms, it is depth. We are closing the last gaps with
+            the web app, adding push notifications, and smoothing the rough edges
+            that only show up once people use something every day. If you hit one
+            of those, send feedback from inside the app. It comes straight to us.
           </p>
 
           <p>
@@ -184,14 +187,27 @@ export default function FinlynqMobileAppPage() {
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
-            Want to follow along
+            Get the app
           </h2>
 
           <p>
-            The fastest ways to know the moment the apps go live:
+            Download it now and sign in with your Finlynq account:
           </p>
 
+          <StoreBadges className="not-prose" />
+
           <ul className="list-disc pl-6 space-y-1.5">
+            <li>
+              New to Finlynq? The cloud app is free, and there is a public demo
+              at{" "}
+              <Link
+                href="/cloud"
+                className="underline underline-offset-2 hover:text-primary"
+              >
+                /cloud
+              </Link>
+              .
+            </li>
             <li>
               Star or watch the repo at{" "}
               <a
@@ -203,17 +219,6 @@ export default function FinlynqMobileAppPage() {
               .
             </li>
             <li>
-              Try Finlynq today on the web. The cloud app is free, and there is a
-              public demo at{" "}
-              <Link
-                href="/cloud"
-                className="underline underline-offset-2 hover:text-primary"
-              >
-                /cloud
-              </Link>
-              .
-            </li>
-            <li>
               Have a feature request for mobile? Open an issue at{" "}
               <a
                 href="https://github.com/finlynq/finlynq/issues"
@@ -221,7 +226,7 @@ export default function FinlynqMobileAppPage() {
               >
                 github.com/finlynq/finlynq/issues
               </a>
-              , or send feedback from inside the app once you are in.
+              , or send feedback from inside the app.
             </li>
           </ul>
 

--- a/src/app/blog/how-finlynq-encrypts-your-money/page.tsx
+++ b/src/app/blog/how-finlynq-encrypts-your-money/page.tsx
@@ -12,9 +12,9 @@ const PUBLISHED = "2026-05-13";
 
 export const metadata: Metadata = {
   title:
-    "How Finlynq encrypts your money — envelope encryption, in plain English",
+    "How Finlynq encrypts your money: envelope encryption, in plain English",
   description:
-    "A walkthrough of Finlynq's encryption architecture: AES-256-GCM at rest, a per-user Data Encryption Key wrapped by a scrypt-derived key from your password, and the honest tradeoffs (operator can see anonymized amounts; lose your password, lose your data).",
+    "A walkthrough of Finlynq's encryption: AES-256-GCM at rest, a per-user Data Encryption Key wrapped by a scrypt-derived key from your password, and the tradeoffs I won't pretend away (the operator can see anonymized amounts; lose your password and your data is gone).",
   alternates: { canonical: `/blog/${SLUG}` },
   openGraph: {
     title: "How Finlynq encrypts your money",
@@ -70,117 +70,120 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
 
         <article className="prose prose-invert max-w-none space-y-6 text-[15px] leading-relaxed">
           <p className="text-base">
-            If your AI assistant can read your money, who else can? That is the
-            question I had to answer for myself before I felt okay handing a
-            language model the keys to my real bank data. This post is the
-            honest answer for Finlynq — what is encrypted, what is not, what
-            tradeoffs I accepted, and where you can read the code that
-            implements it.
+            If your AI assistant can read your money, who else can? I had to
+            answer that for myself before I felt okay handing a language model
+            the keys to my real bank data. So here&apos;s the honest answer for
+            Finlynq. What&apos;s encrypted, what isn&apos;t, the tradeoffs I
+            made my peace with, and where you can go read the code that does it.
           </p>
 
           <p>
-            I built Finlynq partly because I wanted a personal-finance app that
-            an AI could query without me having to email a CSV to a chatbot. The
-            unavoidable second question once you build that is: how do you keep
-            the operator (me) honest? Finlynq runs on a single VPS I own. If I
-            wanted to read your transactions, what would stop me?
+            I built Finlynq partly because I wanted a personal-finance app an AI
+            could query without me emailing a CSV to a chatbot. But the moment
+            you build that, a second question shows up and won&apos;t leave: how
+            do you keep the operator (me) honest? Finlynq runs on a single VPS I
+            own. If I wanted to read your transactions, what would actually stop
+            me?
           </p>
 
           <p>
             The answer is{" "}
             <strong>per-user envelope encryption with a key derived from your password</strong>
-            , and it has real teeth. It also has real limits. Both halves are in
-            this post.
+            . It has real teeth. It also has real limits, and I&apos;d rather
+            you hear about both from me. So both are in this post.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
-            1. The threat model — what we are and aren&apos;t protecting against
+            1. The threat model, or what we are and aren&apos;t protecting
+            against
           </h2>
 
           <p>
-            Encryption schemes only make sense relative to a threat. Here are
-            the threats Finlynq&apos;s design takes seriously:
+            Encryption only means something if you say what it&apos;s protecting
+            against. So here are the threats Finlynq&apos;s design actually takes
+            seriously:
           </p>
 
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
               <strong>Stolen database dump.</strong> Someone gets read access to
-              the Postgres database — disk image, pg_dump, or an unauthorized
-              backup copy. They should not be able to read your merchant names,
-              account names, notes, tags, or categories from that dump alone.
+              the Postgres database. A disk image, a pg_dump, an unauthorized
+              backup copy, whatever. They should not be able to read your
+              merchant names, account names, notes, tags, or categories from
+              that dump alone.
             </li>
             <li>
               <strong>Stolen database <em>and</em> server filesystem.</strong>{" "}
-              An attacker has the DB plus the server&apos;s environment
-              variables. The pepper helps (more below), but they would still
-              need to brute-force every user&apos;s password individually.
-              That&apos;s slow on purpose.
+              Now an attacker has the DB plus the server&apos;s environment
+              variables. The pepper helps here (more on that below), but they
+              would still have to brute-force every user&apos;s password one at a
+              time. That&apos;s slow on purpose.
             </li>
             <li>
               <strong>Stale backups in cloud storage.</strong> Database backups
-              are encrypted on disk with a symmetric key kept off the host, so a
-              copy floating around a backup bucket does not equal a breach.
+              are encrypted on disk with a symmetric key kept off the host. So a
+              copy floating around some backup bucket isn&apos;t a breach by
+              itself.
             </li>
             <li>
               <strong>Cross-tenant data leaks.</strong> One user&apos;s data
-              should never become readable by another user via a buggy import,
-              backup restore, or account wipe.
+              should never become readable by another user. Not through a buggy
+              import, not a backup restore, not an account wipe.
             </li>
           </ul>
 
           <p>
-            Here are the threats Finlynq does <em>not</em> claim to defend
-            against — and you should know this before you trust the system:
+            And here are the threats Finlynq does <em>not</em> claim to defend
+            against. You should know these before you trust the system:
           </p>
 
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
               <strong>A malicious or compromised operator at runtime.</strong>{" "}
-              When you are signed in, your decryption key is held in the
-              server&apos;s memory. An attacker who roots the server while you
-              are using it can read it. There is no honest way around this for
-              a web app that responds to your queries server-side; only a true
-              client-side-only design avoids it, and that comes with its own
-              set of compromises (no server-side aggregation, no MCP, no AI
-              assistant access).
+              When you&apos;re signed in, your decryption key is sitting in the
+              server&apos;s memory. An attacker who roots the box while
+              you&apos;re using it can read it. I&apos;m not going to pretend
+              there&apos;s a clean way around this for a web app that answers
+              your queries server-side. Only a true client-side-only design
+              dodges it, and that comes with its own pile of compromises (no
+              server-side aggregation, no MCP, no AI assistant access).
             </li>
             <li>
               <strong>The amounts and dates of your transactions.</strong> These
-              are stored as plain numbers and dates in the database. They must
-              be — otherwise the app could not sum your spending, compute a
-              budget, or feed an AI assistant a portfolio analysis without your
-              browser doing all the math. The operator can see anonymized
-              amounts and dates. They are useless without the labels, but they
-              are not encrypted.
+              live in the database as plain numbers and dates. They have to.
+              Otherwise the app couldn&apos;t sum your spending, build a budget,
+              or hand an AI a portfolio analysis without your browser doing all
+              the math. So the operator can see anonymized amounts and dates.
+              They&apos;re useless without the labels, but they&apos;re not
+              encrypted, and I&apos;m not going to dress that up.
             </li>
             <li>
               <strong>The structure of your data.</strong> The fact that you
               have 14 accounts, 320 transactions a month, and a 7.4% savings
-              rate is visible to the operator. Just not <em>what</em> any of
-              them are for.
+              rate is visible to the operator. Just not <em>what</em> any of it
+              is for.
             </li>
             <li>
               <strong>Side-channel inference.</strong> If your &ldquo;Account
               #3&rdquo; has a recurring $1,847.00 charge on the 15th of every
-              month and you live in a major city, a determined operator could
-              guess &ldquo;that&apos;s probably rent.&rdquo; Encryption does
-              not stop guesses. It stops <em>reading</em>.
+              month, and you live in a big city, a determined operator could
+              guess &ldquo;that&apos;s probably rent.&rdquo; Encryption
+              doesn&apos;t stop guesses. It stops <em>reading</em>.
             </li>
             <li>
               <strong>A subpoena.</strong> Operators get subpoenaed. Finlynq is
-              operated from Canada and we have a privacy policy with retention
-              rules, but a court order is a court order — what we could be
-              compelled to hand over is the encrypted data plus whatever
-              metadata the database contains. Without your password, even we
-              cannot read the labels.
+              run from Canada and we have a privacy policy with retention rules,
+              but a court order is a court order. What we could be forced to hand
+              over is the encrypted data plus whatever metadata the database
+              holds. Without your password, even we can&apos;t read the labels.
             </li>
           </ul>
 
           <p>
-            If any of the second list is a dealbreaker for you, self-hosting is
-            the right answer. Finlynq is AGPL v3 — the same code runs on your
-            laptop or homelab as on our managed cloud. The full self-hosting
-            guide is at{" "}
+            If anything in that second list is a dealbreaker for you,
+            self-hosting is the right answer. Finlynq is AGPL v3, so the exact
+            same code runs on your laptop or homelab as on our managed cloud.
+            The full self-hosting guide is at{" "}
             <Link href="/self-hosted" className="underline underline-offset-2 hover:text-primary">
               /self-hosted
             </Link>
@@ -199,21 +202,21 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
 
           <ol className="list-decimal pl-6 space-y-2">
             <li>
-              A <strong>Data Encryption Key</strong> (DEK) — 32 random bytes,
-              one per user, generated the moment you sign up. This is the key
-              that actually encrypts your fields.
+              A <strong>Data Encryption Key</strong> (DEK). 32 random bytes, one
+              per user, generated the moment you sign up. This is the key that
+              actually encrypts your fields.
             </li>
             <li>
-              A <strong>Key Encryption Key</strong> (KEK) — derived from your
-              password every time you sign in. The KEK&apos;s only job is to
-              wrap and unwrap the DEK.
+              A <strong>Key Encryption Key</strong> (KEK). Derived fresh from
+              your password every time you sign in. Its only job is to wrap and
+              unwrap the DEK.
             </li>
           </ol>
 
           <p>
-            The DEK never leaves the server, but it&apos;s only useful when
-            unwrapped, and unwrapping requires your password. Here&apos;s the
-            sequence in slightly more detail.
+            The DEK never leaves the server, but it&apos;s only useful once
+            it&apos;s unwrapped, and unwrapping it takes your password.
+            Here&apos;s the sequence in a bit more detail.
           </p>
 
           <p>
@@ -221,8 +224,8 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
-              Finlynq generates a fresh, random 32-byte DEK using the OS random
-              source.
+              Finlynq generates a fresh, random 32-byte DEK straight from the OS
+              random source.
             </li>
             <li>
               It also generates a 16-byte random salt and runs your password
@@ -234,19 +237,19 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
                 scrypt
               </a>{" "}
               with parameters{" "}
-              <code>N = 2<sup>16</sup>, r = 8, p = 1</code> — roughly 64 MB of
-              memory and ~80 ms of compute per derivation on modern hardware.
-              That&apos;s the KEK.
+              <code>N = 2<sup>16</sup>, r = 8, p = 1</code>. That&apos;s roughly
+              64 MB of memory and around 80 ms of compute per derivation on
+              modern hardware. The result is the KEK.
             </li>
             <li>
-              The DEK is wrapped (encrypted) with the KEK using AES-256-GCM,
-              and the wrapped DEK plus the salt are stored in your{" "}
+              The DEK gets wrapped (encrypted) with the KEK using AES-256-GCM,
+              and the wrapped DEK plus the salt go into your{" "}
               <code>users</code> row.
             </li>
             <li>
-              The raw KEK is discarded the moment the wrap finishes. The
-              database now contains a wrapped DEK and a salt — and nothing on
-              the server can unwrap that DEK without your password.
+              The raw KEK is thrown away the instant the wrap finishes. So now
+              the database holds a wrapped DEK and a salt, and nothing on the
+              server can unwrap that DEK without your password. Nothing.
             </li>
           </ul>
 
@@ -260,16 +263,15 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
               re-derive your KEK.
             </li>
             <li>
-              It uses the KEK to unwrap your DEK and caches the raw DEK in
+              It uses that KEK to unwrap your DEK and caches the raw DEK in
               memory, keyed by your session id.
             </li>
             <li>
-              The KEK is again discarded immediately. The cache holds only the
-              DEK, and only for the lifetime of your session — with a sliding
-              2-hour idle timeout. If you walk away from your laptop for the
-              afternoon, your DEK is gone from memory by the time you come
-              back, and the next request decrypts nothing until you sign in
-              again.
+              The KEK gets discarded again, right away. The cache holds only the
+              DEK, and only for the life of your session, with a sliding 2-hour
+              idle timeout. Walk away from your laptop for the afternoon and your
+              DEK is already gone from memory by the time you come back. The next
+              request decrypts nothing until you sign in again.
             </li>
           </ul>
 
@@ -281,36 +283,35 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
               For every encrypted column on every row, Finlynq runs AES-256-GCM
               with a freshly-random 12-byte IV. The output is stored as{" "}
               <code>v1:&lt;base64 iv&gt;:&lt;base64 ciphertext&gt;:&lt;base64 auth-tag&gt;</code>.
-              The{" "}
-              <code>v1:</code> prefix is a version marker so we can rotate
-              schemes later without ambiguity.
+              That{" "}
+              <code>v1:</code> prefix is just a version marker, so we can rotate
+              schemes down the road without any guesswork.
             </li>
             <li>
-              GCM is an{" "}
-              <em>authenticated</em> encryption mode — every row has a 16-byte
-              authentication tag that&apos;s checked on decrypt. If a single bit
-              of the ciphertext was tampered with, decryption fails loudly
-              instead of returning subtly wrong plaintext.
+              GCM is an <em>authenticated</em> encryption mode. Every row carries
+              a 16-byte authentication tag that gets checked on decrypt. Flip a
+              single bit of the ciphertext and decryption fails loudly, instead
+              of quietly handing back wrong plaintext.
             </li>
             <li>
-              Random IV per row means even if two transactions have the exact
-              same payee name, their ciphertexts are completely different. The
-              operator can&apos;t even tell that &ldquo;you shop at the same
-              place twice.&rdquo;
+              A random IV per row means even if two transactions have the exact
+              same payee name, their ciphertexts look nothing alike. The operator
+              can&apos;t even tell that &ldquo;you shop at the same place
+              twice.&rdquo;
             </li>
           </ul>
 
           <p>
-            One extra detail worth calling out: the password input to scrypt is
-            not the raw password. It&apos;s{" "}
+            One more detail worth calling out. The password fed into scrypt
+            isn&apos;t the raw password. It&apos;s{" "}
             <code>HMAC-SHA256(server-pepper, password)</code>, where the pepper
-            is a long random secret stored in the server&apos;s environment and
-            never in the database. The pepper exists to defend against a
-            database-only leak: even a stolen DB plus a 1080 Ti can&apos;t
-            mount an offline scrypt-cracking run without also stealing the
-            pepper out of the server&apos;s environment. The pepper is not a
-            user-facing feature — losing it is the same as losing the DB — but
-            it raises the bar against database-only theft, which is the most
+            is a long random secret that lives in the server&apos;s environment
+            and never touches the database. The whole point of the pepper is to
+            blunt a database-only leak: even a stolen DB plus a 1080 Ti
+            can&apos;t mount an offline scrypt-cracking run without also lifting
+            the pepper out of the server&apos;s environment. It&apos;s not a
+            user-facing thing, and losing it is the same as losing the DB. But it
+            raises the bar against database-only theft, which is by far the most
             common breach shape.
           </p>
 
@@ -322,8 +323,8 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
             >
               <code>pf-app/src/lib/crypto/envelope.ts</code>
             </a>
-            . It&apos;s about 280 lines including comments. AGPL v3, read it
-            yourself.
+            . It&apos;s about 280 lines, comments and all. AGPL v3, so go read it
+            yourself. Please do.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -331,12 +332,12 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
           </h2>
 
           <p>
-            Here is what the operator (me) can and cannot see when I open a
-            psql shell against the production database:
+            Here&apos;s exactly what the operator (me) can and can&apos;t see
+            when I open a psql shell against the production database:
           </p>
 
           <p>
-            <strong>I cannot decrypt:</strong>
+            <strong>What I cannot decrypt:</strong>
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>The payee on any transaction.</li>
@@ -345,63 +346,62 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
             <li>
               The display names of your accounts, categories, goals, loans,
               subscriptions, and portfolio holdings. These were the last
-              plaintext labels in the database — they were physically dropped
-              from the schema on 2026-05-03 in a project we called Stream D
-              Phase 4. The plaintext columns are gone; only the encrypted
-              versions remain.
+              plaintext labels left in the database, and they got physically
+              dropped from the schema on 2026-05-03 in a project we called
+              Stream D Phase 4. The plaintext columns are gone now. Only the
+              encrypted versions remain.
             </li>
             <li>
               The encrypted attachment of any receipt you upload to the file
               store.
             </li>
-            <li>The aliases you assigned to your accounts.</li>
+            <li>The aliases you gave your accounts.</li>
           </ul>
 
           <p>
-            <strong>I can see:</strong>
+            <strong>What I can see:</strong>
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
               The numeric amount of every transaction, and the currency code.
             </li>
             <li>
-              The transaction date and the date the row was created or last
+              The transaction date, plus the date the row was created or last
               updated.
             </li>
             <li>
-              The integer foreign keys that connect a transaction to an
+              The integer foreign keys that tie a transaction to an
               (encrypted-name) account and an (encrypted-name) category.
             </li>
             <li>
               Whether a row is a regular transaction, a transfer, an income, or
-              an expense — the one-character{" "}
+              an expense. That one-character{" "}
               <code>type</code> column (<code>E</code> / <code>I</code> /{" "}
-              <code>R</code> / <code>T</code>) is plaintext because the
+              <code>R</code> / <code>T</code>) stays plaintext, because the
               category-vs-sign invariant has to be checked server-side.
             </li>
             <li>
               How many accounts, categories, goals, and holdings you have, and
-              the structural shape of your portfolio (counts, dates, integer
-              IDs).
+              the overall shape of your portfolio (counts, dates, integer IDs).
             </li>
           </ul>
 
           <p>
-            In other words: I can see &ldquo;there&apos;s a $42.18 expense on
-            2026-04-09 in category #14, account #3.&rdquo; I cannot see what
-            category #14 is, what account #3 is, who the payee was, or what
-            note you wrote on it. The amounts and dates are visible. The labels
+            Put another way: I can see &ldquo;there&apos;s a $42.18 expense on
+            2026-04-09 in category #14, account #3.&rdquo; I can&apos;t see what
+            category #14 is, what account #3 is, who the payee was, or what note
+            you scribbled on it. The amounts and dates are visible. The labels
             are not.
           </p>
 
           <p>
             This is the honest version of the privacy claim. The landing page
             says &ldquo;Mathematically private,&rdquo; and that&apos;s true{" "}
-            <em>about the labels</em> — they really are sealed by a key derived
-            from your password. But it overstates the case if you read it as
+            <em>about the labels</em>. They really are sealed by a key derived
+            from your password. But it overstates things if you read it as
             &ldquo;the operator sees nothing.&rdquo; The operator sees plenty.
-            The operator just can&apos;t read the labels that turn those
-            numbers into meaningful information about your life.
+            The operator just can&apos;t read the labels that turn those numbers
+            into anything meaningful about your life.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -409,64 +409,63 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
           </h2>
 
           <p>
-            Three tradeoffs worth being explicit about.
+            Three tradeoffs I want to be flat-out about.
           </p>
 
           <p>
             <strong>Tradeoff 1: lose your password, lose your data.</strong>{" "}
-            Finlynq has no recovery key, no admin override, no master
-            decryption key kept on ice for emergencies. If you forget your
-            password, the &ldquo;reset&rdquo; flow does the only thing it
-            cryptographically can: it wipes all your data and provisions a
-            fresh DEK under your new password. There is no way to call support
-            and recover what was in there. This is by design — any recovery
-            mechanism would necessarily mean Finlynq holds something that can
-            decrypt your data, which is exactly what we&apos;re promising
-            isn&apos;t the case.
+            Finlynq has no recovery key, no admin override, no master decryption
+            key sitting on ice for emergencies. If you forget your password, the
+            &ldquo;reset&rdquo; flow does the only thing it cryptographically
+            can: it wipes all your data and hands you a fresh DEK under your new
+            password. There&apos;s no calling support to recover what was in
+            there. And that&apos;s on purpose. Any recovery mechanism would mean
+            Finlynq is holding something that can decrypt your data, which is the
+            exact thing we&apos;re promising isn&apos;t true.
           </p>
 
           <p>
-            This is a real cost. People do forget passwords. The mitigation is
-            simple but boring: pick a password from a password manager, write
-            it down somewhere physically secure, and export an unencrypted JSON
-            backup to your own machine periodically (Settings → Data →
-            Export). Finlynq can&apos;t save you from losing your password, but
+            This is a real cost. People forget passwords, it happens. The fix is
+            simple, if boring: pick a password from a password manager, write it
+            down somewhere physically safe, and now and then export an
+            unencrypted JSON backup to your own machine (Settings → Data →
+            Export). Finlynq can&apos;t save you from losing your password. But
             you can save yourself.
           </p>
 
           <p>
-            <strong>Tradeoff 2: amounts and dates are not encrypted.</strong>{" "}
-            Some personal-finance apps encrypt the amounts too, computing all
-            aggregations in the browser. That&apos;s a defensible design — it
-            shrinks what the operator can see — but it also makes the things
+            <strong>Tradeoff 2: amounts and dates aren&apos;t encrypted.</strong>{" "}
+            Some personal-finance apps encrypt the amounts too and do all the
+            aggregation in the browser. That&apos;s a defensible design. It does
+            shrink what the operator can see. But it also makes the things
             Finlynq cares most about (server-side MCP tools, aggregate queries
-            from an AI assistant, multi-currency conversion, the FIRE
-            calculator) either impossible or very slow. We made the call that
-            the value of an AI being able to answer &ldquo;what was my total
-            spend last month?&rdquo; server-side outweighs the marginal privacy
-            cost of the operator seeing un-labelled amounts.
+            from an AI, multi-currency conversion, the FIRE calculator) either
+            impossible or painfully slow. So I made the call: an AI being able to
+            answer &ldquo;what was my total spend last month?&rdquo; server-side
+            is worth more than the slim privacy gain of hiding un-labelled
+            amounts from the operator.
           </p>
 
           <p>
-            If you disagree with that call — and reasonable people do — the
-            answer is self-hosting. When you self-host, &ldquo;the operator
-            sees the amounts&rdquo; collapses to &ldquo;you see the
-            amounts,&rdquo; which presumably is fine.
+            If you disagree with that call, and reasonable people do, the answer
+            is self-hosting. When you self-host, &ldquo;the operator sees the
+            amounts&rdquo; quietly becomes &ldquo;you see the amounts,&rdquo;
+            which is presumably fine.
           </p>
 
           <p>
             <strong>Tradeoff 3: deploys briefly degrade the read path.</strong>{" "}
-            The DEK cache lives in process memory, so when Finlynq restarts —
-            for a deploy, a crash, a maintenance window — every signed-in user
-            momentarily has a valid session cookie but no cached DEK on the
-            server. Rather than 503ing every page until everyone re-logs in,
-            read paths handle this gracefully: encrypted fields render as a
-            placeholder, the app keeps working, and the next sign-in restores
-            normal display. Writes that need the key block until you re-sign-in,
-            because silently writing plaintext into encrypted columns would be
+            The DEK cache lives in process memory, so whenever Finlynq restarts
+            (a deploy, a crash, a maintenance window) every signed-in user
+            suddenly has a valid session cookie but no cached DEK on the server.
+            Instead of 503ing every page until everyone logs back in, the read
+            paths handle it gracefully: encrypted fields render as a placeholder,
+            the app keeps working, and your next sign-in puts everything back to
+            normal. Writes that need the key block until you re-sign-in, because
+            silently writing plaintext into encrypted columns would be a lot
             worse than blocking. There&apos;s also a deploy-generation marker
-            that proactively invalidates old sessions across a deploy boundary
-            so you get a clean re-auth instead of a degraded one.
+            that proactively kills old sessions across a deploy boundary, so you
+            get a clean re-auth instead of a half-broken one.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -475,55 +474,55 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
 
           <p>
             Finlynq&apos;s pitch is &ldquo;track your money here, analyze it
-            anywhere.&rdquo; The &ldquo;anywhere&rdquo; is the{" "}
+            anywhere.&rdquo; The &ldquo;anywhere&rdquo; part is the{" "}
             <a
               href="https://modelcontextprotocol.io"
               className="underline underline-offset-2 hover:text-primary"
             >
               Model Context Protocol
             </a>{" "}
-            server, with 109 HTTP tools (93 over stdio) that let Claude,
-            ChatGPT, Cursor, or any other MCP-compatible AI assistant query and
-            mutate your financial data on your behalf.
+            server, with 109 HTTP tools (93 over stdio) that let Claude, ChatGPT,
+            Cursor, or any other MCP-compatible AI assistant query and change
+            your financial data on your behalf.
           </p>
 
           <p>
-            The encryption model matters here because of a question every
-            cautious user asks before they connect an AI to their bank data:{" "}
-            <em>where does the data actually go, and who sees it?</em>
+            The encryption model matters here because of the one question every
+            cautious person asks before they wire an AI up to their bank data:{" "}
+            <em>where does the data actually go, and who gets to see it?</em>
           </p>
 
           <p>
-            The answer for Finlynq is layered:
+            For Finlynq, the answer comes in layers:
           </p>
 
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
               Your <strong>raw data</strong> lives in Finlynq&apos;s database,
-              with the labels encrypted at rest as described above.
+              with the labels encrypted at rest, exactly as described above.
             </li>
             <li>
               When an AI assistant calls an MCP tool, it authenticates with
               either OAuth 2.1, a Bearer API key, or stdio. The server unwraps
-              your DEK on that request, decrypts only what that tool needs to
-              return, and the tool&apos;s response goes back to the AI as
-              plaintext JSON. The AI provider (Anthropic, OpenAI, whoever) does
-              see that response — that is unavoidable if you want the AI to
-              answer questions about it.
+              your DEK for that request, decrypts only what the tool actually
+              needs to return, and the tool&apos;s response heads back to the AI
+              as plaintext JSON. The AI provider (Anthropic, OpenAI, whoever)
+              does see that response. There&apos;s no way around it if you want
+              the AI to answer questions about your data.
             </li>
             <li>
-              That MCP session is <em>scoped</em>: it gets read-only or
-              read-write tools according to the OAuth scope you granted; you
-              can revoke the grant from Settings → Connected apps at any time;
-              destructive operations require a preview-then-confirm
-              cryptographic token so the AI cannot mutate your data without
-              your explicit step.
+              That MCP session is <em>scoped</em>. It gets read-only or
+              read-write tools based on the OAuth scope you granted, you can
+              revoke the grant from Settings → Connected apps whenever you like,
+              and destructive operations need a preview-then-confirm
+              cryptographic token, so the AI can&apos;t change your data without
+              you taking an explicit step.
             </li>
             <li>
-              We do not train models on your data. The MCP server is a tool
+              We don&apos;t train models on your data. The MCP server is a tool
               gateway, not an ingest pipeline. Anything that crosses the AI
-              vendor&apos;s API is governed by{" "}
-              <em>their</em> privacy policy — refer to{" "}
+              vendor&apos;s API is governed by <em>their</em> privacy policy, so
+              check{" "}
               <a
                 href="https://www.anthropic.com/legal/privacy"
                 className="underline underline-offset-2 hover:text-primary"
@@ -537,18 +536,18 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
               >
                 OpenAI&apos;s
               </a>{" "}
-              for the details — but the connection from your data to that
-              vendor is one you explicitly authorize and can revoke.
+              for the specifics. But the link between your data and that vendor
+              is one you explicitly turn on, and can turn off.
             </li>
           </ul>
 
           <p>
-            So if you&apos;re worried about AI assistants getting access to
-            your financial life: the answer isn&apos;t &ldquo;never grant the
-            access.&rdquo; The useful answer is &ldquo;grant a scoped,
-            revocable, observable session, and use a backend that can&apos;t
-            read the data on its own.&rdquo; That second half is what the
-            encryption model buys you.
+            So if you&apos;re nervous about AI assistants reaching into your
+            financial life, the answer isn&apos;t &ldquo;never grant the
+            access.&rdquo; The useful answer is &ldquo;grant a scoped, revocable,
+            observable session, and run it on a backend that can&apos;t read the
+            data on its own.&rdquo; That second half is the part the encryption
+            model buys you.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -556,9 +555,9 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
           </h2>
 
           <p>
-            Everything in this post is described in more rigorous detail in the
-            architecture docs, and the code that implements it is published
-            under AGPL v3:
+            Everything in this post is spelled out in more rigorous detail in
+            the architecture docs, and the code behind it is published under
+            AGPL v3:
           </p>
 
           <ul className="list-disc pl-6 space-y-1.5">
@@ -569,12 +568,12 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
               >
                 <code>pf-app/docs/architecture/encryption.md</code>
               </a>{" "}
-              — the authoritative technical reference. Covers Phase 2, Phase 3,
-              and the Stream D rollout that finally encrypted display names; the
-              auth-tag failure resilience helper that prevented a class of
-              regressions; the wipe-account primitive; the backup-restore
-              foreign-key remap; the grace migration for pre-encryption
-              accounts.
+              is the authoritative technical reference. It covers Phase 2, Phase
+              3, and the Stream D rollout that finally encrypted display names,
+              plus the auth-tag failure resilience helper that headed off a whole
+              class of regressions, the wipe-account primitive, the
+              backup-restore foreign-key remap, and the grace migration for
+              pre-encryption accounts.
             </li>
             <li>
               <a
@@ -583,8 +582,8 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
               >
                 <code>pf-app/src/lib/crypto/</code>
               </a>{" "}
-              — the implementation. Roughly 1,500 lines across envelope, key
-              cache, column helpers, staging envelope, file envelope. Small
+              is the implementation. Roughly 1,500 lines across envelope, key
+              cache, column helpers, staging envelope, and file envelope. Small
               enough to read in an afternoon.
             </li>
             <li>
@@ -594,8 +593,8 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
               >
                 <code>STREAM_D.md</code>
               </a>{" "}
-              — the design doc for the display-name encryption rollout. Useful
-              if you want to understand the parallel{" "}
+              is the design doc for the display-name encryption rollout. Worth a
+              look if you want to understand the parallel{" "}
               <code>(name_ct, name_lookup)</code> column pattern that lets
               encrypted strings still support exact-match SQL queries and
               per-user unique constraints.
@@ -607,7 +606,7 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
               >
                 /privacy
               </Link>{" "}
-              — the policy version of all this, with GDPR Article 30 records,
+              is the policy version of all of this, with GDPR Article 30 records,
               retention rules, and the sub-processor list.
             </li>
             <li>
@@ -616,16 +615,16 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
                 className="underline underline-offset-2 hover:text-primary"
               >
                 /self-hosted
-              </Link>{" "}
-              — if the &ldquo;trust the operator&rdquo; layer is the part you
-              want to skip, run Finlynq on your own hardware. Same code, same
-              encryption, you&apos;re the operator.
+              </Link>
+              . If the &ldquo;trust the operator&rdquo; layer is the part
+              you&apos;d rather skip, run Finlynq on your own hardware. Same code,
+              same encryption, except now you&apos;re the operator.
             </li>
           </ul>
 
           <p>
-            And if you find something in the design or the code that&apos;s
-            wrong — or weaker than this post claims — please tell me. Email{" "}
+            And if you spot something in the design or the code that&apos;s
+            wrong, or just weaker than this post claims, please tell me. Email{" "}
             <code>privacy@finlynq.com</code>, or open an issue at{" "}
             <a
               href="https://github.com/finlynq/finlynq/issues"
@@ -633,9 +632,9 @@ export default function HowFinlynqEncryptsYourMoneyPage() {
             >
               github.com/finlynq/finlynq/issues
             </a>
-            . An honest threat model is more useful than a confident one, and
-            the only way it stays honest is if people who know more than me
-            keep poking holes.
+            . An honest threat model beats a confident one every time, and the
+            only way it stays honest is if people who know more than I do keep
+            poking holes in it.
           </p>
 
           <p className="mt-12 text-xs text-muted-foreground">

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -3,9 +3,9 @@ import type { Metadata } from "next";
 import { AnalyticsConsent } from "@/components/analytics-consent";
 
 export const metadata: Metadata = {
-  title: "Blog — Finlynq",
+  title: "Blog · Finlynq",
   description:
-    "Long-form writing about the Finlynq personal-finance app: encryption architecture, MCP design, AI in personal finance, open-source operations.",
+    "Long-form writing about the Finlynq personal-finance app: encryption architecture, MCP design, AI in personal finance, and what it's like running an open-source app.",
   alternates: { canonical: "/blog" },
   openGraph: {
     title: "Finlynq blog",
@@ -35,14 +35,14 @@ const POSTS: Post[] = [
     slug: "finlynq-mobile-app",
     title: "Finlynq is now on iOS and Android",
     blurb:
-      "Finlynq's native mobile app is here, available on the App Store and Google Play. Check balances, budgets, your portfolio, and net worth on the go, add transactions, import statements, all with the same encryption as the web app. Self-hosters can point it at their own instance.",
+      "The native app is finally here, on the App Store and Google Play. Check your balances, budgets, portfolio, and net worth from your phone. Add transactions, import statements, the works. Same encryption as the web app, no shortcuts. And if you self-host, just point it at your own instance.",
     date: "2026-06-01",
   },
   {
     slug: "how-finlynq-encrypts-your-money",
     title: "How Finlynq encrypts your money",
     blurb:
-      "Envelope encryption, in plain English. AES-256-GCM, a scrypt-derived key from your password, a per-user DEK, and the honest tradeoffs (operator can see anonymized amounts; lose your password, lose your data).",
+      "Envelope encryption, explained like a human would. AES-256-GCM, a scrypt-derived key from your password, a DEK per user, and the tradeoffs I'm not going to pretend away (the operator can still see anonymized amounts, and if you lose your password, your data is gone).",
     date: "2026-05-13",
   },
 ];
@@ -61,8 +61,8 @@ export default function BlogIndexPage() {
           </Link>
           <h1 className="mt-4 text-4xl font-bold tracking-tight">Blog</h1>
           <p className="mt-3 text-sm text-muted-foreground">
-            Long-form writing on encryption, MCP design, and running an
-            open-source personal-finance app.
+            Longer pieces on encryption, MCP design, and what it&apos;s
+            actually like to run an open-source personal-finance app.
           </p>
         </header>
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -33,9 +33,9 @@ type Post = {
 const POSTS: Post[] = [
   {
     slug: "finlynq-mobile-app",
-    title: "Finlynq is going mobile: Android coming soon, iOS to follow",
+    title: "Finlynq is now on iOS and Android",
     blurb:
-      "Finlynq now has a native mobile app. The Android version is in final testing on Google Play, with iOS to follow. Check balances, budgets, your portfolio, and net worth on the go, add transactions, import statements, all with the same encryption as the web app. Self-hosters can point it at their own instance.",
+      "Finlynq's native mobile app is here, available on the App Store and Google Play. Check balances, budgets, your portfolio, and net worth on the go, add transactions, import statements, all with the same encryption as the web app. Self-hosters can point it at their own instance.",
     date: "2026-06-01",
   },
   {

--- a/src/app/cloud/layout.tsx
+++ b/src/app/cloud/layout.tsx
@@ -1,21 +1,21 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Finlynq cloud — free managed personal finance with MCP",
+  title: "Finlynq cloud: free managed personal finance with MCP",
   description:
-    "Log in or register for Finlynq's free managed cloud. No infrastructure to manage. Same code as the self-hosted edition, with a first-party MCP server and per-user envelope encryption.",
+    "Log in or register for Finlynq's free managed cloud. There's no infrastructure to manage. It's the same code as the self-hosted edition, with a first-party MCP server and per-user envelope encryption.",
   alternates: { canonical: "/cloud" },
   openGraph: {
-    title: "Finlynq cloud — free managed personal finance",
+    title: "Finlynq cloud: free managed personal finance",
     description:
-      "Free managed Finlynq. No infrastructure to manage. Same features as self-host, with a first-party MCP server.",
+      "Free managed Finlynq, with no infrastructure to manage. It's the same features as self-host, plus a first-party MCP server.",
     url: "/cloud",
     type: "website",
     siteName: "Finlynq",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Finlynq cloud — free managed personal finance",
+    title: "Finlynq cloud: free managed personal finance",
     description:
       "Free managed Finlynq with a first-party MCP server and per-user envelope encryption.",
   },

--- a/src/app/cloud/page.tsx
+++ b/src/app/cloud/page.tsx
@@ -24,7 +24,7 @@ function CloudAuthPageInner() {
   const redirectTo = searchParams.get("redirect") ?? "/dashboard";
   // ?demo=1 pre-fills the login form with the published demo credentials so
   // a marketing link can drop users one click away from Sign In. Reuses the
-  // normal /api/auth/login path — no auto-submit — so the user explicitly
+  // normal /api/auth/login path (no auto-submit) so the user explicitly
   // consents to the action. For zero-click full auto-login + redirect, see
   // the /try-demo route.
   const demoPrefill = searchParams.get("demo") === "1";
@@ -147,7 +147,7 @@ function CloudAuthPageInner() {
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
-    // Last-mile guard — the server enforces this too, but failing fast in the
+    // Last-mile guard. The server enforces this too, but failing fast in the
     // UI avoids a roundtrip and keeps the message inline.
     if (!registerEmail.trim() && !acknowledgeNoRecovery) {
       setError(
@@ -213,8 +213,8 @@ function CloudAuthPageInner() {
         </h1>
         <p className="mb-8 text-muted-foreground">
           {tab === "register"
-            ? "Sign up to track your money here and analyze it anywhere. Access your data from any device."
-            : "Sign in with your account. Access your data from any device."}
+            ? "Sign up to track your money here and analyze it anywhere. Your data follows you to any device."
+            : "Sign in to your account. Your data follows you to any device."}
         </p>
         {tab === "register" && (
           <p className="mb-8 -mt-6 text-xs text-muted-foreground/80">
@@ -258,7 +258,7 @@ function CloudAuthPageInner() {
           <>
             {demoPrefill && tab === "login" && (
               <div className="mb-6 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2.5 text-xs text-foreground/90">
-                Demo credentials pre-filled — click <strong>Sign In</strong> to
+                Demo credentials are pre-filled. Just click <strong>Sign In</strong> to
                 enter the public demo. Data resets nightly.
               </div>
             )}
@@ -327,8 +327,8 @@ function CloudAuthPageInner() {
                       id={usernameHelpId}
                       className="mt-1.5 text-xs text-muted-foreground/80"
                     >
-                      3–254 chars. Letters, digits, and{" "}
-                      <span className="font-mono">. @ + _ -</span>. Pick anything that hides your
+                      3 to 254 chars. Letters, digits, and{" "}
+                      <span className="font-mono">. @ + _ -</span>. Pick something that hides your
                       identity if your data ever leaks.
                     </p>
                     {availability.status === "checking" && (
@@ -378,7 +378,7 @@ function CloudAuthPageInner() {
                     className="w-full rounded-lg border border-border bg-background px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   />
                   <p className="mt-1.5 text-xs text-muted-foreground/80">
-                    Used only for password reset. Leave blank for full zero-knowledge — but you{`’`}ll
+                    Used only for password reset. Leave it blank for full zero-knowledge, but then you{`’`}ll
                     have no way to recover a forgotten password.
                   </p>
                 </div>
@@ -410,7 +410,7 @@ function CloudAuthPageInner() {
                     className="mt-0.5 h-4 w-4 shrink-0 rounded border-border bg-background accent-primary"
                   />
                   <span>
-                    I understand. Finlynq encrypts everything with my password — there{`’`}s
+                    I understand. Finlynq encrypts everything with my password, and there{`’`}s
                     no recovery key. Forgetting it means losing all my data. Without an
                     email I also can{`’`}t reset the password at all.
                   </span>

--- a/src/app/glossary/page.tsx
+++ b/src/app/glossary/page.tsx
@@ -5,7 +5,7 @@ import { JsonLd, breadcrumbSchema } from "@/components/seo/json-ld";
 import { GLOSSARY } from "@/lib/seo/glossary";
 
 export const metadata: Metadata = {
-  title: "Glossary — personal finance, MCP & encryption terms | Finlynq",
+  title: "Glossary: personal finance, MCP & encryption terms | Finlynq",
   description:
     "Plain-English definitions of the concepts behind Finlynq: MCP servers, envelope encryption, zero-knowledge personal finance, self-hosting, and lot-tracked cost basis.",
   alternates: { canonical: "/glossary" },
@@ -49,7 +49,7 @@ export default function GlossaryIndexPage() {
           </div>
           <h1 className="mt-4 text-4xl font-bold tracking-tight">Glossary</h1>
           <p className="mt-4 text-base leading-relaxed text-muted-foreground">
-            Plain-English definitions of the concepts behind Finlynq — the open-
+            Plain-English definitions of the concepts behind Finlynq, the open-
             source, MCP-first, end-to-end-encrypted personal finance app.
           </p>
         </header>

--- a/src/app/landing.css
+++ b/src/app/landing.css
@@ -262,8 +262,8 @@ html:has(.fl-landing) body {
   border-radius: 999px;
   font-weight: 500;
 }
-/* Second hero pill ("mobile coming soon") — forced onto its own line below
-   the MCP pill, sized to content, and clickable through to the blog post. */
+/* Second hero pill ("mobile apps now available") — forced onto its own line
+   below the MCP pill, sized to content, and clickable through to the blog post. */
 .fl-landing .hero-bar-mobile {
   display: flex;
   width: fit-content;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,9 +17,9 @@ const instrumentSerif = Instrument_Serif({
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
-  title: "Finlynq — open-source personal finance with a first-party MCP server",
+  title: "Finlynq: open-source personal finance with a first-party MCP server",
   description:
-    "Finlynq — open-source personal finance with a first-party MCP server. Free hosted at finlynq.com/cloud, or self-host with Docker. AGPL v3.",
+    "Finlynq: open-source personal finance with a first-party MCP server. Free hosted at finlynq.com/cloud, or self-host with Docker. AGPL v3.",
   applicationName: "Finlynq",
   keywords: [
     "personal finance",
@@ -39,13 +39,13 @@ export const metadata: Metadata = {
     siteName: "Finlynq",
     locale: "en_US",
     url: "/",
-    title: "Finlynq — track your money here, analyze it anywhere",
+    title: "Finlynq: track your money here, analyze it anywhere",
     description:
       "Open-source personal finance with a first-party MCP server. Connect Claude, Cursor, or any AI assistant. Per-user envelope encryption. Self-host or free cloud.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Finlynq — track your money here, analyze it anywhere",
+    title: "Finlynq: track your money here, analyze it anywhere",
     description:
       "Open-source personal finance with a first-party MCP server. Connect any AI assistant. Self-host or free cloud.",
   },

--- a/src/app/mcp-guide/layout.tsx
+++ b/src/app/mcp-guide/layout.tsx
@@ -1,16 +1,16 @@
 import type { Metadata } from "next";
 
 // `mcp-guide/page.tsx` is a client component (interactive setup tabs), so its
-// metadata lives here in a server layout — same pattern as `/cloud`.
+// metadata lives here in a server layout, the same pattern as `/cloud`.
 export const metadata: Metadata = {
   title:
-    "Finlynq MCP guide — connect Claude, Cursor & Windsurf to your finances",
+    "Finlynq MCP guide: connect Claude, Cursor & Windsurf to your finances",
   // keep in sync with src/lib/mcp/tool-counts.ts
   description:
     "Connect Finlynq's first-party MCP server to Claude, Cursor, Windsurf, or any MCP client. OAuth 2.1 + Dynamic Client Registration, Bearer API key, or stdio. 109 HTTP / 93 stdio tools over your own financial data.",
   alternates: { canonical: "/mcp-guide" },
   openGraph: {
-    title: "Finlynq MCP guide — connect any AI assistant to your finances",
+    title: "Finlynq MCP guide: connect any AI assistant to your finances",
     description:
       "Set up the Finlynq MCP server in Claude, Cursor, Windsurf, and more. OAuth 2.1, Bearer key, or stdio.",
     url: "/mcp-guide",

--- a/src/app/mcp-guide/page.tsx
+++ b/src/app/mcp-guide/page.tsx
@@ -45,7 +45,7 @@ const toolGroups: {
     title: "Import transactions (CSV / OFX)",
     icon: Upload,
     blurb:
-      "Drop a CSV or OFX into Finlynq with the Upload button, then ask Claude to take it from there. Claude lists pending uploads, shows you a preview with duplicate detection, and only commits after you confirm.",
+      "Drop a CSV or OFX into Finlynq with the Upload button, then ask Claude to take it from there. Claude lists pending uploads, shows you a preview with duplicate detection, and only commits once you confirm.",
     example: "Preview my pending CSV import and show me the duplicates before you commit.",
     tools: ["list_pending_uploads", "preview_import", "execute_import", "cancel_import"],
   },
@@ -53,7 +53,7 @@ const toolGroups: {
     title: "Bulk cleanup",
     icon: Wand2,
     blurb:
-      "Recategorize, retag, or delete many transactions at once. Every bulk operation is two steps: a preview that returns a sample and a signed confirmation token, then an execute call that commits. Claude can't skip the confirmation — the token is scoped to the exact payload.",
+      "Recategorize, retag, or delete many transactions at once. Every bulk operation runs in two steps: a preview that returns a sample and a signed confirmation token, then an execute call that commits. Claude can't skip the confirmation, since the token is scoped to the exact payload.",
     example: "Recategorize every Starbucks transaction from the last 90 days as Coffee.",
     tools: [
       "preview_bulk_update",
@@ -113,7 +113,7 @@ const toolGroups: {
     title: "Split transactions",
     icon: Scissors,
     blurb:
-      "Split a single transaction across multiple categories — useful for $200 grocery runs that include household goods, or Costco trips that mix food and electronics.",
+      "Split a single transaction across multiple categories. Handy for $200 grocery runs that include household goods, or Costco trips that mix food and electronics.",
     example: "Split my last Costco run: $120 groceries, $60 household, $40 electronics.",
     tools: ["list_splits", "add_split", "update_split", "delete_split", "replace_splits"],
   },
@@ -137,7 +137,7 @@ const toolGroups: {
     title: "Portfolio holdings",
     icon: Briefcase,
     blurb:
-      "Manually create, rename, move, or delete portfolio positions (the import pipeline auto-creates them from CSV/ZIP, but for one-offs use these). Plus the read tools for portfolio metrics, performance, deep-dive on a single position, and rebalancing/benchmark insights. Renames cascade to all transactions automatically; deletes leave the transactions in place with the holding link cleared.",
+      "Manually create, rename, move, or delete portfolio positions (the import pipeline auto-creates them from CSV/ZIP, but for one-offs these are what you want). Plus the read tools for portfolio metrics, performance, a deep-dive on a single position, and rebalancing/benchmark insights. Renames cascade to all transactions automatically; deletes leave the transactions in place with the holding link cleared.",
     example: "Add 'VEQT.TO' as a new holding under my RRSP, then move my Apple position to my TFSA.",
     tools: [
       "add_portfolio_holding",
@@ -154,8 +154,8 @@ const toolGroups: {
     title: "Accounts and aliases",
     icon: Landmark,
     blurb:
-      "Add or update accounts, including a short alias (e.g. last 4 digits of a card, or a receipt label) so Claude can match a transaction even when the source document doesn't use the canonical name. The account parameter on every write tool fuzzy-matches your account names and exact-matches aliases — pass either.",
-    example: "When I send you receipts that say 'Visa ending 4242', file them under my Chase Sapphire account — set its alias to '4242'.",
+      "Add or update accounts, including a short alias (e.g. last 4 digits of a card, or a receipt label) so Claude can match a transaction even when the source document doesn't use the canonical name. The account parameter on every write tool fuzzy-matches your account names and exact-matches aliases, so pass either one.",
+    example: "When I send you receipts that say 'Visa ending 4242', file them under my Chase Sapphire account, and set its alias to '4242'.",
     tools: ["add_account", "update_account", "delete_account", "get_account_balances"],
   },
   {
@@ -163,14 +163,14 @@ const toolGroups: {
     icon: Lightbulb,
     blurb:
       "Before recording a transaction, ask Claude to guess the right category and tags based on your rules and history.",
-    example: "I'm about to enter a charge from 'TIM HORTONS #4412' for $7.40 — what category should it be?",
+    example: "I'm about to enter a charge from 'TIM HORTONS #4412' for $7.40. What category should it be?",
     tools: ["suggest_transaction_details"],
   },
   {
     title: "Reads & dashboards",
     icon: Bot,
     blurb:
-      "Balances, net worth, budgets, goals, spending trends, income statements, health score, spotlight alerts, weekly recap, cash flow forecast, anomalies — all the dashboards, queryable in natural language. Portfolio metrics live in the Portfolio holdings card above.",
+      "Balances, net worth, budgets, goals, spending trends, income statements, health score, spotlight alerts, weekly recap, cash flow forecast, anomalies. Every dashboard, queryable in natural language. Portfolio metrics live in the Portfolio holdings card above.",
     example: "Summarize my week: spending, net worth change, and anything unusual.",
     tools: [
       "get_account_balances",
@@ -259,7 +259,7 @@ export default function McpGuidePage() {
   const mcpUrl = `${serverUrl}/api/mcp`;
   const displayKey = apiKey ?? "YOUR_API_KEY";
 
-  // Config snippets always use a placeholder — users copy their actual key from the section above
+  // Config snippets always use a placeholder; users copy their actual key from the section above
   const httpConfig = JSON.stringify(
     {
       mcpServers: {
@@ -319,7 +319,7 @@ export default function McpGuidePage() {
             </div>
             <div>
               <h1 className="text-2xl font-bold tracking-tight text-foreground">Connect Your AI</h1>
-              <p className="text-sm text-muted-foreground">Ask Claude, ChatGPT, Cursor, Windsurf, or any MCP client about your finances</p>
+              <p className="text-sm text-muted-foreground">Ask Claude, ChatGPT, Cursor, Windsurf, or any MCP client about your finances.</p>
             </div>
           </div>
 
@@ -339,8 +339,8 @@ export default function McpGuidePage() {
             {status === "connected" && <CheckCircle2 className="h-4 w-4" />}
             {status === "disconnected" && <XCircle className="h-4 w-4" />}
             {status === "checking" && "Checking MCP server…"}
-            {status === "connected" && "MCP server is running — ready to connect"}
-            {status === "disconnected" && "MCP server not reachable — is the app running?"}
+            {status === "connected" && "MCP server is running, ready to connect"}
+            {status === "disconnected" && "MCP server not reachable. Is the app running?"}
           </div>
         </div>
 
@@ -358,7 +358,7 @@ export default function McpGuidePage() {
               <code className="flex-1 font-mono text-sm bg-background/60 border border-border rounded-lg px-3 py-2 text-foreground truncate">
                 {apiKey
                   ? (apiKeyVisible ? apiKey : `${apiKey.slice(0, 6)}${"•".repeat(20)}${apiKey.slice(-4)}`)
-                  : "Hidden — regenerate from Settings to view"}
+                  : "Hidden. Regenerate from Settings to view."}
               </code>
               <button
                 onClick={() => setApiKeyVisible(!apiKeyVisible)}
@@ -384,7 +384,7 @@ export default function McpGuidePage() {
             </div>
             {!apiKey && (
               <p className="text-xs text-muted-foreground">
-                Sign in at <a href="/cloud" className="underline underline-offset-2 hover:text-foreground">finlynq.com/cloud</a> (free), then visit <a href="/settings/account" className="underline underline-offset-2 hover:text-foreground">Settings → API Key</a> to generate one. We only store a hash — the raw key is shown to you once at creation and cannot be re-shown.
+                Sign in at <a href="/cloud" className="underline underline-offset-2 hover:text-foreground">finlynq.com/cloud</a> (free), then visit <a href="/settings/account" className="underline underline-offset-2 hover:text-foreground">Settings → API Key</a> to generate one. We only store a hash, so the raw key is shown to you once at creation and can&apos;t be shown again.
               </p>
             )}
           </div>
@@ -474,8 +474,8 @@ export default function McpGuidePage() {
                   <div>
                     <p className="font-semibold text-foreground mb-0.5">Easiest way to connect</p>
                     <p className="text-xs text-muted-foreground">
-                      No config files, no API keys to paste. Just click, log in, and authorize — done in under
-                      a minute. Works on claude.ai in any browser, and on the Claude iOS / Android app.
+                      No config files, no API keys to paste. Just click, log in, and authorize. You&apos;ll be
+                      done in under a minute. Works on claude.ai in any browser, and on the Claude iOS / Android app.
                     </p>
                   </div>
                 </div>
@@ -533,7 +533,7 @@ export default function McpGuidePage() {
                         </div>
                         <div className="flex items-center gap-3 px-3 py-2">
                           <span className="w-28 shrink-0 text-muted-foreground">Advanced</span>
-                          <span className="text-muted-foreground italic">Leave collapsed — OAuth handles auth</span>
+                          <span className="text-muted-foreground italic">Leave collapsed; OAuth handles auth</span>
                         </div>
                       </div>
                     </div>
@@ -586,7 +586,7 @@ export default function McpGuidePage() {
                 <div className="flex items-start gap-2 rounded-lg bg-amber-500/5 border border-amber-500/20 p-3">
                   <Shield className="h-4 w-4 text-amber-400 shrink-0 mt-0.5" />
                   <p className="text-xs text-muted-foreground">
-                    <strong className="text-foreground">Privacy note:</strong> Claude Web uses OAuth 2.1 — your
+                    <strong className="text-foreground">Privacy note:</strong> Claude Web uses OAuth 2.1, so your
                     Finlynq passphrase and financial data are never shared with Anthropic. Only the tool
                     responses (query results) pass through Claude&apos;s servers.
                   </p>
@@ -658,7 +658,7 @@ export default function McpGuidePage() {
                         </div>
                         <div className="flex items-center gap-3 px-3 py-2">
                           <span className="w-28 shrink-0 text-muted-foreground">Authentication</span>
-                          <span className="text-muted-foreground italic">OAuth — no API key to paste</span>
+                          <span className="text-muted-foreground italic">OAuth, no API key to paste</span>
                         </div>
                       </div>
                     </div>
@@ -917,12 +917,12 @@ export default function McpGuidePage() {
           </div>
         </section>
 
-        {/* Worked examples — copy-paste prompts that trigger multi-tool flows */}
+        {/* Worked examples: copy-paste prompts that trigger multi-tool flows */}
         <section className="mb-10">
           <h2 className="mb-1 text-lg font-semibold text-foreground">Try a full flow</h2>
           <p className="mb-4 text-sm text-muted-foreground">
-            Paste any of these into Claude to see a preview / confirm / execute flow end-to-end. Claude asks
-            before it commits anything destructive.
+            Paste any of these into Claude to watch a preview / confirm / execute flow run end-to-end. Claude
+            always asks before it commits anything destructive.
           </p>
           <div className="grid gap-3 sm:grid-cols-2">
             {workedExamples.map((ex) => (
@@ -945,7 +945,7 @@ export default function McpGuidePage() {
           </div>
         </section>
 
-        {/* What Claude can do — capability groups, not tool-by-tool */}
+        {/* What Claude can do: capability groups, not tool-by-tool */}
         <section>
           <h2 className="mb-1 text-lg font-semibold text-foreground">What Claude can do</h2>
           <p className="mb-4 text-sm text-muted-foreground">
@@ -1082,9 +1082,9 @@ export default function McpGuidePage() {
                 <span className="text-muted-foreground text-xs group-open:rotate-180 transition-transform">▾</span>
               </summary>
               <div className="px-5 pb-4 text-sm text-muted-foreground leading-relaxed">
-                If you&apos;re on the public demo account, portfolio data is reseeded nightly — querying
+                If you&apos;re on the public demo account, portfolio data is reseeded nightly, so querying
                 right after a deploy may return a stale cache. Open a fresh chat and re-query. On your own
-                account, ensure every transaction in an investment account is bound to a holding: Finlynq
+                account, make sure every transaction in an investment account is bound to a holding: Finlynq
                 requires <code className="bg-muted px-1 rounded text-xs">portfolio_holding_id</code> on
                 every row in an <code className="bg-muted px-1 rounded text-xs">is_investment=true</code>{" "}
                 account. Cash legs are auto-bound to a per-account Cash sleeve.
@@ -1099,7 +1099,7 @@ export default function McpGuidePage() {
               <div className="px-5 pb-4 text-sm text-muted-foreground leading-relaxed">
                 Per-user transaction-aggregation caches are invalidated automatically on every MCP write.
                 If you ever see truly stale data in Claude.ai, sign out and back in to clear the per-user
-                cache. Long-running conversations don&apos;t hold cached results — every tool call hits the
+                cache. Long-running conversations don&apos;t hold cached results; every tool call hits the
                 live database.
               </div>
             </details>
@@ -1113,7 +1113,7 @@ export default function McpGuidePage() {
                 Set BOTH <code className="bg-muted px-1 rounded text-xs">DATABASE_URL</code> and{" "}
                 <code className="bg-muted px-1 rounded text-xs">PF_USER_ID</code> (a UUID matching a row in{" "}
                 <code className="bg-muted px-1 rounded text-xs">users.id</code>). The stdio transport has
-                no HTTP auth layer — it binds to one user at process startup. Without{" "}
+                no HTTP auth layer, so it binds to one user at process startup. Without{" "}
                 <code className="bg-muted px-1 rounded text-xs">PF_USER_ID</code> the process exits 1
                 immediately.
               </div>
@@ -1126,10 +1126,10 @@ export default function McpGuidePage() {
               </summary>
               <div className="px-5 pb-4 text-sm text-muted-foreground leading-relaxed">
                 As of the Stream D Phase 4 rollout (2026-05-03), plaintext name columns are physically
-                dropped from those six tables — names are stored encrypted under your DEK. The stdio
+                dropped from those six tables, and names are stored encrypted under your DEK. The stdio
                 transport has no DEK, so it can&apos;t compute the encrypted-name siblings on write. Use
                 the HTTP MCP transport or the Finlynq web UI for create/update on those tables. Read tools
-                across all six tables continue to work on stdio (names render as &ldquo;—&rdquo; without a DEK).
+                across all six tables still work on stdio (names render as a blank dash without a DEK).
               </div>
             </details>
           </div>
@@ -1142,8 +1142,8 @@ export default function McpGuidePage() {
               rel="noreferrer noopener"
             >
               github.com/finlynq/finlynq/issues
-            </a>{" "}
-            — we triage daily.
+            </a>
+            . We triage daily.
           </p>
         </section>
       </div>

--- a/src/app/mcp-guide/tools/page.tsx
+++ b/src/app/mcp-guide/tools/page.tsx
@@ -9,23 +9,23 @@ import {
   type ToolCategory,
 } from "./tools.generated";
 
-// Static page — generated at build time from the catalog source. No client
-// interactivity needed; rendering is pure server component so the full tool
+// Static page, generated at build time from the catalog source. No client
+// interactivity needed; rendering is a pure server component so the full tool
 // list is in the initial HTML for crawlers.
 
 export const metadata: Metadata = {
-  title: `Finlynq MCP — ${TOOL_COUNT_HTTP} tools for AI personal finance`,
+  title: `Finlynq MCP: ${TOOL_COUNT_HTTP} tools for AI personal finance`,
   description: `Complete catalog of the ${TOOL_COUNT_HTTP} HTTP MCP tools Finlynq exposes to Claude, Cursor, Windsurf, and any other MCP client. Covers reads (balances, net worth, budgets, portfolio, goals, FX, spending trends, anomalies), writes (transactions, transfers, trades, accounts, categories, rules, subscriptions, loans, goals, splits, holdings, FX overrides), preview/execute pairs for bulk operations, destructive ops with confirmation tokens, and the unified import staging pipeline.`,
   alternates: { canonical: "/mcp-guide/tools" },
   openGraph: {
-    title: `Finlynq MCP — ${TOOL_COUNT_HTTP} tools for AI personal finance`,
+    title: `Finlynq MCP: ${TOOL_COUNT_HTTP} tools for AI personal finance`,
     description: `Complete catalog of all ${TOOL_COUNT_HTTP} HTTP and ${TOOL_COUNT_STDIO} stdio MCP tools.`,
     url: "/mcp-guide/tools",
     type: "article",
   },
   twitter: {
     card: "summary",
-    title: `Finlynq MCP — ${TOOL_COUNT_HTTP} tools`,
+    title: `Finlynq MCP: ${TOOL_COUNT_HTTP} tools`,
     description: `Catalog of all ${TOOL_COUNT_HTTP} HTTP MCP tools exposed by Finlynq.`,
   },
 };
@@ -43,7 +43,7 @@ const CATEGORY_ORDER: CategoryMeta[] = [
     key: "read",
     label: "Read",
     blurb:
-      "Pure queries — balances, net worth, budgets, transactions, portfolios, goals, loans, FX rates, spending trends, recurring bills, weekly recaps. Read-only. Allowed under both mcp:read and mcp:write OAuth scopes.",
+      "Pure queries: balances, net worth, budgets, transactions, portfolios, goals, loans, FX rates, spending trends, recurring bills, weekly recaps. Read-only. Allowed under both mcp:read and mcp:write OAuth scopes.",
     icon: Eye,
     badgeClass: "bg-emerald-500/15 text-emerald-400 ring-emerald-500/30",
   },
@@ -59,7 +59,7 @@ const CATEGORY_ORDER: CategoryMeta[] = [
     key: "preview",
     label: "Preview",
     blurb:
-      "Dry-run pair for every destructive bulk op. Returns a sample of the affected rows plus a signed confirmation token scoped to the exact payload. Read-only — nothing is written.",
+      "Dry-run pair for every destructive bulk op. Returns a sample of the affected rows plus a signed confirmation token scoped to the exact payload. Read-only, so nothing is written.",
     icon: Sparkles,
     badgeClass: "bg-indigo-500/15 text-indigo-300 ring-indigo-500/30",
   },
@@ -75,7 +75,7 @@ const CATEGORY_ORDER: CategoryMeta[] = [
     key: "write",
     label: "Write",
     blurb:
-      "Mutations — record / update transactions, transfers, trades; create or edit accounts, categories, rules, subscriptions, loans, goals, splits, holdings, snapshots, FX overrides. Requires mcp:write OAuth scope.",
+      "Mutations: record / update transactions, transfers, trades; create or edit accounts, categories, rules, subscriptions, loans, goals, splits, holdings, snapshots, FX overrides. Requires mcp:write OAuth scope.",
     icon: Pencil,
     badgeClass: "bg-amber-500/15 text-amber-300 ring-amber-500/30",
   },
@@ -130,7 +130,7 @@ export default function ToolCatalogPage() {
             Finlynq MCP tool catalog
           </h1>
           <p className="mt-3 text-base text-muted-foreground max-w-2xl leading-relaxed">
-            Every tool the Finlynq MCP server exposes — what it does, whether
+            Every tool the Finlynq MCP server exposes: what it does, whether
             it reads or writes, which OAuth scope it needs, and which transports
             (HTTP, stdio) carry it. Source-of-truth is the registration code
             in <code className="text-xs bg-muted px-1.5 py-0.5 rounded">mcp-server/register-tools-pg.ts</code>;
@@ -258,7 +258,7 @@ export default function ToolCatalogPage() {
             <code className="text-xs bg-muted px-1.5 py-0.5 rounded">bulk_record_transactions</code>
             {" "}and{" "}
             <code className="text-xs bg-muted px-1.5 py-0.5 rounded">approve_staged_rows</code>
-            {" "}with a 72-hour replay window — Claude retrying a flaky import
+            {" "}with a 72-hour replay window, so Claude retrying a flaky import
             won&apos;t double-book the rows.
           </p>
         </section>
@@ -279,7 +279,7 @@ export default function ToolCatalogPage() {
             <code className="bg-muted px-1 py-0.5 rounded">idempotentHint</code>,{" "}
             <code className="bg-muted px-1 py-0.5 rounded">openWorldHint</code>) are injected by{" "}
             <code className="bg-muted px-1 py-0.5 rounded">auto-annotations.ts</code> from name
-            prefixes — same rules drive the categorization above.
+            prefixes. The same rules drive the categorization above.
           </p>
           <p className="mt-2">
             Spotted a tool description that reads poorly?{" "}
@@ -290,8 +290,8 @@ export default function ToolCatalogPage() {
               className="underline underline-offset-2 hover:text-foreground"
             >
               Open an issue
-            </a>{" "}
-            — we triage daily.
+            </a>
+            . We triage daily.
           </p>
         </footer>
       </div>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -5,7 +5,7 @@ import { ImageResponse } from "next/og";
 // PNG server-side (not subject to the page CSP). Uses the bundled default font
 // so there's no font-fetch step.
 export const alt =
-  "Finlynq — open-source personal finance with a first-party MCP server";
+  "Finlynq: open-source personal finance with a first-party MCP server";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,12 +8,12 @@ import { JsonLd, softwareApplicationSchema } from "@/components/seo/json-ld";
 // a `"use client"` file cannot export.
 export const metadata: Metadata = {
   title:
-    "Finlynq — Open-Source Personal Finance with a First-Party MCP Server",
+    "Finlynq: Open-Source Personal Finance with a First-Party MCP Server",
   description:
-    "Open-source (AGPL v3) personal finance app with a first-party MCP server. Track income, expenses, budgets, investments, loans, and goals — then query your money in plain English from Claude, Cursor, or any MCP client. Self-host with Docker or use the free cloud.",
+    "Open-source (AGPL v3) personal finance app with a first-party MCP server. Track income, expenses, budgets, investments, loans, and goals, then query your money in plain English from Claude, Cursor, or any MCP client. Self-host with Docker or use the free cloud.",
   alternates: { canonical: "/" },
   openGraph: {
-    title: "Finlynq — track your money here, analyze it anywhere",
+    title: "Finlynq: track your money here, analyze it anywhere",
     description:
       "Open-source personal finance with a first-party MCP server. Connect Claude, Cursor, or any AI assistant. Per-user envelope encryption. Self-host or free cloud.",
     url: "/",
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Finlynq — track your money here, analyze it anywhere",
+    title: "Finlynq: track your money here, analyze it anywhere",
     description:
       "Open-source personal finance with a first-party MCP server. Connect any AI assistant. Self-host or free cloud.",
   },

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -3,12 +3,12 @@ import type { Metadata } from "next";
 import { ConsentControls } from "./consent-controls";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy — Finlynq",
+  title: "Privacy Policy | Finlynq",
   description:
     "What Finlynq collects, how it's encrypted, what we never share, and how to export or delete your data.",
   alternates: { canonical: "/privacy" },
   openGraph: {
-    title: "Privacy Policy — Finlynq",
+    title: "Privacy Policy | Finlynq",
     description:
       "What Finlynq collects, how it's encrypted, what we never share, and how to export or delete your data.",
     url: "/privacy",
@@ -36,23 +36,23 @@ export default function PrivacyPage() {
 
         <section className="prose prose-invert max-w-none space-y-8 text-[15px] leading-relaxed">
           <p className="text-base">
-            Finlynq is an open-source personal-finance application (AGPL v3) that
-            you can run on your own hardware or use through our managed cloud at{" "}
-            <code>finlynq.com</code>. This policy applies to the managed cloud.
-            If you self-host, you are the data controller — this policy does not
+            Finlynq is an open-source personal-finance app (AGPL v3). You can run
+            it on your own hardware or use our managed cloud at{" "}
+            <code>finlynq.com</code>. This policy covers the managed cloud. If you
+            self-host, you&apos;re the data controller, so this policy doesn&apos;t
             apply to your own deployment.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">1. What we collect</h2>
           <p>
-            On the managed cloud, Finlynq stores only the data you put into it
+            On the managed cloud, Finlynq only stores the data you put into it
             yourself:
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
-              Account identity: a username (your choice), an email address (used
-              only for password recovery and security alerts), and a password
-              hash.
+              Account identity: a username (your choice), an email address (we
+              use it only for password recovery and security alerts), and a
+              password hash.
             </li>
             <li>
               Financial data you import or enter: accounts, transactions,
@@ -60,16 +60,17 @@ export default function PrivacyPage() {
             </li>
             <li>
               Operational logs: HTTP request logs (IP address, user agent, URL
-              path, status code), kept 30 days for abuse prevention and
+              path, status code). We keep these 30 days for abuse prevention and
               debugging.
             </li>
             <li>
-              MCP / API tokens you generate: stored as one-way hashes; the raw
-              token is shown to you once at creation and cannot be re-shown.
+              MCP / API tokens you generate: we store these as one-way hashes. We
+              show you the raw token once when you create it, and we can&apos;t
+              show it again.
             </li>
           </ul>
           <p>
-            We do not collect bank credentials. Finlynq has no Plaid, MX,
+            We don&apos;t collect bank credentials. Finlynq has no Plaid, MX,
             Yodlee, or Finicity integration. Your bank login never touches our
             servers. You import data via CSV / OFX / QFX / PDF / email.
           </p>
@@ -78,49 +79,52 @@ export default function PrivacyPage() {
             2. How your financial data is encrypted
           </h2>
           <p>
-            Finlynq uses per-user envelope encryption. Summary:
+            Finlynq uses per-user envelope encryption. Here&apos;s the short
+            version:
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
-            <li>Each user has a Data Encryption Key (DEK) generated at signup.</li>
+            <li>Each user gets a Data Encryption Key (DEK), generated at signup.</li>
             <li>
-              The DEK is wrapped with a Key Encryption Key (KEK) derived from
-              your password using <strong>scrypt</strong> with a server-side pepper.
+              We wrap the DEK with a Key Encryption Key (KEK) derived from your
+              password using <strong>scrypt</strong> with a server-side pepper.
             </li>
             <li>
-              Sensitive fields (transaction payees, notes, tags, attached files,
-              encrypted display names) are stored as <strong>AES-256-GCM</strong>{" "}
-              ciphertext with random IV and authentication tags.
+              We store sensitive fields (transaction payees, notes, tags,
+              attached files, encrypted display names) as{" "}
+              <strong>AES-256-GCM</strong> ciphertext with a random IV and
+              authentication tags.
             </li>
             <li>
-              Your DEK lives only in memory while you are signed in (sliding 2h
-              idle timeout). It is never persisted in plaintext on disk.
+              Your DEK lives only in memory while you&apos;re signed in (sliding
+              2h idle timeout). We never write it to disk in plaintext.
             </li>
             <li>
-              If you forget your password, your encrypted data cannot be
-              recovered. This is by design.
+              If you forget your password, your encrypted data can&apos;t be
+              recovered. That&apos;s by design.
             </li>
           </ul>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">3. What we never share</h2>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
-              We do not sell, rent, or share your data with advertisers, data
+              We don&apos;t sell, rent, or share your data with advertisers, data
               brokers, or any third party.
             </li>
             <li>
-              We do not move money. Finlynq is not a broker, bank, advisor, or
-              SEC-registered RIA. We have no ability to initiate transfers from
-              your accounts.
+              We don&apos;t move money. Finlynq isn&apos;t a broker, bank,
+              advisor, or SEC-registered RIA. We can&apos;t initiate transfers
+              from your accounts.
             </li>
             <li>
-              We do not use your financial data to train AI models. The MCP
-              server lets <em>you</em> grant a third-party AI assistant access
-              to your data — under your control, scoped per session, revocable.
+              We don&apos;t use your financial data to train AI models. The MCP
+              server lets <em>you</em> grant a third-party AI assistant access to
+              your data. You stay in control: it&apos;s scoped per session and
+              you can revoke it.
             </li>
             <li>
-              We do not use third-party analytics inside the application. The
-              public marketing pages load Google Analytics only after you
-              explicitly accept the cookie banner.
+              We don&apos;t use third-party analytics inside the app. The public
+              marketing pages load Google Analytics only after you explicitly
+              accept the cookie banner.
             </li>
           </ul>
 
@@ -130,13 +134,13 @@ export default function PrivacyPage() {
           <p>
             When you connect Finlynq to an AI assistant via our MCP server, the
             assistant authenticates through OAuth 2.1 (or with a Bearer API key
-            if you are using a CLI client). It receives only the data returned
+            if you&apos;re using a CLI client). It only receives the data returned
             by the specific tool it calls, scoped to your account.
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
-              The AI vendor (e.g., Anthropic) sees the tool responses, because
-              they pass through the model. Refer to the vendor privacy policy.
+              The AI vendor (e.g., Anthropic) sees the tool responses, since they
+              pass through the model. Check the vendor&apos;s privacy policy.
             </li>
             <li>
               You can revoke an OAuth grant at any time from{" "}
@@ -144,43 +148,43 @@ export default function PrivacyPage() {
             </li>
             <li>
               Destructive operations (bulk delete, bulk update, imports) use a
-              preview-confirm-execute pattern with a server-signed token, so an
-              AI cannot mutate your data without your explicit confirmation.
+              preview-confirm-execute pattern with a server-signed token, so an AI
+              can&apos;t change your data without your explicit confirmation.
             </li>
           </ul>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">5. Sub-processors</h2>
           <p>
-            The managed cloud runs on a single VPS that we operate. We do not
-            use third-party data processors for the application database. The
-            only outbound integrations are:
+            The managed cloud runs on a single VPS that we operate. We don&apos;t
+            use third-party data processors for the app database. The only
+            outbound integrations are:
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
-              Yahoo Finance, CoinGecko, Stooq — anonymous public-price queries
-              for portfolio valuation. No user data is sent.
+              Yahoo Finance, CoinGecko, Stooq, for anonymous public-price queries
+              that value your portfolio. No user data is sent.
             </li>
             <li>
-              Resend — transactional email (password reset, account alerts) and
-              the optional inbound-import address.
+              Resend, for transactional email (password reset, account alerts)
+              and the optional inbound-import address.
             </li>
             <li>
-              GitHub Sponsors / Ko-fi — donation processing, only if you choose
+              GitHub Sponsors / Ko-fi, for donation processing, only if you choose
               to donate. They handle their own KYC/payment data.
             </li>
           </ul>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">6. Cookies and analytics</h2>
           <p>
-            The application itself loads no third-party analytics, no
-            advertising scripts, and no tracking pixels. Authentication uses a
-            single first-party session cookie required to keep you signed in;
-            it expires automatically.
+            The app itself loads no third-party analytics, no advertising
+            scripts, and no tracking pixels. Sign-in uses a single first-party
+            session cookie that keeps you signed in, and it expires
+            automatically.
           </p>
           <p>
-            On the public marketing pages we load Google Analytics to understand
-            which posts bring people here. GA is non-essential, so we ask for
-            your consent before loading it. You can change your mind at any time:
+            On the public marketing pages we load Google Analytics to see which
+            posts bring people here. GA isn&apos;t essential, so we ask for your
+            consent before loading it. You can change your mind at any time:
           </p>
           <ConsentControls />
 
@@ -188,9 +192,9 @@ export default function PrivacyPage() {
             7. Records of processing (GDPR Article 30)
           </h2>
           <p>
-            For users protected by GDPR, the following is our public record of
-            processing activities. Internal records are kept current and made
-            available to supervisory authorities on request.
+            If you&apos;re protected by GDPR, here&apos;s our public record of
+            processing activities. We keep our internal records current and make
+            them available to supervisory authorities on request.
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
@@ -264,7 +268,8 @@ export default function PrivacyPage() {
             </li>
             <li>
               <strong>Reporting a vulnerability:</strong> please email{" "}
-              <code>privacy@finlynq.com</code>. We confirm receipt within 48 hours.
+              <code>privacy@finlynq.com</code>. We&apos;ll confirm we got it
+              within 48 hours.
             </li>
           </ul>
 
@@ -291,9 +296,9 @@ export default function PrivacyPage() {
 
           <h2 className="text-xl font-semibold mt-12 mb-3">10. Children</h2>
           <p>
-            Finlynq is not directed at children under 16 and we do not
-            knowingly collect data from children. If you become aware of a
-            child account, contact us and we will delete it.
+            Finlynq isn&apos;t directed at children under 16, and we don&apos;t
+            knowingly collect data from children. If you spot a child&apos;s
+            account, contact us and we&apos;ll delete it.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -302,18 +307,18 @@ export default function PrivacyPage() {
           <p>
             Finlynq is operated from Canada. You can exercise your access,
             rectification, deletion, and portability rights at any time directly
-            from <code>Settings → Data</code>; you do not need to ask us. For
-            other inquiries (GDPR Article 15 access requests, CCPA opt-outs,
-            EU data-subject requests), contact us using the address below — we
-            will respond within 30 days.
+            from <code>Settings → Data</code>; you don&apos;t need to ask us. For
+            anything else (GDPR Article 15 access requests, CCPA opt-outs, EU
+            data-subject requests), contact us at the address below and
+            we&apos;ll respond within 30 days.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">12. Changes</h2>
           <p>
-            We will update this page when our practices change and bump the
-            Last updated date at the top. Material changes (a new sub-processor,
-            a change to encryption guarantees) will also be announced in the
-            project{" "}
+            We&apos;ll update this page when our practices change and bump the
+            Last updated date at the top. We&apos;ll also announce material
+            changes (a new sub-processor, a change to encryption guarantees) in
+            the project{" "}
             <a
               href="https://github.com/finlynq/finlynq/blob/main/CHANGELOG.md"
               className="underline underline-offset-2 hover:text-primary"
@@ -326,8 +331,8 @@ export default function PrivacyPage() {
           <h2 className="text-xl font-semibold mt-12 mb-3">13. Contact</h2>
           <p>
             Privacy questions, data-subject requests, security disclosures:{" "}
-            <code>privacy@finlynq.com</code>. Source-code questions, bugs,
-            feature requests: open an issue at{" "}
+            <code>privacy@finlynq.com</code>. For source-code questions, bugs, or
+            feature requests, open an issue at{" "}
             <a
               href="https://github.com/finlynq/finlynq/issues"
               className="underline underline-offset-2 hover:text-primary"
@@ -338,10 +343,9 @@ export default function PrivacyPage() {
           </p>
 
           <p className="mt-12 text-xs text-muted-foreground">
-            For a plain-English walkthrough of how the encryption works in
-            practice — including the honest tradeoffs (lose your password, lose
-            your data; the operator can see anonymized amounts and dates) —
-            see{" "}
+            Want a plain-English walkthrough of how the encryption works in
+            practice, including the honest tradeoffs (lose your password, lose
+            your data; the operator can see anonymized amounts and dates)? Read{" "}
             <Link
               href="/blog/how-finlynq-encrypts-your-money"
               className="underline underline-offset-2 hover:text-primary"
@@ -357,7 +361,7 @@ export default function PrivacyPage() {
               pf-app/docs/architecture/encryption.md
             </a>
             . The code that implements it is in{" "}
-            <code>pf-app/src/lib/crypto/</code>. Both are AGPL v3 — read the
+            <code>pf-app/src/lib/crypto/</code>. Both are AGPL v3, so read the
             code, audit it, fork it.
           </p>
         </section>

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -6,7 +6,7 @@ import { JsonLd, breadcrumbSchema } from "@/components/seo/json-ld";
 const PATH = "/roadmap";
 
 export const metadata: Metadata = {
-  title: "Roadmap — Finlynq",
+  title: "Roadmap | Finlynq",
   description:
     "What's live, what we're building, and what's next for Finlynq, the open-source personal finance app with a first-party MCP server. Directional, community-shaped, AGPL v3.",
   alternates: { canonical: PATH },
@@ -27,10 +27,10 @@ export const metadata: Metadata = {
 };
 
 const INTRO =
-  "This is what's already live, what we're building now, and what we're weighing next. It's directional, not a contract: priorities shift, and because Finlynq is open source (AGPL v3), the community can build any of it too. Want something moved up? Send feedback in the app or open a discussion on GitHub.";
+  "Here's what's already live, what we're building now, and what we're weighing next. It's directional, not a contract: priorities shift, and since Finlynq is open source (AGPL v3), the community can build any of it too. Want something moved up the list? Send feedback in the app or open a discussion on GitHub.";
 
 const CTA =
-  "Have an opinion on what's next? Send feedback from inside the app, or open a discussion on GitHub. Finlynq is AGPL v3, so issues and pull requests are welcome too.";
+  "Got an opinion on what should come next? Send feedback from inside the app, or open a discussion on GitHub. Finlynq is AGPL v3, so issues and pull requests are welcome too.";
 
 type Item = {
   title: string;
@@ -52,13 +52,13 @@ const SECTIONS: Section[] = [
   {
     key: "live",
     label: "Live now",
-    blurb: "Already shipped and in the app today.",
+    blurb: "Already shipped, and in the app today.",
     badge: "bg-emerald-500/15 text-emerald-500",
     items: [
       {
         title: "Talk to your money with any AI assistant",
         // keep in sync with src/lib/mcp/tool-counts.ts
-        desc: "A built-in MCP server (109 HTTP / 93 stdio tools) for Claude, Cursor, and more.",
+        desc: "A built-in MCP server (109 HTTP / 93 stdio tools) for Claude, Cursor, and the rest.",
         href: "/mcp-guide",
         hrefLabel: "See the MCP guide",
       },
@@ -74,11 +74,11 @@ const SECTIONS: Section[] = [
       },
       {
         title: "Multi-currency net worth",
-        desc: "Hold accounts in any currency and see one consolidated picture.",
+        desc: "Hold accounts in any currency and still see one consolidated picture.",
       },
       {
         title: "Import from anywhere",
-        desc: "CSV, Excel, PDF, OFX/QFX, and forward-by-email statements, with a reconcile step before anything lands.",
+        desc: "CSV, Excel, PDF, OFX/QFX, and forward-by-email statements. There's a reconcile step before anything lands.",
       },
       {
         title: "Budgets your way",
@@ -86,7 +86,7 @@ const SECTIONS: Section[] = [
       },
       {
         title: "Plan ahead",
-        desc: "Set savings goals and track your progress toward them.",
+        desc: "Set savings goals and watch your progress toward them.",
       },
       {
         title: "See the whole picture",
@@ -94,7 +94,7 @@ const SECTIONS: Section[] = [
       },
       {
         title: "Run it your way",
-        desc: "Free managed cloud or self-host with Docker, same features either way.",
+        desc: "Free managed cloud, or self-host with Docker. Same features either way.",
         href: "/self-hosted",
         hrefLabel: "Self-hosting guide",
       },
@@ -114,11 +114,11 @@ const SECTIONS: Section[] = [
     items: [
       {
         title: "In-app AI chat",
-        desc: "Ask questions about your finances in plain English without setting up an external MCP client. In active development behind a feature flag.",
+        desc: "Ask questions about your finances in plain English, no external MCP client required. In active development behind a feature flag.",
       },
       {
         title: "Automatic account connections",
-        desc: "Link banks and brokerages so transactions flow in automatically. Starting with US banks (SimpleFIN) and North American brokerages including Wealthsimple, Questrade, and IBKR (SnapTrade). You keep the connection and the credentials, not us.",
+        desc: "Link banks and brokerages so transactions flow in on their own. We're starting with US banks (SimpleFIN) and North American brokerages, including Wealthsimple, Questrade, and IBKR (SnapTrade). You keep the connection and the credentials, not us.",
       },
     ],
   },
@@ -134,7 +134,7 @@ const SECTIONS: Section[] = [
       },
       {
         title: "Categorization that learns",
-        desc: "Smarter auto-categorization, cleaner merchant names, faster bulk edits and splits.",
+        desc: "Smarter auto-categorization, cleaner merchant names, and faster bulk edits and splits.",
       },
       {
         title: "Budgeting and savings, deeper",
@@ -142,7 +142,7 @@ const SECTIONS: Section[] = [
       },
       {
         title: "Debt payoff and FIRE planning",
-        desc: "Avalanche and snowball debt-payoff strategies, plus FIRE projections with Monte Carlo simulations.",
+        desc: "Avalanche and snowball payoff strategies, plus FIRE projections with Monte Carlo simulations.",
       },
       {
         title: "More for investors",
@@ -178,7 +178,7 @@ const SECTIONS: Section[] = [
       },
       {
         title: "Share with the people who matter",
-        desc: "Partner and household access, advisor read-only, and a community hub.",
+        desc: "Partner and household access, read-only access for your advisor, and a community hub.",
       },
     ],
   },

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -98,6 +98,12 @@ const SECTIONS: Section[] = [
         href: "/self-hosted",
         hrefLabel: "Self-hosting guide",
       },
+      {
+        title: "Native mobile apps",
+        desc: "Finlynq on your phone, now available on the App Store and Google Play. Point it at the managed cloud or your own self-hosted instance.",
+        href: "/blog/finlynq-mobile-app",
+        hrefLabel: "Read the announcement",
+      },
     ],
   },
   {
@@ -106,12 +112,6 @@ const SECTIONS: Section[] = [
     blurb: "In active development.",
     badge: "bg-amber-500/15 text-amber-500",
     items: [
-      {
-        title: "Mobile app",
-        desc: "Android first (in final testing on Google Play), with iOS to follow.",
-        href: "/blog/finlynq-mobile-app",
-        hrefLabel: "Read the announcement",
-      },
       {
         title: "In-app AI chat",
         desc: "Ask questions about your finances in plain English without setting up an external MCP client. In active development behind a feature flag.",

--- a/src/app/self-hosted/page.tsx
+++ b/src/app/self-hosted/page.tsx
@@ -3,9 +3,9 @@ import Link from "next/link";
 import { AnalyticsConsent } from "@/components/analytics-consent";
 
 export const metadata: Metadata = {
-  title: "Self-host Finlynq — Docker Compose personal finance with MCP",
+  title: "Self-host Finlynq: Docker Compose personal finance with MCP",
   description:
-    "Self-host Finlynq on your own infrastructure with Docker Compose. Same code as the managed cloud — first-party MCP server, per-user envelope encryption, PostgreSQL. AGPL v3, no license fees.",
+    "Self-host Finlynq on your own infrastructure with Docker Compose. It's the same code as the managed cloud: first-party MCP server, per-user envelope encryption, PostgreSQL. AGPL v3, no license fees.",
   alternates: { canonical: "/self-hosted" },
   openGraph: {
     title: "Self-host Finlynq with Docker",
@@ -47,9 +47,9 @@ export default function SelfHostedPage() {
           Self-Hosted Setup
         </h1>
         <p className="mb-10 text-muted-foreground">
-          Run Finlynq on your own infrastructure. App + PostgreSQL run in
-          Docker, sensitive fields are encrypted at rest with a per-user
-          key derived from the account password.
+          Run Finlynq on your own infrastructure. The app and PostgreSQL both
+          run in Docker, and sensitive fields are encrypted at rest with a
+          per-user key derived from your account password.
         </p>
 
         {/* Quick Start */}
@@ -66,9 +66,9 @@ docker compose up -d`}</code>
             <code className="rounded bg-muted px-1 py-0.5 text-xs">
               http://localhost:3000
             </code>{" "}
-            and register your account. Remember to change the default
+            and register your account. One thing first: change the default
             PostgreSQL password and <code className="rounded bg-muted px-1 py-0.5 text-xs">PF_JWT_SECRET</code>
-            {" "}before exposing the container to anything but localhost.
+            {" "}before you expose the container to anything but localhost.
           </p>
         </section>
 
@@ -78,7 +78,7 @@ docker compose up -d`}</code>
             What You Get
           </h2>
           <ul className="space-y-2 text-sm text-muted-foreground">
-            <li>✓ Self-contained Docker Compose — app + PostgreSQL, nothing external</li>
+            <li>✓ Self-contained Docker Compose. Just the app and PostgreSQL, nothing external</li>
             <li>✓ Envelope encryption on transaction text fields (payees, notes, tags, holdings)</li>
             <li>✓ MCP server for plugging in AI assistants (Claude, etc.)</li>
             <li>✓ Automatic schema migrations on container start</li>
@@ -93,33 +93,33 @@ docker compose up -d`}</code>
           <ul className="space-y-1 text-sm text-muted-foreground">
             <li>
               <code className="rounded bg-muted px-1 py-0.5 text-xs">DATABASE_URL</code>{" "}
-              — PostgreSQL connection string (required)
+              is your PostgreSQL connection string (required)
             </li>
             <li>
               <code className="rounded bg-muted px-1 py-0.5 text-xs">PF_JWT_SECRET</code>{" "}
-              — JWT signing secret, at least 32 chars of entropy (required)
+              is the JWT signing secret, at least 32 chars of entropy (required)
             </li>
             <li>
               <code className="rounded bg-muted px-1 py-0.5 text-xs">PF_PEPPER</code>{" "}
-              — scrypt password peppering, at least 32 chars (required in production)
+              handles scrypt password peppering, at least 32 chars (required in production)
             </li>
             <li>
               <code className="rounded bg-muted px-1 py-0.5 text-xs">PF_STAGING_KEY</code>{" "}
-              — wraps email-staged transactions, at least 32 chars (required in production)
+              wraps email-staged transactions, at least 32 chars (required in production)
             </li>
             <li>
               <code className="rounded bg-muted px-1 py-0.5 text-xs">PORT</code>{" "}
-              — server port (default <code className="rounded bg-muted px-1 py-0.5 text-xs">3000</code>)
+              sets the server port (default <code className="rounded bg-muted px-1 py-0.5 text-xs">3000</code>)
             </li>
           </ul>
         </section>
 
         <div className="rounded-xl border border-border bg-card p-5 text-sm text-muted-foreground">
           <strong className="text-foreground">Security note:</strong> the envelope-encryption
-          DEK is derived from your account password via scrypt. If you forget
-          it, the password-reset flow wipes your data and provisions a fresh
-          DEK — there is no backdoor. Back up your data via the Settings →
-          Privacy & Backup panel periodically.
+          DEK is derived from your account password via scrypt. Forget the
+          password and the reset flow wipes your data and provisions a fresh
+          DEK. There&apos;s no backdoor. So back up your data now and then via the
+          Settings → Privacy & Backup panel.
         </div>
       </div>
     </div>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -2,12 +2,12 @@ import Link from "next/link";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms of Service — Finlynq",
+  title: "Terms of Service | Finlynq",
   description:
     "Terms governing the Finlynq managed cloud service at finlynq.com. Self-hosted use of the source code is governed by AGPL v3.",
   alternates: { canonical: "/terms" },
   openGraph: {
-    title: "Terms of Service — Finlynq",
+    title: "Terms of Service | Finlynq",
     description:
       "Terms governing the Finlynq managed cloud service. Self-hosted use is governed by AGPL v3.",
     url: "/terms",
@@ -53,8 +53,8 @@ export default function TermsPage() {
               github.com/finlynq/finlynq
             </a>
             . If you run the software on your own infrastructure, your use is
-            governed by the AGPL v3 license in the repository and these Terms
-            do not apply to that deployment.
+            governed by the AGPL v3 license in the repository, and these Terms
+            don&apos;t apply to that deployment.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -63,21 +63,21 @@ export default function TermsPage() {
           <p>
             By creating an account on the Service, accessing the Service, or
             connecting an AI assistant to your Finlynq account via our MCP
-            server, you agree to these Terms. If you do not agree, do not use
-            the Service. You may instead self-host the open-source software
-            under the AGPL v3.
+            server, you agree to these Terms. If you don&apos;t agree,
+            don&apos;t use the Service. You can instead self-host the
+            open-source software under the AGPL v3.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">2. The Service</h2>
           <p>
-            Finlynq is a personal-finance tracking application. It lets you
-            record accounts, transactions, budgets, investments, loans, and
-            goals, and query that data through a built-in UI or through an MCP
-            (Model Context Protocol) server that exposes your data to AI
-            assistants you authorize.
+            Finlynq is a personal-finance tracking app. It lets you record
+            accounts, transactions, budgets, investments, loans, and goals, and
+            query that data through a built-in UI or through an MCP (Model
+            Context Protocol) server that exposes your data to AI assistants you
+            authorize.
           </p>
           <p>
-            The Service is offered in two forms:
+            The Service comes in two forms:
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
@@ -88,17 +88,17 @@ export default function TermsPage() {
               <strong>Self-hosted:</strong> you run the source code on your own
               hardware. That use is governed by the AGPL v3 license file in the
               repository, not by these Terms. We provide the software as-is and
-              have no operational role in your self-hosted deployment.
+              play no operational role in your self-hosted deployment.
             </li>
           </ul>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">3. Eligibility</h2>
           <p>
             You must be at least 16 years old to use the Service. By creating
-            an account, you represent that you meet this minimum age and that
-            you have the legal capacity to enter into these Terms in your
-            jurisdiction. The Service is not directed at children under 16 and
-            we do not knowingly accept accounts from them.
+            an account, you confirm that you meet this minimum age and that you
+            have the legal capacity to enter into these Terms in your
+            jurisdiction. The Service isn&apos;t directed at children under 16,
+            and we don&apos;t knowingly accept accounts from them.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -106,24 +106,24 @@ export default function TermsPage() {
           </h2>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
-              You choose a username and provide a recovery email address. Your
-              password is hashed; we never see or store it in clear text.
+              You choose a username and provide a recovery email address. We
+              hash your password; we never see or store it in clear text.
             </li>
             <li>
               Your financial data is encrypted with a Data Encryption Key (DEK)
-              wrapped by a Key Encryption Key derived from your password. If
-              you forget your password, your encrypted data cannot be
-              recovered. This is by design. Export your data regularly.
+              wrapped by a Key Encryption Key derived from your password. If you
+              forget your password, your encrypted data can&apos;t be recovered.
+              That&apos;s by design, so export your data regularly.
             </li>
             <li>
-              You are responsible for keeping your credentials, MCP/API
-              tokens, and OAuth grants confidential. Notify us promptly if you
-              suspect unauthorized access.
+              It&apos;s on you to keep your credentials, MCP/API tokens, and
+              OAuth grants confidential. Let us know promptly if you suspect
+              unauthorized access.
             </li>
             <li>
-              One person per account. You may not share an account with
-              someone else or operate the account on behalf of a third party
-              without their authorization.
+              One person per account. You may not share an account with someone
+              else or operate the account on behalf of a third party without
+              their authorization.
             </li>
           </ul>
 
@@ -145,9 +145,9 @@ export default function TermsPage() {
           </p>
           <p>
             These Terms govern <em>only</em> the managed cloud service we
-            operate at <code>finlynq.com</code>. They do not modify, restrict,
-            or override the AGPL v3 rights granted by the license file in the
-            repository for users of the source code.
+            operate at <code>finlynq.com</code>. They don&apos;t modify,
+            restrict, or override the AGPL v3 rights granted by the license file
+            in the repository for users of the source code.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -168,11 +168,11 @@ export default function TermsPage() {
               Run automated scrapers or load-generators against the Service,
               or otherwise interfere with availability for other users. Normal
               programmatic use through the MCP server and the documented API
-              endpoints with your own credentials is permitted.
+              endpoints with your own credentials is fine.
             </li>
             <li>
               Resell, white-label, or sub-license access to the managed cloud
-              service. You may, of course, self-host under the AGPL v3.
+              service. You can, of course, self-host under the AGPL v3.
             </li>
             <li>
               Upload content that infringes intellectual property, is unlawful,
@@ -185,8 +185,8 @@ export default function TermsPage() {
           </ul>
           <p>
             We may suspend or terminate accounts that violate this section.
-            Egregious violations (active intrusion attempts, malware
-            distribution) may be terminated without notice.
+            We may terminate serious violations (active intrusion attempts,
+            malware distribution) without notice.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -194,9 +194,9 @@ export default function TermsPage() {
           </h2>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
-              You own the data you put into the Service. We claim no
-              ownership of your financial records, notes, attachments, or any
-              other content you upload.
+              You own the data you put into the Service. We claim no ownership
+              of your financial records, notes, attachments, or any other
+              content you upload.
             </li>
             <li>
               You can export your full account at any time as a JSON backup
@@ -211,8 +211,8 @@ export default function TermsPage() {
               backups.
             </li>
             <li>
-              We do not sell, rent, or share your data with advertisers or
-              data brokers. We do not use your financial data to train AI
+              We don&apos;t sell, rent, or share your data with advertisers or
+              data brokers. We don&apos;t use your financial data to train AI
               models. See the{" "}
               <Link
                 href="/privacy"
@@ -228,8 +228,8 @@ export default function TermsPage() {
             8. No Financial Services
           </h2>
           <p>
-            Finlynq is a personal-finance <em>tracking</em> application.
-            Finlynq is not, and does not hold itself out as:
+            Finlynq is a personal-finance <em>tracking</em> app. Finlynq
+            isn&apos;t, and doesn&apos;t hold itself out as:
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>a broker, dealer, or money transmitter;</li>
@@ -240,14 +240,14 @@ export default function TermsPage() {
             <li>a tax advisor or accountant.</li>
           </ul>
           <p>
-            The Service does not execute trades, transfer funds, hold money,
-            or initiate any transaction with your real-world financial
-            accounts. Numbers, charts, projections, and AI-generated
-            commentary in the Service are informational only and are not
-            investment, tax, legal, or financial advice. Consult a qualified
-            professional before making financial decisions. You are solely
-            responsible for the accuracy of the data you enter and for any
-            decisions you make based on what you see in the Service.
+            The Service doesn&apos;t execute trades, transfer funds, hold money,
+            or initiate any transaction with your real-world financial accounts.
+            Numbers, charts, projections, and AI-generated commentary in the
+            Service are informational only and are not investment, tax, legal, or
+            financial advice. Consult a qualified professional before making
+            financial decisions. You&apos;re solely responsible for the accuracy
+            of the data you enter and for any decisions you make based on what
+            you see in the Service.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">9. Donations</h2>
@@ -269,8 +269,8 @@ export default function TermsPage() {
             . Donations are voluntary, non-refundable except where required by
             law, and do not entitle you to any service-level guarantee, paid
             tier, additional feature, or priority support. There are no paid
-            tiers and no subscriptions. If donations do not sustain operating
-            costs, we may discontinue the managed cloud — see Section 14.
+            tiers and no subscriptions. If donations don&apos;t cover operating
+            costs, we may discontinue the managed cloud (see Section 14).
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -286,10 +286,10 @@ export default function TermsPage() {
             INTERRUPTION, OR BE FREE OF DEFECTS.
           </p>
           <p>
-            We do not offer a service-level agreement (SLA), uptime guarantee,
-            or recovery-time objective. The Service is operated on a single
-            VPS by a small team and may be unavailable for maintenance,
-            failure, or other reasons. Export your data regularly.
+            We don&apos;t offer a service-level agreement (SLA), uptime
+            guarantee, or recovery-time objective. The Service runs on a single
+            VPS, operated by a small team, and may be unavailable for
+            maintenance, failure, or other reasons. Export your data regularly.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -319,10 +319,10 @@ export default function TermsPage() {
             12. Third-Party Services
           </h2>
           <p>
-            The Service integrates with the following third parties to
-            function. We do not control their accuracy, availability, or
-            terms, and we are not responsible for outages, data errors, or
-            changes on their side:
+            The Service relies on the following third parties to function. We
+            don&apos;t control their accuracy, availability, or terms, and
+            we&apos;re not responsible for outages, data errors, or changes on
+            their side:
           </p>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
@@ -344,7 +344,7 @@ export default function TermsPage() {
               <strong>AI assistants:</strong> when you authorize Anthropic
               Claude or another AI client through the MCP server, the
               assistant&apos;s vendor sees the tool responses returned to it.
-              Their privacy policies apply to that side of the connection.
+              Their privacy policies cover that side of the connection.
             </li>
           </ul>
 
@@ -365,7 +365,7 @@ export default function TermsPage() {
           <h2 className="text-xl font-semibold mt-12 mb-3">14. Termination</h2>
           <ul className="list-disc pl-6 space-y-1.5">
             <li>
-              <strong>By you:</strong> you may stop using the Service at any
+              <strong>By you:</strong> you can stop using the Service at any
               time and delete your account from <code>Settings → Data → Delete
               account</code>.
             </li>
@@ -391,8 +391,8 @@ export default function TermsPage() {
             </li>
           </ul>
           <p>
-            Even if the managed cloud is discontinued, the source code remains
-            available under AGPL v3 and you can continue using Finlynq by
+            Even if the managed cloud is discontinued, the source code stays
+            available under AGPL v3, and you can keep using Finlynq by
             self-hosting it.
           </p>
 
@@ -402,13 +402,13 @@ export default function TermsPage() {
           <p>
             We may update these Terms when our practices change. For{" "}
             <strong>material changes</strong> (anything that meaningfully
-            reduces your rights or expands your obligations), we will give at
-            least 30 days&apos; notice via an in-app banner or an email to
-            your recovery address. Continued use of the Service after the
-            effective date constitutes acceptance. For minor changes (typo
-            fixes, clarifications, formatting), the updated Terms take effect
-            immediately on posting. The current effective date is shown at
-            the top of this page.
+            reduces your rights or expands your obligations), we&apos;ll give at
+            least 30 days&apos; notice via an in-app banner or an email to your
+            recovery address. If you keep using the Service after the effective
+            date, that counts as acceptance. For minor changes (typo fixes,
+            clarifications, formatting), the updated Terms take effect
+            immediately on posting. The current effective date is shown at the
+            top of this page.
           </p>
 
           <h2 className="text-xl font-semibold mt-12 mb-3">
@@ -424,8 +424,8 @@ export default function TermsPage() {
             by your jurisdiction&apos;s consumer-protection law.
           </p>
           <p>
-            Before filing a formal claim, please contact us first using the
-            address below; we will try in good faith to resolve the dispute
+            Before filing a formal claim, please contact us first at the
+            address below. We&apos;ll try in good faith to resolve the dispute
             informally within 30 days.
           </p>
 
@@ -433,8 +433,8 @@ export default function TermsPage() {
           <p>
             Questions about these Terms:{" "}
             <code>privacy@finlynq.com</code> (the same address handles legal
-            and privacy correspondence). Source-code questions, bugs, or
-            feature requests: open an issue at{" "}
+            and privacy correspondence). For source-code questions, bugs, or
+            feature requests, open an issue at{" "}
             <a
               href="https://github.com/finlynq/finlynq/issues"
               className="underline underline-offset-2 hover:text-primary"
@@ -460,7 +460,7 @@ export default function TermsPage() {
             >
               repository
             </a>{" "}
-            for the terms governing self-hosted use of the source code.
+            for the terms that govern self-hosted use of the source code.
           </p>
         </section>
       </div>

--- a/src/app/vs/_components/VsPage.tsx
+++ b/src/app/vs/_components/VsPage.tsx
@@ -7,9 +7,9 @@ import { JsonLd, breadcrumbSchema } from "@/components/seo/json-ld";
  * Shared layout for `/vs/<competitor>` comparison pages.
  *
  * Data-driven so each `/vs/<slug>/page.tsx` only owns its content. Pages render
- * inside a dark prose layout that mirrors `/privacy` and `/terms` — content
+ * inside a dark prose layout that mirrors `/privacy` and `/terms` (content
  * rather than the premium `fl-landing` motion system, which would distract from
- * a research-mode read.
+ * a research-mode read).
  *
  * Pattern for adding a new `/vs/<slug>`:
  *   1. Create `pf-app/src/app/vs/<slug>/page.tsx` with a default export.
@@ -111,8 +111,8 @@ export function VsPage({ content }: { content: VsPageContent }) {
             When to choose {competitorName}
           </h2>
           <p>
-            {competitorName} is the right call if any of these matter more than
-            ownership:
+            {competitorName} is probably the better pick if any of these matter
+            to you more than owning your data:
           </p>
           <ul className="list-disc pl-6 space-y-2">
             {whenCompetitor.map((bullet, i) => (
@@ -124,7 +124,7 @@ export function VsPage({ content }: { content: VsPageContent }) {
           <h2 className="text-xl font-semibold mt-12 mb-3">
             When to choose Finlynq
           </h2>
-          <p>Finlynq is the right call if any of these matter:</p>
+          <p>Finlynq is the one to pick if any of these matter to you:</p>
           <ul className="list-disc pl-6 space-y-2">
             {whenFinlynq.map((bullet, i) => (
               <li key={i}>{bullet}</li>
@@ -227,21 +227,22 @@ export function VsPage({ content }: { content: VsPageContent }) {
                 </a>
                 {source.note ? (
                   <span className="ml-1 text-muted-foreground/80">
-                    — {source.note}
+                    ({source.note})
                   </span>
                 ) : null}
               </li>
             ))}
           </ul>
 
-          {/* Soft CTA — research-mode page, one link only per the brief */}
+          {/* Soft CTA: research-mode page, one link only per the brief */}
           <div className="not-prose mt-12 rounded-2xl border border-primary/20 bg-primary/5 p-6">
             <h3 className="text-base font-semibold text-foreground">
               Try Finlynq
             </h3>
             <p className="mt-2 text-sm text-muted-foreground">
-              Free, open source, AGPL v3. Run it on our managed cloud or self-host
-              with one Docker Compose file. Same features either way.
+              Free, open source, AGPL v3. Run it on our managed cloud, or
+              self-host with one Docker Compose file. You get the same features
+              either way.
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <Link

--- a/src/app/vs/actual/page.tsx
+++ b/src/app/vs/actual/page.tsx
@@ -2,12 +2,12 @@ import type { Metadata } from "next";
 import { VsPage, type VsPageContent } from "../_components/VsPage";
 
 export const metadata: Metadata = {
-  title: "Finlynq vs Actual Budget — open-source PFM with investments & MCP",
+  title: "Finlynq vs Actual Budget: open-source PFM with investments & MCP",
   description:
     "Finlynq vs Actual Budget: two open-source self-hostable personal finance apps. Actual is best-in-class local-first envelope budgeting; Finlynq adds native investment tracking, correct multi-currency, per-user envelope encryption, and a first-party MCP server. Side-by-side table, when to choose each, and migration steps.",
   alternates: { canonical: "/vs/actual" },
   openGraph: {
-    title: "Finlynq vs Actual Budget — open-source PFM with investments & MCP",
+    title: "Finlynq vs Actual Budget: open-source PFM with investments & MCP",
     description:
       "Two open-source self-hostable PFMs. Actual: local-first envelope budgeting (MIT). Finlynq: investments + multi-currency + per-user encryption + a first-party MCP server.",
     url: "/vs/actual",
@@ -26,21 +26,21 @@ const content: VsPageContent = {
   competitorName: "Actual Budget",
   slug: "actual",
   tagline:
-    "Actual Budget is the leading open-source, local-first envelope-budgeting app — a popular YNAB replacement. Finlynq is also open-source and self-hostable, but adds native investment tracking, correct multi-currency, per-user envelope encryption, and a first-party MCP server that Actual's maintainers have declined to ship.",
+    "Actual Budget is the leading open-source, local-first envelope-budgeting app, and a popular YNAB replacement. Finlynq is also open-source and self-hostable, but it adds native investment tracking, correct multi-currency, per-user envelope encryption, and a first-party MCP server that Actual's maintainers have declined to ship.",
   whenCompetitor: [
-    "You want best-in-class envelope / zero-based budgeting UX — a keyboard-driven register, payee autocomplete, splits, and schedules. Actual nails budgeting in a way Finlynq does not aim to.",
-    "You want true local-first with opt-in end-to-end encryption — your data lives on-device and the sync server stores opaque encrypted blobs. Architecturally very private for a single user's data.",
+    "You want best-in-class envelope and zero-based budgeting UX: a keyboard-driven register, payee autocomplete, splits, and schedules. Actual nails budgeting in a way Finlynq doesn't aim to.",
+    "You want true local-first with opt-in end-to-end encryption, where your data lives on-device and the sync server only holds opaque encrypted blobs. That's architecturally very private for a single user's data.",
     "You want a permissive MIT license (proprietary forks allowed) rather than Finlynq's copyleft AGPL v3.",
     "You want built-in bank sync via GoCardless (EU/UK), SimpleFIN Bridge (US/Canada), or Pluggy.ai (Brazil). Finlynq has no first-party bank sync today.",
     "You want a desktop app and offline-first multi-device via Actual's sync engine.",
   ],
   whenFinlynq: [
-    "You want native investment / portfolio tracking — holdings, lot-tracked cost basis, dividends. Actual has none; it is a budgeting app, full stop. This is the single largest feature gap.",
-    "You want first-party multi-currency. Actual's docs state it is currency-agnostic and does not support multi-currency; the workaround is separate budgets. Finlynq locks FX at trade date.",
-    "You want a first-party MCP server. Actual has shipped none and closed AI feature requests without merging. A capable community server exists (s-stefanov/actual-mcp) but is not blessed or in-app.",
-    "You want an official managed cloud from the project. Actual offers none — you self-host or trust a third-party host. Finlynq offers finlynq.com/cloud directly.",
-    "You want per-user encryption that is on by default. Actual's E2EE is opt-in; default installs store plaintext on the sync server.",
-    "You want loans / amortization, goals, and subscription detection in the same app. Actual is budgeting-only.",
+    "You want native investment and portfolio tracking: holdings, lot-tracked cost basis, dividends. Actual has none; it's a budgeting app, full stop. This is the single largest feature gap.",
+    "You want first-party multi-currency. Actual's docs say it's currency-agnostic and doesn't support multi-currency, so the workaround is separate budgets. Finlynq locks FX at trade date.",
+    "You want a first-party MCP server. Actual has shipped none and closed AI feature requests without merging. A capable community server exists (s-stefanov/actual-mcp), but it isn't blessed or in-app.",
+    "You want an official managed cloud from the project. Actual offers none, so you self-host or trust a third-party host. Finlynq offers finlynq.com/cloud directly.",
+    "You want per-user encryption that's on by default. Actual's E2EE is opt-in, and default installs store plaintext on the sync server.",
+    "You want loans and amortization, goals, and subscription detection in the same app. Actual is budgeting-only.",
   ],
   comparisonRows: [
     { label: "License", finlynq: "AGPL v3", competitor: "MIT (more permissive)" },
@@ -51,9 +51,9 @@ const content: VsPageContent = {
     },
     {
       label: "First-party MCP",
-      finlynq: "Yes — 109 HTTP / 93 stdio tools",
+      finlynq: "Yes, 109 HTTP / 93 stdio tools",
       competitor:
-        "No — AI requests closed unmerged; community s-stefanov/actual-mcp exists",
+        "No: AI requests closed unmerged; community s-stefanov/actual-mcp exists",
     },
     {
       label: "MCP auth",
@@ -62,7 +62,7 @@ const content: VsPageContent = {
     },
     {
       label: "REST / HTTP API",
-      finlynq: "Yes — full surface mirrored from MCP",
+      finlynq: "Yes, full surface mirrored from MCP",
       competitor: "Programmatic access via the @actual-app/api Node library",
     },
     {
@@ -81,7 +81,7 @@ const content: VsPageContent = {
     {
       label: "Multi-currency",
       finlynq: "Native, per-currency cost basis, FX locked at trade date",
-      competitor: "No — currency-agnostic; single-currency budget per docs",
+      competitor: "No: currency-agnostic; single-currency budget per docs",
     },
     {
       label: "Investment / portfolio",
@@ -111,30 +111,30 @@ const content: VsPageContent = {
     },
   ],
   migrationSteps: [
-    "Export from Actual — use the file export, or pull data via the @actual-app/api Node library.",
-    "Import into Finlynq at /import/reconcile — review and edit each row; transfer pairs, multi-currency, and dedup are handled in staging.",
-    "Connect Claude (or any MCP client) at /mcp — paste the URL into Claude → Customize → Connectors; OAuth handles auth.",
+    "Export from Actual. Use the file export, or pull data via the @actual-app/api Node library.",
+    "Import into Finlynq at /import/reconcile. Review and edit each row; transfer pairs, multi-currency, and dedup are all handled in staging.",
+    "Connect Claude (or any MCP client) at /mcp. Paste the URL into Claude, then Customize, then Connectors; OAuth handles auth.",
   ],
   faq: [
     {
       q: "Is Actual's budgeting better than Finlynq's?",
-      a: "For pure envelope / zero-based budgeting UX, generally yes — Actual's register and shortcuts are excellent. Finlynq covers a wider surface (investments, loans, goals, multi-currency) and adds MCP.",
+      a: "For pure envelope and zero-based budgeting UX, generally yes. Actual's register and shortcuts are excellent. Finlynq covers a wider surface (investments, loans, goals, multi-currency) and adds MCP.",
     },
     {
-      q: "Actual is local-first and end-to-end encrypted — isn't that more private?",
-      a: "For a single device, Actual's opt-in E2EE is architecturally strong. But it is opt-in (the default stores plaintext on the sync server), whereas Finlynq's per-user envelope encryption is always on server-side, which is also what makes the MCP story work.",
+      q: "Actual is local-first and end-to-end encrypted. Isn't that more private?",
+      a: "For a single device, Actual's opt-in E2EE is architecturally strong. But it's opt-in (the default stores plaintext on the sync server), whereas Finlynq's per-user envelope encryption is always on server-side, which is also what makes the MCP story work.",
     },
     {
       q: "Does Actual have a first-party MCP or AI feature?",
-      a: "No. AI requests were closed unmerged and the roadmap is silent on AI. A capable community MCP exists (s-stefanov/actual-mcp), but it is third-party and not integrated into the app.",
+      a: "No. AI requests were closed unmerged and the roadmap is silent on AI. A capable community MCP exists (s-stefanov/actual-mcp), but it's third-party and not integrated into the app.",
     },
     {
       q: "Does Actual track investments?",
-      a: "No — it is budgeting only. If you want budgets and a portfolio in one app, that is a Finlynq advantage.",
+      a: "No, it's budgeting only. If you want budgets and a portfolio in one app, that's a Finlynq advantage.",
     },
     {
       q: "Can Actual do multi-currency?",
-      a: "Not natively; its docs say it is currency-agnostic. Finlynq handles per-account and per-holding currency with FX locked at trade date.",
+      a: "Not natively; its docs say it's currency-agnostic. Finlynq handles per-account and per-holding currency with FX locked at trade date.",
     },
   ],
   sources: [

--- a/src/app/vs/actual/page.tsx
+++ b/src/app/vs/actual/page.tsx
@@ -91,7 +91,7 @@ const content: VsPageContent = {
     },
     {
       label: "Native mobile app",
-      finlynq: "React Native (Expo) app — functional, not at parity with consumer apps",
+      finlynq: "Yes, native iOS and Android apps (App Store, Google Play)",
       competitor: "No native app; mobile-responsive web / PWA + desktop",
     },
     {

--- a/src/app/vs/alderfi/page.tsx
+++ b/src/app/vs/alderfi/page.tsx
@@ -3,15 +3,15 @@ import { VsPage, type VsPageContent } from "../_components/VsPage";
 
 export const metadata: Metadata = {
   title:
-    "Finlynq vs Alderfi — two open-source MCP-first personal finance apps",
+    "Finlynq vs Alderfi: two open-source MCP-first personal finance apps",
   description:
-    "Finlynq vs Alderfi: production-ready AGPL v3 PFM with 109 MCP tools, hosted demo, per-user envelope encryption, and multi-currency support — compared with Alderfi's pre-alpha Apache-2.0 project that ships local LLM (Llama 3 via llama.cpp). Side-by-side feature table, when to choose each, dated 2026-05-13.",
+    "Finlynq vs Alderfi: production-ready AGPL v3 PFM with 109 MCP tools, hosted demo, per-user envelope encryption, and multi-currency support, compared with Alderfi's pre-alpha Apache-2.0 project that ships local LLM (Llama 3 via llama.cpp). Side-by-side feature table, when to choose each, dated 2026-05-13.",
   alternates: {
     canonical: "/vs/alderfi",
   },
   openGraph: {
     title:
-      "Finlynq vs Alderfi — two open-source MCP-first personal finance apps",
+      "Finlynq vs Alderfi: two open-source MCP-first personal finance apps",
     description:
       "Two open-source MCP-first PFMs, honestly compared. Finlynq: AGPL v3, production, 109 MCP tools, hosted + self-host, per-user encryption. Alderfi: Apache-2.0, pre-alpha, local LLM via llama.cpp.",
     url: "/vs/alderfi",
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title:
-      "Finlynq vs Alderfi — two open-source MCP-first personal finance apps",
+      "Finlynq vs Alderfi: two open-source MCP-first personal finance apps",
     description:
       "AGPL v3 production PFM with 109 MCP tools vs Apache-2.0 pre-alpha with local LLM. Pick the one that matches your trade-offs.",
   },
@@ -34,9 +34,9 @@ const content: VsPageContent = {
     <>
       Alderfi and Finlynq are both open-source, MCP-first personal finance
       projects. Alderfi is Apache-2.0, pre-alpha, and ships local LLM support
-      out of the box. Finlynq is AGPL v3, production, hosted-or-self-hosted,
-      with a 109 HTTP / 93 stdio tool MCP surface. This page exists so you can
-      pick the one that actually matches your trade-offs.
+      out of the box. Finlynq is AGPL v3, in production, hosted or self-hosted,
+      with a 109 HTTP / 93 stdio tool MCP surface. This page is here so you can
+      pick the one that actually fits your trade-offs.
     </>
   ),
   whenCompetitor: [
@@ -46,10 +46,10 @@ const content: VsPageContent = {
       </strong>{" "}
       Apache-2.0 has a patent grant and no copyleft, so you can wrap Alderfi in
       a closed-source product, ship a SaaS without sharing changes, or vendor
-      it into a regulated stack without AGPL §13&apos;s source-disclosure
-      trigger. Finlynq&apos;s AGPL v3 deliberately forces network forks to
-      publish their changes — that&apos;s a feature for the maintainer and a
-      friction for users who specifically want Apache.
+      it into a regulated stack without tripping AGPL §13&apos;s
+      source-disclosure trigger. Finlynq&apos;s AGPL v3 deliberately forces
+      network forks to publish their changes. That&apos;s a feature for the
+      maintainer and a friction for users who specifically want Apache.
     </>,
     <>
       <strong className="text-foreground">
@@ -57,18 +57,18 @@ const content: VsPageContent = {
       </strong>{" "}
       Alderfi documents Llama 3 8B via llama.cpp as part of its categorization
       pipeline. If your threat model is{" "}
-      {`"`}no third party — including Anthropic or OpenAI — sees my financial
+      {`"`}no third party (including Anthropic or OpenAI) sees my financial
       transactions,{`"`} Alderfi&apos;s posture matches that. Finlynq today
       assumes you connect a cloud LLM (Claude, ChatGPT, Cursor, Windsurf) over
-      MCP; we don&apos;t ship a local-LLM mode.
+      MCP, and we don&apos;t ship a local-LLM mode.
     </>,
     <>
       <strong className="text-foreground">
         You want to follow a project from day one.
       </strong>{" "}
-      Alderfi is openly pre-alpha and is being designed in public. If the
-      appeal is shaping the architecture, naming the abstractions, and being
-      one of the first contributors, an alpha project is exactly where to be.
+      Alderfi is openly pre-alpha and is being designed in public. If what you
+      want is to shape the architecture, name the abstractions, and be one of
+      the first contributors, an alpha project is exactly where to be.
     </>,
     <>
       <strong className="text-foreground">
@@ -164,7 +164,7 @@ const content: VsPageContent = {
     },
     {
       label: "Hosted demo",
-      finlynq: "Yes — demo@finlynq.com / finlynq-demo, resets nightly",
+      finlynq: "Yes, demo@finlynq.com / finlynq-demo, resets nightly",
       competitor: "No (paid hosted tier planned)",
     },
     {
@@ -176,16 +176,16 @@ const content: VsPageContent = {
       label: "First-party MCP",
       finlynq: (
         <>
-          Yes — <strong className="text-foreground">109 HTTP / 93 stdio</strong>{" "}
+          Yes, <strong className="text-foreground">109 HTTP / 93 stdio</strong>{" "}
           tools
         </>
       ),
-      competitor: "Yes — 1 mock tool today; roadmap implies more",
+      competitor: "Yes, 1 mock tool today; roadmap implies more",
     },
     {
       label: "Local LLM support",
-      finlynq: "No (cloud LLMs only — Claude, ChatGPT, Cursor, Windsurf)",
-      competitor: "Yes — Llama 3 8B via llama.cpp",
+      finlynq: "No (cloud LLMs only: Claude, ChatGPT, Cursor, Windsurf)",
+      competitor: "Yes, Llama 3 8B via llama.cpp",
     },
     {
       label: "MCP auth",
@@ -241,18 +241,18 @@ const content: VsPageContent = {
   migrationSteps: [
     <>
       <strong className="text-foreground">From Alderfi to Finlynq.</strong>{" "}
-      Alderfi&apos;s SQLite store can be dumped via standard SQL tooling. Map
+      Alderfi&apos;s SQLite store can be dumped with standard SQL tooling. Map
       transactions to CSV (date, amount, currency, payee, category, account)
-      and feed into Finlynq&apos;s staging-review at <code>/import/reconcile</code> —
-      multi-currency, transfer-pair detection, and SHA-256 dedup over plaintext
-      payee are all built in.
+      and feed them into Finlynq&apos;s staging-review at{" "}
+      <code>/import/reconcile</code>, where multi-currency, transfer-pair
+      detection, and SHA-256 dedup over plaintext payee are all built in.
     </>,
     <>
       <strong className="text-foreground">From Finlynq to Alderfi.</strong>{" "}
       Finlynq&apos;s data-export endpoint produces a JSON backup with
       transactions, accounts, categories, portfolio holdings, and goals.
       You&apos;ll need to write a small JSON-to-Alderfi-import bridge once
-      Alderfi&apos;s import surface stabilizes — neither side has a one-click
+      Alderfi&apos;s import surface stabilizes. Neither side has a one-click
       migration today.
     </>,
     <>
@@ -266,16 +266,16 @@ const content: VsPageContent = {
   ],
   faq: [
     {
-      q: "Isn't Alderfi just a 'future Finlynq' — why not wait for it?",
+      q: "Isn't Alderfi just a 'future Finlynq'? Why not wait for it?",
       a: (
         <>
           You might. The two projects make different trade-offs. Alderfi&apos;s
           commitments (Apache-2.0, local-LLM-first) are structural and unlikely
           to change. Finlynq&apos;s commitments (AGPL v3, hosted + self-host
-          parity, current 109 HTTP / 93 stdio tool surface) are also structural. If Apache-2.0
-          and local-LLM matter more than shipped surface, waiting is
-          reasonable. If you need something running today against real
-          transactions, Finlynq is the project that has it.
+          parity, the current 109 HTTP / 93 stdio tool surface) are structural
+          too. If Apache-2.0 and local-LLM matter more to you than shipped
+          surface, then waiting is reasonable. If you need something running
+          today against real transactions, Finlynq is the one that has it.
         </>
       ),
     },
@@ -286,11 +286,11 @@ const content: VsPageContent = {
           We chose AGPL deliberately. Personal finance is a category that
           historically gets enclosed (Mint → Intuit → shutdown; Hiro → OpenAI →
           shutdown). AGPL §13&apos;s {`"`}network use{`"`} clause means anyone
-          running Finlynq as a hosted service must publish their changes —
-          which keeps the open-source core honest as the project gets adopted
+          running Finlynq as a hosted service has to publish their changes,
+          which keeps the open-source core honest as the project gets picked up
           by others. Apache-2.0 doesn&apos;t do that. It&apos;s a legitimate
-          trade-off; both choices have integrity. If you specifically want a
-          permissive license so you can ship a derivative without sharing
+          trade-off, and both choices have integrity. If you specifically want a
+          permissive license so you can ship a derivative without sharing your
           changes back, Apache (Alderfi) is the better fit.
         </>
       ),
@@ -300,11 +300,11 @@ const content: VsPageContent = {
       a: (
         <>
           Not today. Finlynq&apos;s MCP server speaks Streamable HTTP and
-          stdio, and any MCP-compatible client can connect — including a local
+          stdio, and any MCP-compatible client can connect, including a local
           Ollama / llama.cpp / LM Studio runtime if it exposes MCP. But Finlynq
           doesn&apos;t ship a bundled local-LLM runtime the way Alderfi does,
           and the categorization / suggestion code paths assume an external MCP
-          client. This is a real gap for users with a {`"`}no cloud LLM{`"`}{" "}
+          client. So this is a real gap if you have a {`"`}no cloud LLM{`"`}{" "}
           threat model.
         </>
       ),
@@ -313,11 +313,11 @@ const content: VsPageContent = {
       q: "Doesn't Alderfi's 'the app is the MCP server' framing make Finlynq's architecture obsolete?",
       a: (
         <>
-          It&apos;s a cleaner pitch, but they&apos;re two ways of describing
-          similar architectures. Finlynq&apos;s MCP server is a first-class
-          module of the app (<code>pf-app/mcp-server/</code>) — not a wrapper
-          or a side-channel. The framing difference matters more for marketing
-          than for architecture.
+          It&apos;s a cleaner pitch, but they&apos;re really two ways of
+          describing similar architectures. Finlynq&apos;s MCP server is a
+          first-class module of the app (<code>pf-app/mcp-server/</code>), not a
+          wrapper or a side-channel. The framing difference matters more for
+          marketing than for architecture.
         </>
       ),
     },

--- a/src/app/vs/era/page.tsx
+++ b/src/app/vs/era/page.tsx
@@ -2,14 +2,14 @@ import type { Metadata } from "next";
 import { VsPage, type VsPageContent } from "../_components/VsPage";
 
 export const metadata: Metadata = {
-  title: "Finlynq vs Era — open-source vs closed AI personal finance",
+  title: "Finlynq vs Era: open-source vs closed AI personal finance",
   description:
     "Finlynq vs Era: open-source AGPL v3 with self-host + 109 MCP tools + per-user envelope encryption, compared against Era's closed-source hosted SaaS with 27 MCP tools and operator-held keys. Side-by-side feature table, when to choose each, and migration steps.",
   alternates: {
     canonical: "/vs/era",
   },
   openGraph: {
-    title: "Finlynq vs Era — open-source vs closed AI personal finance",
+    title: "Finlynq vs Era: open-source vs closed AI personal finance",
     description:
       "Two MCP-first personal finance apps, compared. Finlynq: AGPL v3, self-hostable, 109 MCP tools, per-user envelope encryption. Era: closed SaaS, hosted-only, 27 MCP tools, operator-held keys.",
     url: "/vs/era",
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Finlynq vs Era — open-source vs closed AI personal finance",
+    title: "Finlynq vs Era: open-source vs closed AI personal finance",
     description:
       "Open-source self-hostable PFM with 109 MCP tools and per-user envelope encryption, compared with Era.",
   },
@@ -30,30 +30,31 @@ const content: VsPageContent = {
   tagline: (
     <>
       Era is a hosted, AI-first personal finance SaaS with a closed-source MCP
-      server. Finlynq is the open-source, self-hostable alternative — same
-      MCP-driven UX, your infrastructure, your encryption keys, no aggregator
-      hostage.
+      server. Finlynq is the open-source, self-hostable alternative. You get the
+      same MCP-driven feel, but on your own infrastructure, with your own
+      encryption keys, and no aggregator holding your data hostage.
     </>
   ),
   whenCompetitor: [
     <>
       You want bank sync to {`"`}just work{`"`} out of the box. Era ships with
       aggregator-grade automatic transactions across thousands of US
-      institutions; Finlynq is currently file / email import only.
+      institutions. Finlynq is file and email import only right now.
     </>,
     <>
       You want the most polished native mobile experience. Era&apos;s Agency is
-      a mature native app; Finlynq now ships native iOS and Android apps too
-      (App Store and Google Play), but they are newer and still maturing.
+      a mature native app. Finlynq now ships native iOS and Android apps too (on
+      the App Store and Google Play), but they&apos;re newer and still maturing.
     </>,
     <>
       You want regulated investment advisory or brokerage. Era&apos;s Thesis
-      (private beta) is an SEC-registered investment adviser with brokerage via
-      Alpaca. Finlynq is not — and explicitly never will be.
+      (private beta) is an SEC-registered investment adviser with brokerage
+      through Alpaca. Finlynq isn&apos;t, and it never will be.
     </>,
     <>
-      You don&apos;t want to think about Postgres, Docker, encryption keys, or
-      password recovery. Era is hosted; that&apos;s the whole pitch.
+      You&apos;d rather not think about Postgres, Docker, encryption keys, or
+      password recovery. Era is hosted, and honestly that&apos;s the whole
+      pitch.
     </>,
     <>
       You want shared household finances baked in. Era&apos;s multi-user shared
@@ -63,23 +64,23 @@ const content: VsPageContent = {
   whenFinlynq: [
     <>
       <strong className="text-foreground">You want the source code.</strong>{" "}
-      Finlynq is AGPL v3, fully on GitHub. Era is closed-source, so you
-      can&apos;t audit the MCP tool implementations, the encryption story, or
-      what gets sent to your AI assistant.
+      Finlynq is AGPL v3 and it&apos;s all on GitHub. Era is closed-source, so
+      you can&apos;t audit the MCP tool implementations, the encryption story, or
+      what actually gets sent to your AI assistant.
     </>,
     <>
       <strong className="text-foreground">You want to self-host.</strong>{" "}
-      Finlynq runs on your hardware via Docker + PostgreSQL. Era cannot be
-      self-hosted at any price.
+      Finlynq runs on your own hardware with Docker and PostgreSQL. Era
+      can&apos;t be self-hosted at any price.
     </>,
     <>
       <strong className="text-foreground">
         You want per-user encryption with keys derived from your password.
       </strong>{" "}
-      Finlynq&apos;s envelope encryption (AES-256-GCM with scrypt-derived KEK)
-      means even the operator cannot read your transaction notes, payees, tags,
-      or display names. Era&apos;s {`"`}AES-256 at rest{`"`} is a blanket claim
-      about Era&apos;s infra; the operator holds the keys.
+      Finlynq&apos;s envelope encryption (AES-256-GCM with a scrypt-derived KEK)
+      means even the operator can&apos;t read your transaction notes, payees,
+      tags, or display names. Era&apos;s {`"`}AES-256 at rest{`"`} is a blanket
+      claim about Era&apos;s infra, and the operator still holds the keys.
     </>,
     <>
       <strong className="text-foreground">You want the bigger MCP surface.</strong>{" "}
@@ -117,15 +118,15 @@ const content: VsPageContent = {
       label: "First-party MCP",
       finlynq: (
         <>
-          Yes — <strong className="text-foreground">109 HTTP / 93 stdio</strong>{" "}
+          Yes, <strong className="text-foreground">109 HTTP / 93 stdio</strong>{" "}
           tools
         </>
       ),
       competitor: (
         <>
-          Yes — Era Context,{" "}
-          <strong className="text-foreground">27 tools</strong> (per Anthropic
-          directory listing, 2026-05-11)
+          Yes, Era Context,{" "}
+          <strong className="text-foreground">27 tools</strong> (per the
+          Anthropic directory listing, 2026-05-11)
         </>
       ),
     },
@@ -136,7 +137,7 @@ const content: VsPageContent = {
     },
     {
       label: "REST / HTTP API",
-      finlynq: "Yes — full surface mirrored from MCP",
+      finlynq: "Yes, the full surface is mirrored from MCP",
       competitor: "Not publicly documented outside MCP",
     },
     {
@@ -150,7 +151,7 @@ const content: VsPageContent = {
       label: "Encryption at rest",
       finlynq:
         "Per-user envelope encryption: AES-256-GCM with scrypt-derived KEK. The operator cannot decrypt user data.",
-      competitor: `"AES-256 at rest" — Era holds the keys`,
+      competitor: `"AES-256 at rest", but Era holds the keys`,
     },
     {
       label: "Multi-currency",
@@ -168,12 +169,12 @@ const content: VsPageContent = {
       label: "Native mobile app",
       finlynq:
         "Yes, native iOS and Android apps (App Store, Google Play); newer and still maturing",
-      competitor: "Yes — Agency",
+      competitor: "Yes, Agency",
     },
     {
       label: "Multi-user / household",
       finlynq: "No (single-user)",
-      competitor: "Yes — shared views",
+      competitor: "Yes, shared views",
     },
     {
       label: "Pricing",
@@ -209,8 +210,8 @@ const content: VsPageContent = {
     </>,
     <>
       <strong className="text-foreground">Import into Finlynq.</strong> Use the
-      staging-review pipeline at <code>/import/reconcile</code> — upload a CSV,
-      review and edit each row, approve. Multi-currency, transfer-pair
+      staging-review pipeline at <code>/import/reconcile</code>: upload a CSV,
+      review and edit each row, then approve. Multi-currency, transfer-pair
       detection, and dedup are all built into the staging flow.
     </>,
     <>
@@ -226,9 +227,9 @@ const content: VsPageContent = {
       q: "Why are you comparing yourself to a paid product when you're free?",
       a: (
         <>
-          Because the comparison isn&apos;t price — it&apos;s where your data
-          lives, who can read it, and what happens if the operator pivots.
-          Finlynq&apos;s argument is structural, not a discount.
+          Because the comparison isn&apos;t really about price. It&apos;s about
+          where your data lives, who can read it, and what happens if the
+          operator pivots. Finlynq&apos;s argument is structural, not a discount.
         </>
       ),
     },
@@ -236,10 +237,10 @@ const content: VsPageContent = {
       q: "Doesn't Era's bank sync just make this a non-comparison for most users?",
       a: (
         <>
-          For users who want one-click bank sync and don&apos;t care about
-          source code or self-hosting, yes — Era is the better default.
-          Finlynq&apos;s audience is users who specifically don&apos;t want a
-          third-party aggregator holding their bank credentials, even one
+          For people who want one-click bank sync and don&apos;t care about
+          source code or self-hosting, yeah, Era is the better default.
+          Finlynq&apos;s audience is the people who specifically don&apos;t want
+          a third-party aggregator holding their bank credentials, even one
           that&apos;s SOC 2 Type II.
         </>
       ),
@@ -248,11 +249,11 @@ const content: VsPageContent = {
       q: "Why does this read like a hit piece?",
       a: (
         <>
-          It isn&apos;t. Era ships real things — first-party MCP, OAuth-scoped
-          tools, native mobile, an investment-advisory product Finlynq legally
-          cannot offer. The honest difference is: Era is hosted convenience for
-          users who trust an operator with their financial life, and Finlynq is
-          the substrate for users who don&apos;t want to.
+          It isn&apos;t. Era ships real things: first-party MCP, OAuth-scoped
+          tools, native mobile, and an investment-advisory product Finlynq
+          legally can&apos;t offer. The honest difference is that Era is hosted
+          convenience for people who trust an operator with their financial
+          life, and Finlynq is the substrate for people who&apos;d rather not.
         </>
       ),
     },
@@ -270,10 +271,11 @@ const content: VsPageContent = {
       q: "Will Finlynq ever offer regulated investment advisory like Era's Thesis?",
       a: (
         <>
-          No. Becoming an SEC-registered investment adviser is incompatible with
-          the AGPL self-hostable design — the regulator wants a single
-          accountable entity; the design wants none. Finlynq is the database;
-          the user can hire whatever advisor they want against the data.
+          No. Becoming an SEC-registered investment adviser just doesn&apos;t
+          fit the AGPL self-hostable design. The regulator wants a single
+          accountable entity, and the design wants none. Finlynq is the
+          database, and you can hire whatever advisor you want to work against
+          the data.
         </>
       ),
     },
@@ -290,12 +292,12 @@ const content: VsPageContent = {
       note: "fetched 2026-05-07",
     },
     {
-      label: "Anthropic Connectors Directory — Era listing",
+      label: "Anthropic Connectors Directory (Era listing)",
       href: "https://context.era.app",
       note: "27 tools, visible from 2026-05-11",
     },
     {
-      label: "Las Vegas Sun — Era launch coverage",
+      label: "Las Vegas Sun (Era launch coverage)",
       href: "https://lasvegassun.com/news/2026/may/06/era-becomes-the-first-personal-finance-connector-i/",
       note: "2026-05-06",
     },

--- a/src/app/vs/era/page.tsx
+++ b/src/app/vs/era/page.tsx
@@ -42,9 +42,9 @@ const content: VsPageContent = {
       institutions; Finlynq is currently file / email import only.
     </>,
     <>
-      You want a native iOS / Android app today. Era&apos;s Agency is a real
-      native mobile app; Finlynq has a mobile-friendly web UI but no native app
-      yet.
+      You want the most polished native mobile experience. Era&apos;s Agency is
+      a mature native app; Finlynq now ships native iOS and Android apps too
+      (App Store and Google Play), but they are newer and still maturing.
     </>,
     <>
       You want regulated investment advisory or brokerage. Era&apos;s Thesis
@@ -166,7 +166,8 @@ const content: VsPageContent = {
     },
     {
       label: "Native mobile app",
-      finlynq: "No (mobile web UI only)",
+      finlynq:
+        "Yes, native iOS and Android apps (App Store, Google Play); newer and still maturing",
       competitor: "Yes — Agency",
     },
     {
@@ -259,8 +260,9 @@ const content: VsPageContent = {
       q: "Does Finlynq have a mobile app?",
       a: (
         <>
-          Not yet. The web UI is mobile-friendly, but a native iOS / Android
-          wrapper isn&apos;t shipped. If you need native mobile, Era is ahead.
+          Yes. Finlynq has native iOS and Android apps on the App Store and
+          Google Play. They are newer than Era&apos;s Agency, so Era&apos;s
+          mobile experience is more mature today.
         </>
       ),
     },

--- a/src/app/vs/firefly-iii/page.tsx
+++ b/src/app/vs/firefly-iii/page.tsx
@@ -3,7 +3,7 @@ import { VsPage, type VsPageContent } from "../_components/VsPage";
 
 export const metadata: Metadata = {
   title:
-    "Finlynq vs Firefly III — open-source personal finance with first-party MCP",
+    "Finlynq vs Firefly III: open-source personal finance with first-party MCP",
   description:
     "Finlynq vs Firefly III: two AGPL v3 self-hostable personal finance apps. Firefly III is mature double-entry accounting with PSD2 bank sync; Finlynq is UI + first-party MCP (109 HTTP / 93 stdio tools) with per-user envelope encryption. Side-by-side feature table, when to choose each, and migration steps.",
   alternates: {
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title:
-      "Finlynq vs Firefly III — open-source personal finance with first-party MCP",
+      "Finlynq vs Firefly III: open-source personal finance with first-party MCP",
     description:
       "Two AGPL v3 self-hostable PFMs, compared. Firefly III: 11-year-old double-entry, PSD2 bank sync, no first-party MCP. Finlynq: first-party MCP server with 109 HTTP / 93 stdio tools, per-user envelope encryption, native investment tracking.",
     url: "/vs/firefly-iii",
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title:
-      "Finlynq vs Firefly III — open-source personal finance with first-party MCP",
+      "Finlynq vs Firefly III: open-source personal finance with first-party MCP",
     description:
       "AGPL v3 self-hostable PFMs compared. Firefly III's double-entry rigor + PSD2 vs Finlynq's first-party MCP (109 HTTP / 93 stdio) and per-user envelope encryption.",
   },
@@ -32,10 +32,10 @@ const content: VsPageContent = {
   slug: "firefly-iii",
   tagline: (
     <>
-      Firefly III is the canonical open-source self-hosted PFM — eleven years
+      Firefly III is the canonical open-source self-hosted PFM: eleven years
       old, AGPL v3, 23k+ stars, 10M+ Docker pulls, and a deep double-entry
-      accounting model. Finlynq is also AGPL v3 and self-hostable, but built
-      around a first-party MCP server and per-user encryption rather than a
+      accounting model. Finlynq is also AGPL v3 and self-hostable, but it&apos;s
+      built around a first-party MCP server and per-user encryption rather than a
       strict double-entry ledger. They serve overlapping but distinct audiences.
     </>
   ),
@@ -45,7 +45,7 @@ const content: VsPageContent = {
         You want a true double-entry accounting model.
       </strong>{" "}
       Every Firefly III transaction is a transfer between two accounts (asset /
-      expense / revenue / liability) — accountant-grade rigor. Finlynq is
+      expense / revenue / liability), which is accountant-grade rigor. Finlynq is
       single-entry with derived transfer pairs (<code>link_id</code>), which is
       lighter but doesn&apos;t enforce balance.
     </>,
@@ -95,8 +95,8 @@ const content: VsPageContent = {
       Finlynq ships <strong className="text-foreground">109 HTTP and 93 stdio</strong>{" "}
       MCP tools built and maintained by the project, with OAuth 2.1 + Dynamic
       Client Registration, Bearer API keys, and stdio transports. Firefly III
-      has <strong className="text-foreground">no first-party MCP server</strong>{" "}
-      — its maintainer closed{" "}
+      has <strong className="text-foreground">no first-party MCP server</strong>:{" "}
+      its maintainer closed{" "}
       <a
         href="https://github.com/firefly-iii/firefly-iii/issues/9753"
         target="_blank"
@@ -128,7 +128,8 @@ const content: VsPageContent = {
       </strong>{" "}
       Finlynq has cost basis, dividends, FX-aware aggregation across accounts,
       and per-currency cost-basis bucketing. Firefly III has no native concept
-      of holdings, prices, or portfolio P/L — long-standing community gap.
+      of holdings, prices, or portfolio P/L, which is a long-standing community
+      gap.
     </>,
     <>
       <strong className="text-foreground">
@@ -143,8 +144,8 @@ const content: VsPageContent = {
         You want a modern App Router UI.
       </strong>{" "}
       Finlynq is Next.js 16 + Tailwind + shadcn/ui v4. Firefly III is
-      server-rendered Laravel Blade with progressively enhanced JS —
-      boring-stable but visibly older.
+      server-rendered Laravel Blade with progressively enhanced JS:
+      boring-stable, but visibly older.
     </>,
     <>
       <strong className="text-foreground">You&apos;re North American.</strong>{" "}
@@ -192,14 +193,14 @@ const content: VsPageContent = {
       label: "First-party MCP server",
       finlynq: (
         <>
-          Yes —{" "}
+          Yes,{" "}
           <strong className="text-foreground">109 HTTP / 93 stdio</strong> tools,
           v3.3.0
         </>
       ),
       competitor: (
         <>
-          No — maintainer-declined (
+          No, maintainer-declined (
           <a
             href="https://github.com/firefly-iii/firefly-iii/issues/9753"
             target="_blank"
@@ -233,8 +234,8 @@ const content: VsPageContent = {
     },
     {
       label: "REST / HTTP API",
-      finlynq: "Yes — full surface mirrored from MCP",
-      competitor: "Yes — covers almost the whole app; OAuth 2 + PAT",
+      finlynq: "Yes, full surface mirrored from MCP",
+      competitor: "Yes: covers almost the whole app; OAuth 2 + PAT",
     },
     {
       label: "Accounting model",
@@ -256,7 +257,7 @@ const content: VsPageContent = {
       finlynq:
         "Cost basis, dividends, FX-aware aggregation across accounts",
       competitor:
-        "Not natively supported — community workaround via asset accounts",
+        "Not natively supported; community workaround via asset accounts",
     },
     {
       label: "Bank sync",
@@ -269,19 +270,19 @@ const content: VsPageContent = {
       label: "Rule engine",
       finlynq: "Auto-categorize rules (match field / type / value)",
       competitor:
-        "Rule groups, triggers, actions, replay over history — deeper",
+        "Rule groups, triggers, actions, replay over history; deeper",
     },
     {
       label: "Encryption at rest",
       finlynq:
-        "Per-user envelope encryption (AES-256-GCM, scrypt-derived KEK from password) — operator cannot decrypt",
+        "Per-user envelope encryption (AES-256-GCM, scrypt-derived KEK from password); operator cannot decrypt",
       competitor:
         "Plaintext at the application layer; row encryption is the operator's responsibility",
     },
     {
       label: "Multi-user / household",
       finlynq: "No (single-user)",
-      competitor: "Yes — admin / demo / regular roles on one instance",
+      competitor: "Yes: admin / demo / regular roles on one instance",
     },
     {
       label: "Native mobile app",
@@ -291,7 +292,7 @@ const content: VsPageContent = {
     {
       label: "Localization",
       finlynq: "English only at launch",
-      competitor: "Widely translated — strong i18n (EU origin)",
+      competitor: "Widely translated; strong i18n (EU origin)",
     },
     {
       label: "Stack",
@@ -326,7 +327,7 @@ const content: VsPageContent = {
     <>
       <strong className="text-foreground">Import into Finlynq.</strong> Upload
       the CSV at <code>/import/reconcile</code>. The unified staging pipeline
-      lets you review, edit, and approve every row — multi-currency,
+      lets you review, edit, and approve every row; multi-currency,
       transfer-pair detection, and dedup are built in.
     </>,
     <>
@@ -350,10 +351,10 @@ const content: VsPageContent = {
       a: (
         <>
           For traditional double-entry budgeting workflows on EU/UK banking
-          infrastructure, often yes — Firefly III has eleven years of polish, a
+          infrastructure, often yes. Firefly III has eleven years of polish, a
           deep rule engine, PSD2 bank aggregation, and multi-user support.
           Finlynq is built for a different slot: AI-native users who want a
-          first-party MCP server, encryption that excludes the operator, and
+          first-party MCP server, encryption the operator can&apos;t read, and
           native investment tracking. We pick different fights.
         </>
       ),
@@ -372,7 +373,7 @@ const content: VsPageContent = {
           >
             issue #9753
           </a>
-          ). That&apos;s a legitimate product call — Firefly III&apos;s identity
+          ). That&apos;s a legitimate product call. Firefly III&apos;s identity
           is opinionated double-entry accounting, not AI. Two community wrappers
           exist that proxy the REST API; they work, but they aren&apos;t
           blessed, aren&apos;t in-UI, and they expose whatever a Firefly III
@@ -384,8 +385,8 @@ const content: VsPageContent = {
       q: "Are the community MCP wrappers for Firefly III as good as Finlynq's MCP?",
       a: (
         <>
-          They cover a useful slice — accounts, bills, categories, tags,
-          transactions, search, budgets — but they&apos;re external Node /
+          They cover a useful slice (accounts, bills, categories, tags,
+          transactions, search, budgets), but they&apos;re external Node /
           Python processes calling Firefly III&apos;s REST API with a Personal
           Access Token. There&apos;s no per-user envelope encryption, no
           confirmation-token preview/execute pattern for destructive ops, no
@@ -401,9 +402,9 @@ const content: VsPageContent = {
       q: "Does Firefly III have better bank-sync than Finlynq?",
       a: (
         <>
-          In the EU/UK — yes, materially. Firefly III&apos;s Data Importer ships
+          In the EU/UK, yes, materially. Firefly III&apos;s Data Importer ships
           GoCardless / Nordigen (free PSD2 access) and Salt Edge. In North
-          America — both projects largely rely on CSV / OFX / QFX import;
+          America, both projects largely rely on CSV / OFX / QFX import;
           neither ships Plaid out of the box. Finlynq&apos;s email-import
           staging via Resend Inbound is a different angle that some users
           prefer.
@@ -471,7 +472,7 @@ const content: VsPageContent = {
       note: "official docs, REST API + Data Importer",
     },
     {
-      label: "Firefly III #9753 — LLM integration request",
+      label: "Firefly III #9753: LLM integration request",
       href: "https://github.com/firefly-iii/firefly-iii/issues/9753",
       note: "closed without plans to ship",
     },

--- a/src/app/vs/firefly-iii/page.tsx
+++ b/src/app/vs/firefly-iii/page.tsx
@@ -285,7 +285,7 @@ const content: VsPageContent = {
     },
     {
       label: "Native mobile app",
-      finlynq: "No (mobile web UI only)",
+      finlynq: "Yes, native iOS and Android apps (App Store, Google Play)",
       competitor: "No (mobile web UI only)",
     },
     {

--- a/src/app/vs/ghostfolio/page.tsx
+++ b/src/app/vs/ghostfolio/page.tsx
@@ -2,12 +2,12 @@ import type { Metadata } from "next";
 import { VsPage, type VsPageContent } from "../_components/VsPage";
 
 export const metadata: Metadata = {
-  title: "Finlynq vs Ghostfolio — full PFM + first-party MCP vs portfolio tracker",
+  title: "Finlynq vs Ghostfolio: full PFM + first-party MCP vs portfolio tracker",
   description:
-    "Finlynq vs Ghostfolio: both open-source AGPL v3 and self-hostable. Ghostfolio is a best-in-class investment tracker but investments-only; Finlynq covers the full personal-finance surface (budgets, transactions, loans, goals) and ships a first-party MCP server with read and write tools. Side-by-side table, when to choose each, migration steps.",
+    "Finlynq vs Ghostfolio: both open-source AGPL v3 and self-hostable. Ghostfolio is a best-in-class investment tracker, but it's investments-only; Finlynq covers the full personal-finance surface (budgets, transactions, loans, goals) and ships a first-party MCP server with read and write tools. Side-by-side table, when to choose each, migration steps.",
   alternates: { canonical: "/vs/ghostfolio" },
   openGraph: {
-    title: "Finlynq vs Ghostfolio — full PFM + first-party MCP vs portfolio tracker",
+    title: "Finlynq vs Ghostfolio: full PFM + first-party MCP vs portfolio tracker",
     description:
       "Both AGPL v3 and self-hostable. Ghostfolio: best-in-class portfolio analytics, investments-only. Finlynq: full PFM + first-party MCP with write access.",
     url: "/vs/ghostfolio",
@@ -26,20 +26,20 @@ const content: VsPageContent = {
   competitorName: "Ghostfolio",
   slug: "ghostfolio",
   tagline:
-    "Ghostfolio is the leading open-source, AGPL v3 portfolio and wealth tracker — best-in-class investment analytics, but investments-only. Finlynq is also AGPL v3 and self-hostable, but covers the full personal-finance surface (budgets, transactions, loans, goals) and ships a first-party MCP server with read and write tools.",
+    "Ghostfolio is the leading open-source, AGPL v3 portfolio and wealth tracker, with best-in-class investment analytics, but it's investments-only. Finlynq is also AGPL v3 and self-hostable, and it covers the full personal-finance surface (budgets, transactions, loans, goals) plus a first-party MCP server with read and write tools.",
   whenCompetitor: [
-    "You want a dedicated, polished investment tracker — time-weighted and money-weighted return, dividends, and allocation by asset, country, sector, and industry. Its portfolio analytics are the most mature in this set.",
-    "You want a mature dual-host model today — free self-host plus a Ghostfolio Premium managed cloud (~$15/yr) with professionally sourced data feeds.",
-    "You want a PWA plus an official Android wrapper now. Finlynq's React Native app is functional but less mature.",
-    "You want broad self-host distribution — community templates for CasaOS, Home Assistant, Unraid, Umbrel — and a very high release cadence.",
-    "You only track investments and do not need budgets, transactions, loans, or subscriptions.",
+    "You want a dedicated, polished investment tracker: time-weighted and money-weighted return, dividends, and allocation by asset, country, sector, and industry. Its portfolio analytics are the most mature in this set.",
+    "You want a mature dual-host model today: free self-host plus a Ghostfolio Premium managed cloud (~$15/yr) with professionally sourced data feeds.",
+    "You want a PWA plus an official Android wrapper right now. Finlynq's mobile apps are newer and less mature.",
+    "You want broad self-host distribution, with community templates for CasaOS, Home Assistant, Unraid, and Umbrel, plus a very high release cadence.",
+    "You only track investments and don't need budgets, transactions, loans, or subscriptions.",
   ],
   whenFinlynq: [
-    "You want the whole personal-finance picture in one app — budgets, transactions, loans and amortization, goals, subscriptions — not just a portfolio. Ghostfolio is portfolio-only.",
-    "You want a first-party MCP server. Ghostfolio ships none; it proposed a read-only Claude Agent SDK chat (not MCP) that was unshipped at the time of writing. A small third-party community wrapper exists, but is not official.",
+    "You want the whole personal-finance picture in one app: budgets, transactions, loans and amortization, goals, subscriptions, not just a portfolio. Ghostfolio is portfolio-only.",
+    "You want a first-party MCP server. Ghostfolio ships none; it proposed a read-only Claude Agent SDK chat (not MCP) that was unshipped at the time of writing. A small third-party community wrapper exists, but it's not official.",
     "You want AI write access, not just read. Ghostfolio's proposed assistant is read-only; Finlynq's MCP supports write tools with a confirmation-token preview/execute pattern.",
     "You want per-user envelope encryption of names. Ghostfolio stores account, symbol, and comment names without per-user encryption.",
-    "You want any bank or transaction import at all. Ghostfolio has no bank aggregation — manual entry or CSV/JSON activities import only.",
+    "You want any bank or transaction import at all. Ghostfolio has no bank aggregation, just manual entry or CSV/JSON activities import.",
     "You want trade-date-locked multi-currency cost basis. Ghostfolio re-converts at the current spot rate, a documented cost-basis-drift issue.",
   ],
   comparisonRows: [
@@ -47,13 +47,13 @@ const content: VsPageContent = {
     {
       label: "Hosting",
       finlynq: "Self-host (Docker + PostgreSQL) or managed cloud",
-      competitor: "Both — self-host Docker and managed cloud at ghostfol.io",
+      competitor: "Both: self-host Docker and managed cloud at ghostfol.io",
     },
     {
       label: "First-party MCP",
-      finlynq: "Yes — 109 HTTP / 93 stdio tools",
+      finlynq: "Yes, 109 HTTP / 93 stdio tools",
       competitor:
-        "No — proposed read-only Claude Agent SDK chat (unshipped); a small third-party community MCP wrapper exists",
+        "No: proposed read-only Claude Agent SDK chat (unshipped); a small third-party community MCP wrapper exists",
     },
     {
       label: "MCP auth",
@@ -62,14 +62,14 @@ const content: VsPageContent = {
     },
     {
       label: "REST / HTTP API",
-      finlynq: "Yes — full surface mirrored from MCP",
-      competitor: "Yes — public API; activities import/export",
+      finlynq: "Yes, full surface mirrored from MCP",
+      competitor: "Yes: public API; activities import/export",
     },
     {
       label: "Bank sync",
       finlynq:
         "File / email import + connector framework. No first-party Plaid today.",
-      competitor: "None — manual + CSV/JSON activities import only",
+      competitor: "None: manual + CSV/JSON activities import only",
     },
     {
       label: "Encryption at rest",
@@ -80,14 +80,14 @@ const content: VsPageContent = {
     {
       label: "Multi-currency",
       finlynq: "Native, per-currency cost basis, FX locked at trade date",
-      competitor: "Yes, but converts at current spot rate — cost basis drifts (known issue)",
+      competitor: "Yes, but it converts at the current spot rate, so cost basis drifts (known issue)",
     },
     {
       label: "Investment / portfolio",
       finlynq:
         "Lot-tracked cost basis, dividends, FX-aware aggregation; RRSP/TFSA/RESP",
       competitor:
-        "Best-in-class of this set — TWR/MWR, dividends, allocation/risk breakdowns, crypto-native",
+        "Best-in-class of this set: TWR/MWR, dividends, allocation/risk breakdowns, crypto-native",
     },
     {
       label: "Native mobile app",
@@ -97,7 +97,7 @@ const content: VsPageContent = {
     {
       label: "Multi-user / household",
       finlynq: "No (single-user)",
-      competitor: "Yes — multiple independent users per instance",
+      competitor: "Yes: multiple independent users per instance",
     },
     {
       label: "Pricing",
@@ -111,30 +111,30 @@ const content: VsPageContent = {
     },
   ],
   migrationSteps: [
-    "Export from Ghostfolio — use the activities JSON/CSV export of your buys, sells, and dividends.",
-    "Import into Finlynq at /import/reconcile (or record trades via the portfolio flow) — review and edit, with FX-aware cost basis and per-holding currency handled in staging.",
+    "Export from Ghostfolio. Use the activities JSON/CSV export of your buys, sells, and dividends.",
+    "Import into Finlynq at /import/reconcile (or record trades via the portfolio flow). Review and edit, with FX-aware cost basis and per-holding currency handled in staging.",
     "Connect Claude (or any MCP client) at /mcp for natural-language portfolio queries that also reach your budgets, loans, and goals.",
   ],
   faq: [
     {
       q: "Isn't Ghostfolio's portfolio tracking better than Finlynq's?",
-      a: "Its analytics (TWR/MWR, allocation breakdowns) are more polished. Finlynq's edge is scope (budgets + portfolio + loans + goals in one app), trade-date-locked multi-currency cost basis, and a first-party MCP server.",
+      a: "Its analytics (TWR/MWR, allocation breakdowns) are more polished, no argument there. Finlynq's edge is scope (budgets + portfolio + loans + goals in one app), trade-date-locked multi-currency cost basis, and a first-party MCP server.",
     },
     {
       q: "Does Ghostfolio have an MCP server?",
-      a: "Not a first-party one. It proposed a Claude Agent SDK chat (read-only, unshipped at the time of writing). A small third-party community wrapper exists but is not official or maintained by the Ghostfolio team.",
+      a: "Not a first-party one. It proposed a Claude Agent SDK chat (read-only, unshipped at the time of writing). A small third-party community wrapper exists, but it isn't official or maintained by the Ghostfolio team.",
     },
     {
       q: "Can Ghostfolio sync my bank?",
-      a: "No — it has no bank aggregation. It is manual entry or CSV/JSON activities import. Finlynq imports CSV/OFX/QFX/PDF/email.",
+      a: "No, it has no bank aggregation. It's manual entry or CSV/JSON activities import. Finlynq imports CSV/OFX/QFX/PDF/email.",
     },
     {
       q: "Is Ghostfolio's multi-currency accurate?",
       a: "It converts using the current spot rate, which causes cost-basis drift (a documented open issue). Finlynq locks FX at trade date.",
     },
     {
-      q: "They're both AGPL v3 — why pick Finlynq?",
-      a: "If you want only investments, Ghostfolio is a strong, mature choice. Finlynq is for users who want investments plus budgets, loans, and goals, plus a first-party MCP server with write access and per-user encryption.",
+      q: "They're both AGPL v3. Why pick Finlynq?",
+      a: "If you only want investments, Ghostfolio is a strong, mature choice. Finlynq is for users who want investments plus budgets, loans, and goals, plus a first-party MCP server with write access and per-user encryption.",
     },
   ],
   sources: [

--- a/src/app/vs/ghostfolio/page.tsx
+++ b/src/app/vs/ghostfolio/page.tsx
@@ -91,7 +91,7 @@ const content: VsPageContent = {
     },
     {
       label: "Native mobile app",
-      finlynq: "React Native (Expo) app — functional, not at parity with consumer apps",
+      finlynq: "Yes, native iOS and Android apps (App Store, Google Play)",
       competitor: "PWA + official Android wrapper",
     },
     {

--- a/src/app/vs/maybe/page.tsx
+++ b/src/app/vs/maybe/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { VsPage, type VsPageContent } from "../_components/VsPage";
 
 export const metadata: Metadata = {
-  title: "Finlynq vs Maybe (and the Sure fork) — actively-built open-source PFM",
+  title: "Finlynq vs Maybe (and the Sure fork): actively-built open-source PFM",
   description:
     "Finlynq vs Maybe Finance and its community fork Sure: Maybe was a venture-funded PFM that open-sourced after shutting down; Sure is the volunteer fork. Finlynq targets the same holistic user with a modern stack, per-user envelope encryption, and a first-party MCP server neither ships. Side-by-side table, when to choose each, migration steps.",
   alternates: { canonical: "/vs/maybe" },
@@ -29,18 +29,18 @@ const content: VsPageContent = {
     "Maybe Finance was a venture-funded full personal-finance app that open-sourced after shutting down; Sure is the volunteer-run community fork that keeps it alive. Finlynq targets the same holistic user, but with a modern stack, per-user envelope encryption, and a first-party MCP server that neither Maybe nor Sure ships.",
   whenCompetitor: [
     "You want the inherited brand recognition and net-worth-first dashboard from the well-known open-sourced-after-shutdown project.",
-    "You want Plaid bank aggregation already in the codebase — Maybe was Plaid-native (plus SimpleFIN). Note: Plaid is dormant after archival, so live sync requires your own setup.",
-    "You prefer a conventional Ruby on Rails + Hotwire monolith — easy for senior Ruby contributors to work in.",
-    "You want full PFM scope (budgets, transactions, holdings, multi-currency) in one open-source app and do not need first-party AI/MCP.",
+    "You want Plaid bank aggregation already in the codebase. Maybe was Plaid-native (plus SimpleFIN), though Plaid is dormant after archival, so live sync means setting it up yourself.",
+    "You prefer a conventional Ruby on Rails + Hotwire monolith that senior Ruby contributors can drop right into.",
+    "You want full PFM scope (budgets, transactions, holdings, multi-currency) in one open-source app and don't need first-party AI or MCP.",
     "You specifically want the actively-maintained Sure fork's community momentum.",
   ],
   whenFinlynq: [
-    "You want a single-team-led project with a clear roadmap. The original Maybe is archived; Sure is volunteer-run with thinner roadmap clarity.",
-    "You want a first-party MCP server. Neither Maybe nor Sure ships one — Maybe's old in-app AI was in-process OpenAI function-calling (not MCP, not exposed to external clients). Finlynq ships first-party MCP (HTTP + stdio) with read and write tools.",
-    "You want per-user envelope encryption where the operator cannot read your data. Maybe/Sure has no app-layer column encryption.",
+    "You want a single-team-led project with a clear roadmap. The original Maybe is archived, and Sure is volunteer-run with thinner roadmap clarity.",
+    "You want a first-party MCP server. Neither Maybe nor Sure ships one. Maybe's old in-app AI was in-process OpenAI function-calling (not MCP, and not exposed to external clients). Finlynq ships first-party MCP (HTTP + stdio) with read and write tools.",
+    "You want per-user envelope encryption where the operator can't read your data. Maybe and Sure have no app-layer column encryption.",
     "You want a modern React / TypeScript stack the AI-tooling ecosystem speaks natively, rather than a Rails / Hotwire monolith.",
     "You want an official managed cloud. Sure is self-host only; Finlynq offers finlynq.com/cloud.",
-    "You want to avoid Plaid dependency risk — the same aggregator cost that helped sink the original Maybe company. Finlynq's import + connector framework is Plaid-independent.",
+    "You want to steer clear of Plaid dependency risk, the same aggregator cost that helped sink the original Maybe company. Finlynq's import and connector framework is Plaid-independent.",
   ],
   comparisonRows: [
     { label: "License", finlynq: "AGPL v3", competitor: "AGPL v3 (same as Finlynq)" },
@@ -51,9 +51,9 @@ const content: VsPageContent = {
     },
     {
       label: "First-party MCP",
-      finlynq: "Yes — 109 HTTP / 93 stdio tools",
+      finlynq: "Yes, 109 HTTP / 93 stdio tools",
       competitor:
-        "No — Maybe's in-app AI was in-process OpenAI function-calling; no documented Sure MCP",
+        "No: Maybe's in-app AI was in-process OpenAI function-calling; no documented Sure MCP",
     },
     {
       label: "MCP auth",
@@ -62,7 +62,7 @@ const content: VsPageContent = {
     },
     {
       label: "REST / HTTP API",
-      finlynq: "Yes — full surface mirrored from MCP",
+      finlynq: "Yes, full surface mirrored from MCP",
       competitor: "Partial / internal; no mature documented public REST surface",
     },
     {
@@ -86,7 +86,7 @@ const content: VsPageContent = {
       label: "Investment / portfolio",
       finlynq:
         "Lot-tracked cost basis, dividends, FX-aware aggregation; RRSP/TFSA/RESP",
-      competitor: "Yes — securities, holdings, crypto, performance (a Maybe strength)",
+      competitor: "Yes: securities, holdings, crypto, performance (a Maybe strength)",
     },
     {
       label: "Native mobile app",
@@ -111,9 +111,9 @@ const content: VsPageContent = {
     },
   ],
   migrationSteps: [
-    "Export from Maybe/Sure — use the CSV export of transactions and holdings, or your database export if self-hosting.",
-    "Import into Finlynq at /import/reconcile — review and edit each row; multi-currency, transfer pairs, and dedup are handled in staging; record holdings via the portfolio flow.",
-    "Connect Claude (or any MCP client) at /mcp — paste the URL into Claude → Customize → Connectors; OAuth handles auth.",
+    "Export from Maybe or Sure. Use the CSV export of transactions and holdings, or your database export if you're self-hosting.",
+    "Import into Finlynq at /import/reconcile. Review and edit each row; multi-currency, transfer pairs, and dedup are handled in staging, and you record holdings via the portfolio flow.",
+    "Connect Claude (or any MCP client) at /mcp. Paste the URL into Claude, then Customize, then Connectors; OAuth handles auth.",
   ],
   faq: [
     {
@@ -122,19 +122,19 @@ const content: VsPageContent = {
     },
     {
       q: "Does Maybe/Sure have an MCP server?",
-      a: "No. The original Maybe had an in-app AI chat using OpenAI function-calling internally — not MCP, and not exposed to external AI clients. No documented Sure MCP exists. Finlynq ships first-party MCP.",
+      a: "No. The original Maybe had an in-app AI chat using OpenAI function-calling internally, but that's not MCP and it wasn't exposed to external AI clients. No documented Sure MCP exists. Finlynq ships first-party MCP.",
     },
     {
-      q: "Maybe has Plaid bank sync — does Finlynq?",
+      q: "Maybe has Plaid bank sync. Does Finlynq?",
       a: "Maybe was Plaid-native, but Plaid is dormant after archival and needs self-configuration. Finlynq has no first-party Plaid and uses import plus a connector framework instead (SnapTrade on the roadmap).",
     },
     {
-      q: "Both are AGPL v3 and full PFMs — what's the real difference?",
-      a: "Project health (single-team-led with a roadmap vs a volunteer fork), stack (React/TypeScript vs Rails/Hotwire), per-user envelope encryption, and a first-party MCP server with write access — none of which Maybe/Sure offers.",
+      q: "Both are AGPL v3 and full PFMs. What's the real difference?",
+      a: "Project health (single-team-led with a roadmap vs a volunteer fork), stack (React/TypeScript vs Rails/Hotwire), per-user envelope encryption, and a first-party MCP server with write access. None of which Maybe or Sure offers.",
     },
     {
       q: "Why did Maybe shut down?",
-      a: "Per its founders, a combination of bad timing, a long build before validating fit, few paying customers at launch, and painful, expensive Plaid aggregation. Finlynq's donation-funded, Plaid-independent model is a deliberate response.",
+      a: "Per its founders, a combination of bad timing, a long build before validating fit, few paying customers at launch, and painful, expensive Plaid aggregation. Finlynq's donation-funded, Plaid-independent model is a deliberate response to that.",
     },
   ],
   sources: [
@@ -149,7 +149,7 @@ const content: VsPageContent = {
       note: "active community fork, fetched 2026-05-29",
     },
     {
-      label: "Failory — why Maybe failed",
+      label: "Failory: why Maybe failed",
       href: "https://newsletter.failory.com/p/3-reasons-maybe-failed",
       note: "post-mortem: funding, Plaid cost",
     },

--- a/src/app/vs/maybe/page.tsx
+++ b/src/app/vs/maybe/page.tsx
@@ -90,7 +90,7 @@ const content: VsPageContent = {
     },
     {
       label: "Native mobile app",
-      finlynq: "React Native (Expo) app — functional, not at parity with consumer apps",
+      finlynq: "Yes, native iOS and Android apps (App Store, Google Play)",
       competitor: "No (Flutter companion code existed but never fully shipped)",
     },
     {

--- a/src/app/vs/monarch/page.tsx
+++ b/src/app/vs/monarch/page.tsx
@@ -2,14 +2,14 @@ import type { Metadata } from "next";
 import { VsPage, type VsPageContent } from "../_components/VsPage";
 
 export const metadata: Metadata = {
-  title: "Finlynq vs Monarch Money — open-source AI-native alternative",
+  title: "Finlynq vs Monarch Money: open-source AI-native alternative",
   description:
     "Finlynq vs Monarch Money: open-source AGPL v3 with self-host + 109 MCP tools + per-user envelope encryption + Canadian tax accounts, compared against Monarch's closed-source hosted SaaS with full Plaid bank sync and household budgeting. Side-by-side feature table, when to choose each, and migration steps.",
   alternates: {
     canonical: "/vs/monarch",
   },
   openGraph: {
-    title: "Finlynq vs Monarch Money — open-source AI-native alternative",
+    title: "Finlynq vs Monarch Money: open-source AI-native alternative",
     description:
       "Two AI-native PFMs, compared. Monarch: closed-source SaaS, $99/yr, Plaid bank sync, household plan. Finlynq: AGPL v3, self-hostable, 109 MCP tools, per-user envelope encryption, RRSP/TFSA tracking.",
     url: "/vs/monarch",
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Finlynq vs Monarch Money — open-source AI-native alternative",
+    title: "Finlynq vs Monarch Money: open-source AI-native alternative",
     description:
       "Open-source self-hostable PFM with 109 MCP tools and per-user envelope encryption, compared with Monarch Money's closed SaaS.",
   },
@@ -29,11 +29,11 @@ const content: VsPageContent = {
   slug: "monarch",
   tagline: (
     <>
-      Monarch is the polished hosted SaaS that absorbed most of Mint&apos;s
+      Monarch is the polished hosted SaaS that picked up most of Mint&apos;s
       audience after the 2024 shutdown. Finlynq is the open-source,
-      self-hostable, AI-native alternative — same MCP-driven workflows Monarch
-      is now building, but with your data on your hardware and your encryption
-      keys derived from your password.
+      self-hostable, AI-native alternative. You get the same MCP-driven
+      workflows Monarch is now building, but with your data on your own
+      hardware and your encryption keys derived from your password.
     </>
   ),
   whenCompetitor: [
@@ -82,8 +82,8 @@ const content: VsPageContent = {
   whenFinlynq: [
     <>
       <strong className="text-foreground">You want the source code.</strong>{" "}
-      Finlynq is AGPL v3, fully on GitHub. Monarch is closed-source — you
-      can&apos;t audit the categorization rules, the AI features, the
+      Finlynq is AGPL v3 and it&apos;s all on GitHub. Monarch is closed-source,
+      so you can&apos;t audit the categorization rules, the AI features, the
       encryption claims, or what data leaves your account.
     </>,
     <>
@@ -105,10 +105,10 @@ const content: VsPageContent = {
       <strong className="text-foreground">
         You want a first-party MCP server with 109 HTTP / 93 stdio tools.
       </strong>{" "}
-      Finlynq ships MCP as a core feature, not a bolt-on — OAuth 2.1 + DCR,
-      Bearer API keys, stdio, all transports. Monarch did add an MCP server in
-      2026, but Finlynq&apos;s surface is 3× larger and was built from day one
-      for AI assistants rather than retrofitted to a consumer SaaS.
+      Finlynq ships MCP as a core feature, not a bolt-on: OAuth 2.1 + DCR,
+      Bearer API keys, stdio, all the transports. Monarch did add an MCP server
+      in 2026, but Finlynq&apos;s surface is 3× larger and was built from day one
+      for AI assistants instead of retrofitted onto a consumer SaaS.
     </>,
     <>
       <strong className="text-foreground">
@@ -122,8 +122,9 @@ const content: VsPageContent = {
       <strong className="text-foreground">
         You&apos;re paying ~$100/year and would rather not.
       </strong>{" "}
-      Monarch is $14.99/month or $99.99/year. Finlynq is donation-based — same
-      features whether you self-host for free or use the hosted cloud.
+      Monarch is $14.99/month or $99.99/year. Finlynq is donation-based, and
+      you get the same features whether you self-host for free or use the hosted
+      cloud.
     </>,
     <>
       <strong className="text-foreground">
@@ -153,12 +154,12 @@ const content: VsPageContent = {
       label: "First-party MCP",
       finlynq: (
         <>
-          Yes —{" "}
+          Yes,{" "}
           <strong className="text-foreground">109 HTTP / 93 stdio</strong> tools,
           v3.3.0
         </>
       ),
-      competitor: "Yes — Monarch MCP server (added 2026, smaller surface)",
+      competitor: "Yes, Monarch MCP server (added 2026, smaller surface)",
     },
     {
       label: "MCP auth",
@@ -167,19 +168,19 @@ const content: VsPageContent = {
     },
     {
       label: "REST / HTTP API",
-      finlynq: "Yes — full surface mirrored from MCP",
+      finlynq: "Yes, the full surface is mirrored from MCP",
       competitor: "Limited public API",
     },
     {
       label: "Bank sync (US)",
       finlynq:
         "File / email / CSV / OFX import + connector framework. No first-party Plaid today.",
-      competitor: "Plaid + MX + Finicity — full aggregator coverage",
+      competitor: "Plaid + MX + Finicity, full aggregator coverage",
     },
     {
       label: "Bank sync (Canada)",
-      finlynq: "Same as US — file/email import; SnapTrade brokerage on roadmap",
-      competitor: "Limited — Plaid Canada coverage is partial",
+      finlynq: "Same as US: file/email import; SnapTrade brokerage on roadmap",
+      competitor: "Limited; Plaid Canada coverage is partial",
     },
     {
       label: "Native mobile app",
@@ -191,28 +192,28 @@ const content: VsPageContent = {
       label: "Multi-user / household",
       finlynq: "No (single-user)",
       competitor:
-        "Yes — two-person household plan with shared budgets + net worth",
+        "Yes, two-person household plan with shared budgets + net worth",
     },
     {
       label: "In-app AI chat",
-      finlynq: "Yes — built into the UI, no MCP client setup required",
-      competitor: "Yes — AI assistant added in 2025",
+      finlynq: "Yes, built into the UI, no MCP client setup required",
+      competitor: "Yes, AI assistant added in 2025",
     },
     {
       label: "Encryption at rest",
       finlynq:
         "Per-user envelope encryption: AES-256-GCM with scrypt-derived KEK. Operator cannot decrypt user-scoped fields.",
-      competitor: `"AES-256 at rest" — Monarch holds the keys`,
+      competitor: `"AES-256 at rest", but Monarch holds the keys`,
     },
     {
       label: "Cash-flow forecasting",
-      finlynq: "Yes — projects 30/60/90 days from recurring transactions",
-      competitor: "Yes — flagship feature",
+      finlynq: "Yes, projects 30/60/90 days from recurring transactions",
+      competitor: "Yes, a flagship feature",
     },
     {
       label: "Spending anomaly detection",
-      finlynq: "Yes — flags categories 30%+ above 3-month average",
-      competitor: "Yes — weekly recap",
+      finlynq: "Yes, flags categories 30%+ above the 3-month average",
+      competitor: "Yes, weekly recap",
     },
     {
       label: "Net-worth tracking",
@@ -230,7 +231,7 @@ const content: VsPageContent = {
       label: "Canadian tax accounts",
       finlynq:
         "RRSP, TFSA, RESP via contribution_room table + tax-optimizer.ts with CRA limits",
-      competitor: "Limited — US-centric",
+      competitor: "Limited; US-centric",
     },
     {
       label: "Multi-currency",
@@ -273,8 +274,8 @@ const content: VsPageContent = {
       <strong className="text-foreground">
         Re-create your auto-categorize rules.
       </strong>{" "}
-      Same story — re-author via the rules UI at <code>/settings/rules</code>{" "}
-      or via the <code>create_rule</code> MCP tool.
+      Same story here: re-author them via the rules UI at{" "}
+      <code>/settings/rules</code> or via the <code>create_rule</code> MCP tool.
     </>,
     <>
       <strong className="text-foreground">Hook up your AI client.</strong> Open
@@ -286,14 +287,14 @@ const content: VsPageContent = {
   ],
   faq: [
     {
-      q: "Isn't Monarch obviously better — it has bank sync, native mobile, and household features Finlynq doesn't?",
+      q: "Isn't Monarch obviously better? It has bank sync, native mobile, and household features Finlynq doesn't.",
       a: (
         <>
-          For users whose top priorities are auto-sync, mobile polish, and
-          shared household budgeting on US banks, yes — Monarch is the better
-          default. Finlynq&apos;s audience is users who specifically want open
-          source, self-hosting, per-user encryption that excludes the operator,
-          and a deeper MCP surface — and who are willing to trade Plaid
+          If your top priorities are auto-sync, mobile polish, and shared
+          household budgeting on US banks, then yeah, Monarch is the better
+          default. Finlynq&apos;s audience is the people who specifically want
+          open source, self-hosting, per-user encryption that excludes the
+          operator, and a deeper MCP surface, and who are happy to trade Plaid
           convenience for those properties.
         </>
       ),
@@ -302,13 +303,13 @@ const content: VsPageContent = {
       q: "Monarch has an MCP server now too. Doesn't that close Finlynq's main gap?",
       a: (
         <>
-          It narrows it but doesn&apos;t close it. Finlynq&apos;s MCP is 109 HTTP
-          / 93 stdio tools at v3.3.0, built from day one as a first-party surface
-          with OAuth 2.1 + DCR, stdio transport, and per-user encryption.
-          Monarch&apos;s MCP is a 2026 addition layered on top of a closed-source
-          SaaS — useful, but the underlying data still lives on Monarch&apos;s
-          infrastructure, the operator can read everything, and you can&apos;t
-          audit the tool implementations.
+          It narrows the gap, but it doesn&apos;t close it. Finlynq&apos;s MCP is
+          109 HTTP / 93 stdio tools at v3.3.0, built from day one as a
+          first-party surface with OAuth 2.1 + DCR, stdio transport, and
+          per-user encryption. Monarch&apos;s MCP is a 2026 addition layered on
+          top of a closed-source SaaS. It&apos;s useful, but the underlying data
+          still lives on Monarch&apos;s infrastructure, the operator can read
+          everything, and you can&apos;t audit the tool implementations.
         </>
       ),
     },
@@ -329,10 +330,10 @@ const content: VsPageContent = {
       q: "Does Finlynq have couples / household support?",
       a: (
         <>
-          Not yet. It&apos;s a tracked design item — the envelope-encryption
-          model assumed a single user, so adding shared accounts is a
-          non-trivial cryptographic design. If household is a hard requirement,
-          Monarch is ahead until Finlynq ships it.
+          Not yet. It&apos;s a tracked design item. The envelope-encryption
+          model assumed a single user, so adding shared accounts is a real
+          cryptographic design problem, not a quick toggle. If household is a
+          hard requirement, Monarch is ahead until Finlynq ships it.
         </>
       ),
     },
@@ -351,9 +352,10 @@ const content: VsPageContent = {
       q: "Can I run both?",
       a: (
         <>
-          Yes, plenty of people do — Monarch for bank sync + household, Finlynq
-          as a parallel system with encryption + MCP. Export from Monarch to
-          CSV, import to Finlynq for the data you want under your own control.
+          Yes, plenty of people do: Monarch for bank sync and household,
+          Finlynq as a parallel system with encryption and MCP. Export from
+          Monarch to CSV, then import into Finlynq for the data you want under
+          your own control.
         </>
       ),
     },

--- a/src/app/vs/monarch/page.tsx
+++ b/src/app/vs/monarch/page.tsx
@@ -50,9 +50,9 @@ const content: VsPageContent = {
         You want a polished native iOS and Android app.
       </strong>{" "}
       Monarch&apos;s mobile apps are mature with receipt scanning, push
-      notifications, and quick add. Finlynq has a React Native Expo app for
-      Dashboard, Transactions, Import, Budgets, and Settings — functional but
-      not at parity.
+      notifications, and quick add. Finlynq now ships native iOS and Android
+      apps (App Store and Google Play) for Dashboard, Transactions, Import,
+      Budgets, and Settings. They work well, but they are not yet at parity.
     </>,
     <>
       <strong className="text-foreground">
@@ -184,7 +184,7 @@ const content: VsPageContent = {
     {
       label: "Native mobile app",
       finlynq:
-        "React Native (Expo) — Dashboard, Tx, Import, Budgets, Settings",
+        "iOS and Android (App Store, Google Play), covering Dashboard, Tx, Import, Budgets, Settings; newer and still maturing",
       competitor: "iOS + Android (mature)",
     },
     {

--- a/src/app/vs/page.tsx
+++ b/src/app/vs/page.tsx
@@ -5,7 +5,7 @@ import { JsonLd, breadcrumbSchema } from "@/components/seo/json-ld";
 import { VS_SLUGS, VS_META } from "@/lib/seo/site";
 
 export const metadata: Metadata = {
-  title: "Finlynq vs other personal finance apps — side-by-side comparisons",
+  title: "Finlynq vs other personal finance apps: side-by-side comparisons",
   description:
     "How Finlynq compares to Monarch Money, Era, Firefly III, and Alderfi: open-source AGPL v3, self-hostable, first-party MCP server, and per-user envelope encryption versus each alternative. Honest side-by-side tables, when to choose each, and migration steps.",
   alternates: { canonical: "/vs" },
@@ -52,8 +52,9 @@ export default function VsIndexPage() {
           </h1>
           <p className="mt-4 text-base leading-relaxed text-muted-foreground">
             Honest, sourced side-by-side comparisons. Finlynq is open-source
-            (AGPL v3), self-hostable, and the only personal finance manager with
-            a shipped first-party MCP server and per-user envelope encryption.
+            (AGPL v3) and self-hostable, and it&apos;s the only personal finance
+            manager we know of that ships a first-party MCP server plus per-user
+            envelope encryption.
           </p>
         </header>
 
@@ -77,8 +78,9 @@ export default function VsIndexPage() {
         <div className="mt-12 rounded-2xl border border-primary/20 bg-primary/5 p-6">
           <h3 className="text-base font-semibold text-foreground">Try Finlynq</h3>
           <p className="mt-2 text-sm text-muted-foreground">
-            Free, open source, AGPL v3. Run it on our managed cloud or self-host
-            with one Docker Compose file. Same features either way.
+            Free, open source, AGPL v3. Run it on our managed cloud, or
+            self-host with one Docker Compose file. You get the same features
+            either way.
           </p>
           <div className="mt-4 flex flex-wrap gap-3">
             <Link

--- a/src/app/vs/ynab/page.tsx
+++ b/src/app/vs/ynab/page.tsx
@@ -2,12 +2,12 @@ import type { Metadata } from "next";
 import { VsPage, type VsPageContent } from "../_components/VsPage";
 
 export const metadata: Metadata = {
-  title: "Finlynq vs YNAB — open-source alternative with investments & MCP",
+  title: "Finlynq vs YNAB: open-source alternative with investments & MCP",
   description:
-    "Finlynq vs YNAB (You Need A Budget): open-source AGPL v3 with self-host, native investment tracking, multi-currency, per-user envelope encryption, and a first-party MCP server — compared with YNAB's closed-source zero-based budgeting SaaS. Side-by-side table, when to choose each, and migration steps.",
+    "Finlynq vs YNAB (You Need A Budget): open-source AGPL v3 with self-host, native investment tracking, multi-currency, per-user envelope encryption, and a first-party MCP server, set against YNAB's closed-source zero-based budgeting SaaS. Side-by-side table, when to choose each, and migration steps.",
   alternates: { canonical: "/vs/ynab" },
   openGraph: {
-    title: "Finlynq vs YNAB — open-source alternative with investments & MCP",
+    title: "Finlynq vs YNAB: open-source alternative with investments & MCP",
     description:
       "Open-source self-hostable PFM with investments, multi-currency, encryption, and a first-party MCP server, compared with YNAB's zero-based budgeting SaaS.",
     url: "/vs/ynab",
@@ -26,21 +26,21 @@ const content: VsPageContent = {
   competitorName: "YNAB",
   slug: "ynab",
   tagline:
-    "YNAB (You Need A Budget) is the gold-standard closed-source budgeting SaaS built on a strict zero-based, give-every-dollar-a-job method. Finlynq is the open-source, self-hostable alternative for people who also want investment tracking, multi-currency, encryption that excludes the operator, and a first-party MCP server — with no subscription.",
+    "YNAB (You Need A Budget) is the gold-standard closed-source budgeting SaaS, built on a strict zero-based, give-every-dollar-a-job method. Finlynq is the open-source, self-hostable alternative for people who also want investment tracking, multi-currency, encryption that the operator can't read, and a first-party MCP server, all with no subscription.",
   whenCompetitor: [
-    "You want a proven, opinionated budgeting method with 20 years of content, books, and a strong community. YNAB owns zero-based / envelope budgeting as a category; Finlynq is methodology-agnostic.",
-    "You want first-party bank sync that works out of the box — Plaid (US/Canada, and now UK/EU Direct Import). Finlynq has no first-party bank sync today (file / email import only).",
-    "You want a polished native iOS / Android app with best-in-class quick-entry at the register. YNAB's mobile is more mature than Finlynq's React Native app.",
-    "You want shared household budgeting baked in — multiple people on one subscription. Finlynq is single-user.",
-    "You want a long-stable, well-documented public REST API that a community of tools already builds on.",
+    "You want a proven, opinionated budgeting method with 20 years of content, books, and a strong community behind it. YNAB owns zero-based and envelope budgeting as a category; Finlynq doesn't push any one method.",
+    "You want first-party bank sync that just works out of the box: Plaid (US/Canada, and now UK/EU Direct Import). Finlynq has no first-party bank sync today, just file and email import.",
+    "You want a polished native iOS / Android app with best-in-class quick-entry at the register. YNAB's mobile apps are more mature than Finlynq's newer ones.",
+    "You want shared household budgeting baked right in, with multiple people on one subscription. Finlynq is single-user.",
+    "You want a long-stable, well-documented public REST API that a whole community of tools already builds on.",
   ],
   whenFinlynq: [
-    "You want the source code (AGPL v3, on GitHub) and the option to self-host. YNAB is closed-source, SaaS-only, with no self-host path.",
-    "You want to stop paying a subscription. YNAB is roughly $14.99/mo or $109/yr; Finlynq is donation-funded with the same features on self-host and managed cloud.",
-    "You want native investment / portfolio tracking — holdings, lot-tracked cost basis, dividends, performance. YNAB tracks investment account balances for net worth only, by design.",
-    "You want multi-currency in one place. YNAB is single-currency per budget; international and expat users must run separate budgets and track FX externally.",
-    "You want per-user encryption where even the operator cannot read your payees, notes, or names. YNAB is a hosted SaaS that holds your data in a form it can read.",
-    "You want a first-party MCP server. YNAB has shipped no official AI/MCP; community MCPs exist only because YNAB has a public API, and they proxy an all-or-nothing personal access token.",
+    "You want the source code (AGPL v3, on GitHub) and the option to self-host. YNAB is closed-source, SaaS-only, with no self-host path at all.",
+    "You want to stop paying a subscription. YNAB runs roughly $14.99/mo or $109/yr; Finlynq is donation-funded, with the same features on self-host and managed cloud.",
+    "You want native investment and portfolio tracking: holdings, lot-tracked cost basis, dividends, performance. YNAB tracks investment account balances for net worth only, by design.",
+    "You want multi-currency in one place. YNAB is single-currency per budget, so international and expat users end up running separate budgets and tracking FX on the side.",
+    "You want per-user encryption where even the operator can't read your payees, notes, or names. YNAB is a hosted SaaS that holds your data in a form it can read.",
+    "You want a first-party MCP server. YNAB has shipped no official AI or MCP; community MCPs only exist because YNAB has a public API, and they proxy an all-or-nothing personal access token.",
   ],
   comparisonRows: [
     { label: "License", finlynq: "AGPL v3", competitor: "Closed source" },
@@ -51,9 +51,9 @@ const content: VsPageContent = {
     },
     {
       label: "First-party MCP",
-      finlynq: "Yes — 109 HTTP / 93 stdio tools",
+      finlynq: "Yes, 109 HTTP / 93 stdio tools",
       competitor:
-        "No — but a public REST API has spawned community MCPs (calebl/ynab-mcp-server and others)",
+        "No, but a public REST API has spawned community MCPs (calebl/ynab-mcp-server and others)",
     },
     {
       label: "MCP auth",
@@ -62,8 +62,8 @@ const content: VsPageContent = {
     },
     {
       label: "REST / HTTP API",
-      finlynq: "Yes — full surface mirrored from MCP",
-      competitor: "Yes — official, documented, personal access token + OAuth 2.0",
+      finlynq: "Yes, full surface mirrored from MCP",
+      competitor: "Yes: official, documented, personal access token + OAuth 2.0",
     },
     {
       label: "Bank sync",
@@ -80,7 +80,7 @@ const content: VsPageContent = {
     {
       label: "Multi-currency",
       finlynq: "Native, per-currency cost basis, FX locked at trade date",
-      competitor: "No — one budget is one currency",
+      competitor: "No: one budget is one currency",
     },
     {
       label: "Investment / portfolio",
@@ -91,12 +91,12 @@ const content: VsPageContent = {
     {
       label: "Native mobile app",
       finlynq: "Yes, native iOS and Android apps (App Store, Google Play); newer and still maturing",
-      competitor: "Yes — iOS, Android, Apple Watch (best-in-class quick-entry)",
+      competitor: "Yes: iOS, Android, Apple Watch (best-in-class quick-entry)",
     },
     {
       label: "Multi-user / household",
       finlynq: "No (single-user)",
-      competitor: "Yes — multiple people on one subscription",
+      competitor: "Yes: multiple people on one subscription",
     },
     {
       label: "Pricing",
@@ -110,14 +110,14 @@ const content: VsPageContent = {
     },
   ],
   migrationSteps: [
-    "Export your YNAB data — use the CSV export from the web app, or pull transactions via the YNAB REST API with a personal access token.",
-    "Import into Finlynq via the staging-review pipeline at /import/reconcile — review and edit each row; multi-currency, transfer-pair detection, and dedup are built in.",
-    "Connect your AI client — Claude → Customize → Connectors → paste https://finlynq.com/mcp (or your self-host /mcp URL). OAuth handles the rest.",
+    "Export your YNAB data. Use the CSV export from the web app, or pull transactions via the YNAB REST API with a personal access token.",
+    "Import into Finlynq via the staging-review pipeline at /import/reconcile. Review and edit each row; multi-currency, transfer-pair detection, and dedup are all built in.",
+    "Connect your AI client: Claude, then Customize, then Connectors, then paste https://finlynq.com/mcp (or your self-host /mcp URL). OAuth handles the rest.",
   ],
   faq: [
     {
       q: "Does Finlynq enforce zero-based budgeting like YNAB?",
-      a: "No. Finlynq supports category budgets but is not built around a single opinionated method. If the give-every-dollar-a-job discipline is the reason you would use YNAB, YNAB does that better.",
+      a: "No. Finlynq supports category budgets, but it isn't built around one opinionated method. If the give-every-dollar-a-job discipline is the whole reason you'd use YNAB, YNAB does that better.",
     },
     {
       q: "Can Finlynq sync my bank like YNAB does?",
@@ -125,15 +125,15 @@ const content: VsPageContent = {
     },
     {
       q: "Why compare a free app to a paid one?",
-      a: "The comparison is not price — it is source availability, self-hosting, who can read your data, and whether you get investments, multi-currency, and MCP at all. Finlynq's argument is structural.",
+      a: "The comparison isn't really about price. It's about source availability, self-hosting, who can read your data, and whether you get investments, multi-currency, and MCP at all. Finlynq's argument is structural.",
     },
     {
       q: "Does Finlynq track investments? YNAB does not.",
-      a: "Yes — holdings, lot-tracked cost basis, dividends, and FX-aware aggregation across accounts, including Canadian RRSP/TFSA/RESP accounts. This is one of the clearest gaps in YNAB.",
+      a: "Yes: holdings, lot-tracked cost basis, dividends, and FX-aware aggregation across accounts, including Canadian RRSP/TFSA/RESP accounts. This is one of the clearest gaps in YNAB.",
     },
     {
       q: "Can my household share a Finlynq budget like YNAB's family plan?",
-      a: "Not yet — Finlynq is single-user today. YNAB's shared-budget pricing is genuinely strong for households.",
+      a: "Not yet. Finlynq is single-user today. YNAB's shared-budget pricing is genuinely strong for households.",
     },
   ],
   sources: [

--- a/src/app/vs/ynab/page.tsx
+++ b/src/app/vs/ynab/page.tsx
@@ -90,7 +90,7 @@ const content: VsPageContent = {
     },
     {
       label: "Native mobile app",
-      finlynq: "React Native (Expo) app — functional, not at parity with consumer apps",
+      finlynq: "Yes, native iOS and Android apps (App Store, Google Play); newer and still maturing",
       competitor: "Yes — iOS, Android, Apple Watch (best-in-class quick-entry)",
     },
     {

--- a/src/components/landing/landing-client.tsx
+++ b/src/components/landing/landing-client.tsx
@@ -10,37 +10,37 @@ const FEATURES = [
   {
     idx: "F.01 · AI NATIVE",
     title: "Talk to your money in plain English.",
-    desc: "Connect Claude, Cursor, or any MCP client — or use the in-app AI chat with zero setup. 109 HTTP / 93 stdio tools. Ask questions, get charts and structured answers — no custom exports, no BI tool needed.",
+    desc: "Connect Claude, Cursor, or any MCP client. Or just use the in-app AI chat, no setup at all. That's 109 HTTP / 93 stdio tools. Ask a question, get charts and real answers back. No custom exports, no BI tool.",
     viz: "bars",
   },
   {
     idx: "F.02 · IMPORT",
     title: "Drop a file. Done.",
-    desc: "CSV, Excel, OFX, QFX, and PDF. Finlynq remembers every column mapping as a template — the next import is a single click.",
+    desc: "CSV, Excel, OFX, QFX, PDF. Finlynq remembers how you mapped the columns and saves it as a template, so the next import is one click.",
     viz: "import",
   },
   {
     idx: "F.03 · BUDGETS",
     title: "Envelope budgeting, rolled over.",
-    desc: "Month-by-month envelopes with rollover. Know exactly what's left in Groceries, Dining, or Travel — before you swipe.",
+    desc: "Month-by-month envelopes that roll over. Know exactly what's left in Groceries, Dining, or Travel before you swipe.",
     viz: "budgets",
   },
   {
     idx: "F.04 · PORTFOLIO",
     title: "Holdings, returns, benchmarks.",
-    desc: "Live prices, XIRR, benchmarks vs SPX/QQQ/VTI, lot-tracked cost basis with FX-aware realized gains, RRSP/TFSA/RESP contribution-room tracking. Built for people who actually track their money — not just watch it.",
+    desc: "Live prices, XIRR, benchmarks vs SPX/QQQ/VTI, lot-tracked cost basis with FX-aware realized gains, and RRSP/TFSA/RESP contribution-room tracking. Built for people who actually track their money, not just watch it.",
     viz: "portfolio",
   },
   {
     idx: "F.05 · FIRE",
     title: "Project your freedom number.",
-    desc: "Monte Carlo simulations, savings-rate scenarios, and a realistic FIRE target. See when you can stop — and what would move the date.",
+    desc: "Monte Carlo simulations, savings-rate scenarios, and a realistic FIRE target. See when you can stop, and what would actually move the date.",
     viz: "fire",
   },
   {
     idx: "F.06 · PRIVACY",
     title: "Self-host. Or don't.",
-    desc: "Run it on your Mac, your homelab, or our cloud — same features either way. Per-user envelope encryption (AES-256-GCM, scrypt-derived key). Your DEK lives only in memory while you're signed in.",
+    desc: "Run it on your Mac, your homelab, or our cloud. Same features either way. Per-user envelope encryption (AES-256-GCM, scrypt-derived key), and your DEK only lives in memory while you're signed in.",
     viz: "pips",
   },
 ] as const;
@@ -49,7 +49,7 @@ const STEPS = [
   {
     n: "01",
     title: "Import transactions.",
-    desc: "Upload CSV or OFX from any bank. Finlynq remembers your columns so every future import is one click.",
+    desc: "Upload a CSV or OFX from any bank. Finlynq remembers your columns, so every import after the first is one click.",
   },
   {
     n: "02",
@@ -59,7 +59,7 @@ const STEPS = [
   {
     n: "03",
     title: "Ask anything.",
-    desc: "\"Am I on track with my budget?\" \"What's my net worth?\" \"Any unusual charges?\" — just ask.",
+    desc: "\"Am I on track with my budget?\" \"What's my net worth?\" \"Any unusual charges?\" Just ask.",
   },
 ];
 
@@ -75,16 +75,16 @@ const MCP_TOOLS = [
 ];
 
 const PLAN_FEATS = [
-  "109 MCP tools (HTTP) · 93 (stdio) — read & write",
+  "109 MCP tools (HTTP) · 93 (stdio), read & write",
   "Per-user AES-256-GCM envelope encryption · operator can't decrypt",
-  "In-app AI chat — no MCP client setup required",
+  "In-app AI chat, no MCP client setup required",
   "Native iOS and Android apps, available now",
   "RRSP, TFSA, RESP contribution-room tracking (CRA limits)",
   "Lot-tracked portfolio cost basis · dividends · FX-aware",
   "Cash-flow forecasting · spending anomaly detection",
   "CSV, Excel, OFX/QFX, PDF, email import",
   "Rules engine · budgets · goals · loans · subscriptions",
-  "Self-host or managed cloud · same features either way",
+  "Self-host or managed cloud, same features either way",
   "REST API + MCP (HTTP & stdio · OAuth 2.1 + DCR)",
 ];
 
@@ -108,7 +108,7 @@ const ROADMAP_POINTS = [
 ] as const;
 
 const ROADMAP_LEDE =
-  "What's live, what we're building, and what's next. Directional, not a contract: Finlynq is open source.";
+  "What's live, what we're building, and what's coming. This is a direction, not a promise. Finlynq is open source, after all.";
 
 function FeatureViz({ kind }: { kind: (typeof FEATURES)[number]["viz"] }) {
   switch (kind) {
@@ -297,12 +297,12 @@ export function LandingClient() {
             </h1>
 
             <p className="lede lede-mt-28">
-              Encrypted, private, and yours. Import your bank data, connect Claude or Cursor, and ask
-              questions about your finances in plain English.
+              Encrypted, private, and yours. Import your bank data, connect Claude or Cursor, and
+              ask about your finances in plain English.
             </p>
 
             <p className="lede lede-tagline">
-              Free hosted cloud, or self-host with Docker — same features either way.
+              Use our free hosted cloud, or self-host with Docker. Same features either way.
             </p>
 
             <div className="hero-cta">
@@ -463,8 +463,8 @@ export function LandingClient() {
               </h2>
             </div>
             <p className="lede reveal d2">
-              A complete toolkit — budgets, portfolios, goals, loans, and AI-powered queries. No
-              dashboards required unless you want them.
+              The whole toolkit: budgets, portfolios, goals, loans, and AI-powered queries. No
+              dashboards to babysit unless you actually want them.
             </p>
           </div>
 
@@ -543,7 +543,7 @@ export function LandingClient() {
                   <div className="q-ask">How much did I spend on groceries last month?</div>
                   <div className="q-ans">
                     <div className="text">
-                      <span className="num">$312.40</span> <span className="mute">— up</span>{" "}
+                      <span className="num">$312.40</span> <span className="mute">up</span>{" "}
                       <span className="pos">8%</span> <span className="mute">vs October</span>
                     </div>
                     <svg className="sparkline" viewBox="0 0 96 28" preserveAspectRatio="none">
@@ -581,7 +581,7 @@ export function LandingClient() {
                   <div className="q-ask">What&apos;s my current net worth?</div>
                   <div className="q-ans">
                     <div className="text">
-                      <span className="num">$84,210</span> <span className="mute">— up</span>{" "}
+                      <span className="num">$84,210</span> <span className="mute">up</span>{" "}
                       <span className="pos">$1,240</span> <span className="mute">this month</span>
                     </div>
                     <svg className="sparkline" viewBox="0 0 96 28" preserveAspectRatio="none">
@@ -658,7 +658,7 @@ export function LandingClient() {
             </div>
             <p className="lede reveal d2">
               Your financial data* is encrypted with your password before it ever touches a server.
-              We designed the system so we cannot read it — not a marketing claim, a math one.
+              We built it so we can&apos;t read it. That&apos;s not a marketing claim, it&apos;s a math one.
             </p>
           </div>
 
@@ -681,7 +681,7 @@ export function LandingClient() {
             {[
               {
                 h: "AES-256 encryption.",
-                p: "The same standard used by banks and governments. All data encrypted before it touches any storage — in transit and at rest.",
+                p: "The same standard banks and governments use. Everything is encrypted before it touches storage, in transit and at rest.",
               },
               {
                 h: "Your password is the key.",
@@ -706,7 +706,7 @@ export function LandingClient() {
           </div>
 
           <p className="reveal privacy-disclaimer">
-            <span className="asterisk">*</span> Numeric amounts, dates, and unique IDs are stored unencrypted because they&apos;re required for database operations (totals, sorting, joins, indexes). Everything else &mdash; merchant names, account names, payees, notes, tags, and categories &mdash; is encrypted with a key derived only from your password. Read the{" "}
+            <span className="asterisk">*</span> Numeric amounts, dates, and unique IDs are stored unencrypted because the database needs them to work (totals, sorting, joins, indexes). Everything else (merchant names, account names, payees, notes, tags, and categories) is encrypted with a key derived only from your password. Read the{" "}
             <Link href="/blog/how-finlynq-encrypts-your-money" className="amber-link">
               plain-English writeup
             </Link>
@@ -841,7 +841,7 @@ export function LandingClient() {
             <div className="cta-facts">
               <div className="cta-fact">
                 <div className="eyebrow">LICENSED</div>
-                <div>AGPL v3 — open source forever</div>
+                <div>AGPL v3, open source forever</div>
               </div>
               <div className="cta-fact">
                 <div className="eyebrow">ENCRYPTED</div>

--- a/src/components/landing/landing-client.tsx
+++ b/src/components/landing/landing-client.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useRef } from "react";
 import { AnalyticsConsent } from "@/components/analytics-consent";
 import { LogoMark } from "@/components/logo-mark";
+import { StoreBadges } from "@/components/store-badges";
 
 const FEATURES = [
   {
@@ -77,7 +78,7 @@ const PLAN_FEATS = [
   "109 MCP tools (HTTP) · 93 (stdio) — read & write",
   "Per-user AES-256-GCM envelope encryption · operator can't decrypt",
   "In-app AI chat — no MCP client setup required",
-  "Native mobile app for iOS + Android (coming soon)",
+  "Native iOS and Android apps, available now",
   "RRSP, TFSA, RESP contribution-room tracking (CRA limits)",
   "Lot-tracked portfolio cost basis · dividends · FX-aware",
   "Cash-flow forecasting · spending anomaly detection",
@@ -90,11 +91,11 @@ const PLAN_FEATS = [
 const ROADMAP_POINTS = [
   {
     label: "Live now",
-    desc: "Encrypted finances, a built-in MCP server for any AI, multi-currency portfolios, budgets, and imports.",
+    desc: "Encrypted finances, a built-in MCP server for any AI, native iOS and Android apps, multi-currency portfolios, budgets, and imports.",
   },
   {
     label: "Building",
-    desc: "A native mobile app (Android first, then iOS) and automatic bank and brokerage connections.",
+    desc: "Automatic bank and brokerage connections, and an in-app AI assistant.",
   },
   {
     label: "Up next",
@@ -286,7 +287,7 @@ export function LandingClient() {
 
             <Link href="/blog/finlynq-mobile-app" className="hero-bar hero-bar-mobile hero-bar-link">
               <span className="tag">MOBILE</span>
-              <span>iOS &amp; Android apps coming soon <span aria-hidden="true">→</span></span>
+              <span>Now on iOS and Android <span aria-hidden="true">→</span></span>
             </Link>
 
             <h1 className="display-xl">
@@ -315,6 +316,8 @@ export function LandingClient() {
                 Self-host with Docker
               </Link>
             </div>
+
+            <StoreBadges className="mt-7" />
 
             <div className="hero-meta">
               <div className="cell">

--- a/src/components/store-badges.tsx
+++ b/src/components/store-badges.tsx
@@ -1,0 +1,88 @@
+import { APP_STORE_URL, PLAY_STORE_URL } from "@/lib/app-stores";
+
+/**
+ * Official-style "Download on the App Store" / "Get it on Google Play" badge
+ * links. Logos are inline SVG (CSP-safe — no external images, no inline
+ * styles; SVG `fill` is a presentation attribute, not `style`). Black badges
+ * read correctly on both light and dark themes, per Apple/Google brand guidance.
+ */
+export function StoreBadges({ className = "" }: { className?: string }) {
+  return (
+    <div className={`flex flex-wrap items-center gap-3 ${className}`}>
+      <a
+        href={APP_STORE_URL}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Download Finlynq on the App Store"
+        className="inline-flex items-center gap-2.5 rounded-xl border border-white/15 bg-black px-4 py-2.5 text-white no-underline transition hover:border-white/40"
+      >
+        <AppleLogo />
+        <span className="flex flex-col leading-none">
+          <span className="text-[10px] font-medium opacity-80">
+            Download on the
+          </span>
+          <span className="text-[17px] font-semibold tracking-tight">
+            App Store
+          </span>
+        </span>
+      </a>
+      <a
+        href={PLAY_STORE_URL}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Get Finlynq on Google Play"
+        className="inline-flex items-center gap-2.5 rounded-xl border border-white/15 bg-black px-4 py-2.5 text-white no-underline transition hover:border-white/40"
+      >
+        <GooglePlayLogo />
+        <span className="flex flex-col leading-none">
+          <span className="text-[10px] font-medium uppercase tracking-wide opacity-80">
+            Get it on
+          </span>
+          <span className="text-[17px] font-semibold tracking-tight">
+            Google Play
+          </span>
+        </span>
+      </a>
+    </div>
+  );
+}
+
+function AppleLogo() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 384 512"
+      className="h-7 w-7 shrink-0"
+      fill="currentColor"
+    >
+      <path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zM262.1 104.5c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z" />
+    </svg>
+  );
+}
+
+function GooglePlayLogo() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 512 512"
+      className="h-6 w-6 shrink-0"
+    >
+      <path
+        d="M48 59.49v393a4.33 4.33 0 0 0 7.37 3.07L260 256 55.37 56.42A4.33 4.33 0 0 0 48 59.49z"
+        fill="#00e0ff"
+      />
+      <path
+        d="M345.8 174 89.22 28.16l-.06 0c-5-2.85-9.93-3.18-14.5-.95L260 256z"
+        fill="#00f076"
+      />
+      <path
+        d="M345.8 338 260 256 74.66 441.74c4.57 2.23 9.49 1.9 14.5-.95l.07 0L345.8 338z"
+        fill="#ff3a44"
+      />
+      <path
+        d="M412.06 221.91 345.81 174 260 256l85.81 82 66.25-47.91c14.58-10.55 14.58-46.63 0-57.18z"
+        fill="#ffc900"
+      />
+    </svg>
+  );
+}

--- a/src/lib/app-stores.ts
+++ b/src/lib/app-stores.ts
@@ -1,0 +1,8 @@
+/**
+ * Public store listings for the Finlynq mobile app (React Native / Expo,
+ * package `com.finlynq.mobile`). Single source of truth for the marketing
+ * site — import these rather than hardcoding store URLs.
+ */
+export const APP_STORE_URL = "https://apps.apple.com/app/id6775981169";
+export const PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=com.finlynq.mobile";

--- a/src/lib/seo/glossary.ts
+++ b/src/lib/seo/glossary.ts
@@ -3,8 +3,8 @@
  *
  * Net-new, hand-authored, accurate content targeting informational-intent
  * queries ("what is an MCP server", "what is envelope encryption") that also
- * feed AI-assistant citation. Rendered without any markdown dependency — blocks
- * are plain structured data — so there is zero lockfile risk.
+ * feed AI-assistant citation. Rendered without any markdown dependency (blocks
+ * are plain structured data) so there is zero lockfile risk.
  *
  * Add an entry here and it flows into the sitemap, the /glossary index, and
  * llms-full.txt automatically.
@@ -39,7 +39,7 @@ export const GLOSSARY: GlossaryEntry[] = [
     term: "What is an MCP server?",
     shortTerm: "MCP server",
     description:
-      "An MCP server is a program that exposes tools and data to AI assistants through the Model Context Protocol (MCP) — an open standard introduced by Anthropic in 2024 that lets any compatible AI client (Claude, Cursor, Windsurf, and others) call those tools in a uniform way. A personal-finance MCP server lets an AI assistant securely query and act on your financial data without custom integrations or copy-pasting exports.",
+      "An MCP server is a program that exposes tools and data to AI assistants through the Model Context Protocol (MCP), an open standard introduced by Anthropic in 2024 that lets any compatible AI client (Claude, Cursor, Windsurf, and others) call those tools in a uniform way. A personal-finance MCP server lets an AI assistant securely query and act on your financial data without custom integrations or copy-pasting exports.",
     blocks: [
       {
         type: "p",
@@ -52,14 +52,14 @@ export const GLOSSARY: GlossaryEntry[] = [
       {
         type: "p",
         // keep in sync with src/lib/mcp/tool-counts.ts
-        text: "Finlynq ships a first-party MCP server — not a community wrapper — exposing 109 HTTP tools and 93 stdio tools across budgets, transactions, portfolios, goals, loans, subscriptions, and rules. It supports three transports:",
+        text: "Finlynq ships a first-party MCP server, not a community wrapper, exposing 109 HTTP tools and 93 stdio tools across budgets, transactions, portfolios, goals, loans, subscriptions, and rules. It supports three transports:",
       },
       {
         type: "ul",
         items: [
-          "Streamable HTTP with OAuth 2.1 and Dynamic Client Registration — for web-based clients like Claude.ai and Claude mobile.",
-          "HTTP with a Bearer API key — for scripts and custom agents.",
-          "stdio — for local clients like Claude Desktop.",
+          "Streamable HTTP with OAuth 2.1 and Dynamic Client Registration, for web-based clients like Claude.ai and Claude mobile.",
+          "HTTP with a Bearer API key, for scripts and custom agents.",
+          "stdio, for local clients like Claude Desktop.",
         ],
       },
       {
@@ -91,11 +91,11 @@ export const GLOSSARY: GlossaryEntry[] = [
       },
       {
         type: "p",
-        text: "Each Finlynq user has their own DEK. That DEK is wrapped by a KEK derived from the user's password using scrypt (a memory-hard key-derivation function) plus a server-side pepper. Sensitive display fields — transaction payees, notes, tags, account names, category names, and budget names — are encrypted with AES-256-GCM. The unwrapped DEK only exists in server memory while you are signed in.",
+        text: "Each Finlynq user has their own DEK. That DEK is wrapped by a KEK derived from the user's password using scrypt (a memory-hard key-derivation function) plus a server-side pepper. Sensitive display fields, like transaction payees, notes, tags, account names, category names, and budget names, are encrypted with AES-256-GCM. The unwrapped DEK only exists in server memory while you're signed in.",
       },
       {
         type: "p",
-        text: "The honest trade-off: numeric amounts, dates, and unique IDs are stored unencrypted because the database needs them for totals, sorting, joins, and indexes. Everything name-like is encrypted with a key derived only from your password — so even the operator cannot read it. The corollary is that if you lose your password without a backup, the encrypted fields are unrecoverable.",
+        text: "The honest trade-off: numeric amounts, dates, and unique IDs are stored unencrypted because the database needs them for totals, sorting, joins, and indexes. Everything name-like is encrypted with a key derived only from your password, so even the operator can't read it. The catch is that if you lose your password without a backup, the encrypted fields can't be recovered.",
       },
     ],
     related: [
@@ -110,11 +110,11 @@ export const GLOSSARY: GlossaryEntry[] = [
     term: "What is self-hosted personal finance?",
     shortTerm: "Self-hosted personal finance",
     description:
-      "Self-hosted personal finance means running a personal finance manager (PFM) on infrastructure you control — your own server, homelab, or VPS — instead of a vendor's cloud. You own the database, the backups, and the network boundary, and your financial data never has to leave hardware you trust.",
+      "Self-hosted personal finance means running a personal finance manager (PFM) on infrastructure you control, like your own server, homelab, or VPS, instead of a vendor's cloud. You own the database, the backups, and the network boundary, and your financial data never has to leave hardware you trust.",
     blocks: [
       {
         type: "p",
-        text: "People choose self-hosting for privacy (no third party holds your data), longevity (the app keeps working even if a company pivots or shuts down), and control (you decide when to upgrade and who can reach it). The trade-off is that you are responsible for running it: provisioning a server, applying updates, and keeping backups.",
+        text: "People choose self-hosting for privacy (no third party holds your data), longevity (the app keeps working even if a company pivots or shuts down), and control (you decide when to upgrade and who can reach it). The trade-off is that you're responsible for running it: provisioning a server, applying updates, and keeping backups.",
       },
       {
         type: "h2",
@@ -122,11 +122,11 @@ export const GLOSSARY: GlossaryEntry[] = [
       },
       {
         type: "p",
-        text: "Finlynq runs from a Docker Compose file with PostgreSQL. The self-hosted edition has the same feature set as the managed cloud — the first-party MCP server, per-user envelope encryption, multi-currency investment tracking — with no license fees and no feature gates. It is licensed AGPL v3, so the complete source is public and auditable.",
+        text: "Finlynq runs from a Docker Compose file with PostgreSQL. The self-hosted edition has the same feature set as the managed cloud, including the first-party MCP server, per-user envelope encryption, and multi-currency investment tracking, with no license fees and no feature gates. It's licensed AGPL v3, so the complete source is public and auditable.",
       },
       {
         type: "p",
-        text: "If you would rather not run infrastructure, the same code is available as a free managed cloud. The point is that self-hosting is a choice, not a downgrade.",
+        text: "If you'd rather not run infrastructure, the same code is available as a free managed cloud. The point is that self-hosting is a choice, not a downgrade.",
       },
     ],
     related: [
@@ -149,7 +149,7 @@ export const GLOSSARY: GlossaryEntry[] = [
       },
       {
         type: "h2",
-        text: "How Finlynq applies it — and the honest limits",
+        text: "How Finlynq applies it, and the honest limits",
       },
       {
         type: "p",
@@ -157,7 +157,7 @@ export const GLOSSARY: GlossaryEntry[] = [
       },
       {
         type: "p",
-        text: "The practical consequence of a key derived only from your password is that there is no operator-side recovery. If you forget your password and have no backup, the encrypted fields cannot be restored — by you or anyone else.",
+        text: "The practical consequence of a key derived only from your password is that there's no operator-side recovery. If you forget your password and have no backup, the encrypted fields can't be restored, by you or anyone else.",
       },
     ],
     related: [
@@ -172,11 +172,11 @@ export const GLOSSARY: GlossaryEntry[] = [
     term: "What is lot-tracked cost basis?",
     shortTerm: "Lot-tracked cost basis",
     description:
-      "Lot-tracked cost basis means recording every purchase of a security as a separate \"lot\" — with its own quantity, price, and date — so that when you sell, the realized gain is computed against the specific shares sold rather than a single blended average. It produces accurate, tax-relevant gain figures, especially across multiple buys at different prices.",
+      "Lot-tracked cost basis means recording every purchase of a security as a separate \"lot,\" each with its own quantity, price, and date, so that when you sell, the realized gain is computed against the specific shares sold rather than a single blended average. It produces accurate, tax-relevant gain figures, especially across multiple buys at different prices.",
     blocks: [
       {
         type: "p",
-        text: "If you buy the same stock three times at different prices, your account holds three lots. When you sell, the cost basis depends on which lots the sale draws from — FIFO (first-in, first-out), or a specific-lot selection. Average-cost methods blur this; lot tracking preserves it, which matters for tax reporting and for understanding true performance.",
+        text: "If you buy the same stock three times at different prices, your account holds three lots. When you sell, the cost basis depends on which lots the sale draws from: FIFO (first-in, first-out), or a specific-lot selection. Average-cost methods blur this; lot tracking preserves it, which matters for tax reporting and for understanding true performance.",
       },
       {
         type: "h2",
@@ -184,7 +184,7 @@ export const GLOSSARY: GlossaryEntry[] = [
       },
       {
         type: "p",
-        text: "Finlynq records per-purchase lots and computes realized gains by closing specific lots on a sale. It is multi-currency aware — realized gains can be expressed in your base currency using historical exchange rates at the open and close of each lot — and it supports short positions and dividend reinvestment. Cash sleeves are tracked as explicit holdings so currency-on-currency FX gains surface correctly.",
+        text: "Finlynq records per-purchase lots and computes realized gains by closing specific lots on a sale. It's multi-currency aware, so realized gains can be expressed in your base currency using historical exchange rates at the open and close of each lot, and it supports short positions and dividend reinvestment. Cash sleeves are tracked as explicit holdings so currency-on-currency FX gains surface correctly.",
       },
       {
         type: "p",

--- a/src/lib/seo/site.ts
+++ b/src/lib/seo/site.ts
@@ -12,7 +12,7 @@ export const SITE_URL =
 
 /**
  * Comparison pages under `/vs/<slug>`. Add a slug here when you ship a new
- * comparison page — it flows into the sitemap, the `/vs` index, and llms.txt.
+ * comparison page. It flows into the sitemap, the `/vs` index, and llms.txt.
  */
 export const VS_SLUGS = [
   "monarch",
@@ -41,22 +41,22 @@ export const VS_META: Record<VsSlug, { name: string; blurb: string }> = {
   era: {
     name: "Era",
     blurb:
-      "Two MCP-first personal finance apps — open-source + self-hostable vs closed hosted SaaS.",
+      "Two MCP-first personal finance apps: open-source and self-hostable vs closed hosted SaaS.",
   },
   "firefly-iii": {
     name: "Firefly III",
     blurb:
-      "Two open-source self-hostable PFMs — first-party MCP + name encryption vs mature double-entry.",
+      "Two open-source self-hostable PFMs: first-party MCP and name encryption vs mature double-entry.",
   },
   actual: {
     name: "Actual Budget",
     blurb:
-      "Two open-source PFMs — Actual's local-first budgeting vs Finlynq's investments + multi-currency + MCP.",
+      "Two open-source PFMs: Actual's local-first budgeting vs Finlynq's investments, multi-currency, and MCP.",
   },
   ghostfolio: {
     name: "Ghostfolio",
     blurb:
-      "Full personal-finance app with a first-party MCP vs a dedicated open-source portfolio tracker.",
+      "A full personal-finance app with a first-party MCP vs a dedicated open-source portfolio tracker.",
   },
   maybe: {
     name: "Maybe / Sure",
@@ -83,7 +83,7 @@ export type StaticRoute = {
 
 /**
  * Public top-level routes that live OUTSIDE the `(app)` auth group. Anything
- * requiring a Finlynq login is intentionally excluded — every URL here is
+ * requiring a Finlynq login is intentionally excluded. Every URL here is
  * reachable by an unauthenticated user or a search / LLM crawler.
  */
 export const STATIC_ROUTES: StaticRoute[] = [


### PR DESCRIPTION
Promotes the two marketing-site commits from `dev` to production.

## What's included
1. **Reflect live iOS and Android apps across the marketing site** — the apps are now live on the App Store and Google Play. Updates the "coming soon" / "in testing" copy site-wide, adds clickable App Store + Google Play badge links (shared `StoreBadges` component), and corrects the `/vs/*` comparison rows that claimed Finlynq had no native app.
2. **Drop em dashes and humanize the public marketing copy** — removes every em/en dash across all public pages (landing, /about, /vs/*, /blog, /roadmap, /self-hosted, /cloud, /glossary, /mcp-guide, /privacy, /terms, /account-deletion) plus SEO metadata + glossary data, and rewrites the prose in a plainer, more human voice. All product facts, comparison claims, and tool counts preserved.

## Verification
- ESLint: 0 errors
- `tsc --noEmit`: clean
- All public pages render 200 with zero em/en dashes
- Dev deploy (dev.finlynq.com) is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)