### PR TITLE
Merge dev → main: /admin/inbox reply-in-app + FINLYNQ-281 + import/reports improvements

### DIFF
--- a/mcp-server/investment-balance-overlay.ts
+++ b/mcp-server/investment-balance-overlay.ts
@@ -56,14 +56,30 @@ export type OverlayResult = {
    * investment row). When false, every row carries `balanceBasis:"ledger"`. */
   marketApplied: boolean;
   /** Set only when investment rows exist but the overlay could not run
-   * (dek == null) — surfaced as a top-level `note` by the caller. */
+   * (dek == null, or FINLYNQ-281 decrypt failure) — surfaced as a top-level
+   * `note` by the caller. */
   note?: string;
+  /** FINLYNQ-281 — set when the DEK is present but ≥1 holding ciphertext failed
+   * to decrypt, so the overlay deliberately fell back to ledger rather than
+   * returning a garbage `basis:"market"` total. */
+  decryptionFailed?: boolean;
 };
 
 const DEK_NULL_NOTE =
   "Investment accounts are valued at ledger (net contributions), not market value, " +
   "because this connection has no decryption key (pf_ API key). Connect via OAuth " +
   "(or use the built-in AI chat) for market-valued investment balances.";
+
+// FINLYNQ-281 — the DEK is present but at least one holding's ciphertext failed
+// to authenticate (stale MCP session key after the demo DEK rotation, or a
+// corrupt row). Pricing an undecryptable symbol yields qty×1 garbage, so we
+// withhold market value entirely and fall back to ledger + this note instead of
+// reporting silently-wrong money.
+const DECRYPT_FAILED_NOTE =
+  "Investment holdings could not be decrypted, so accounts are shown at ledger " +
+  "(net contributions), NOT market value. This usually means this connection's " +
+  "decryption key is stale — reconnect the MCP connection — or a holding row is " +
+  "corrupt. Market totals were withheld to avoid reporting wrong numbers.";
 
 /**
  * Apply the market-value overlay to a set of per-account ledger rows.
@@ -81,6 +97,7 @@ export async function applyInvestmentMarketOverlay(
   rows: OverlayInputRow[],
   dek: Buffer | null,
   fetchHoldings: () => Promise<Map<number, { value: number; costBasis: number }>>,
+  verifyDecrypt?: () => Promise<{ failed: number; total: number }>,
 ): Promise<OverlayResult> {
   const hasInvestment = rows.some((r) => r.isInvestment);
 
@@ -94,6 +111,28 @@ export async function applyInvestmentMarketOverlay(
       marketApplied: false,
       note: dek == null && hasInvestment ? DEK_NULL_NOTE : undefined,
     };
+  }
+
+  // FINLYNQ-281 — the DEK is present, but verify it actually decrypts the
+  // user's holdings BEFORE pricing. A stale/wrong DEK decrypts symbols to null,
+  // and `fetchHoldings` (getHoldingsValueByAccount) then prices them at qty×1
+  // (garbage) — which the caller would return as a wrong `basis:"market"`
+  // total. On any decrypt failure, fall back to ledger + an explicit note and
+  // NEVER call `fetchHoldings` (skip the qty×1 path entirely).
+  if (verifyDecrypt) {
+    const health = await verifyDecrypt();
+    if (health.failed > 0) {
+      return {
+        rows: rows.map((r) => ({
+          ...r,
+          balance: r.ledgerBalance,
+          balanceBasis: "ledger" as const,
+        })),
+        marketApplied: false,
+        note: DECRYPT_FAILED_NOTE,
+        decryptionFailed: true,
+      };
+    }
   }
 
   const map = await fetchHoldings();

--- a/mcp-server/tools/reads.ts
+++ b/mcp-server/tools/reads.ts
@@ -51,6 +51,7 @@ import {
 } from "../../src/lib/financial-health";
 import {
   getHoldingsValueByAccount,
+  verifyHoldingDecryptHealth,
 } from "../../src/lib/holdings-value";
 import {
   applyInvestmentMarketOverlay,
@@ -130,6 +131,10 @@ export function registerReadsTools(server: McpServer, ctx: PgToolContext) {
             overlayRows,
             dek,
             () => getHoldingsValueByAccount(userId, dek),
+            // FINLYNQ-281 — withhold market value (fall back to ledger + note)
+            // when a present-but-stale/corrupt DEK fails to decrypt holdings,
+            // instead of returning garbage market numbers.
+            () => verifyHoldingDecryptHealth(userId, dek),
           );
 
       const reporting = await resolveReportingCurrency(db, userId, reportingCurrency);
@@ -612,6 +617,11 @@ export function registerReadsTools(server: McpServer, ctx: PgToolContext) {
               nwOverlayRows,
               dek,
               () => getHoldingsValueByAccount(userId, dek),
+              // FINLYNQ-281 — same decrypt-health gate as get_account_balances
+              // so a stale/corrupt DEK yields ledger + note, not a silently
+              // wrong `basis:"market"` net-worth total (the #210 parity holds:
+              // both tools fall back together).
+              () => verifyHoldingDecryptHealth(userId, dek),
             );
 
         // Roll up per-currency assets/liabilities/net from the OVERLAID

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -14,7 +14,7 @@ import pg from "pg";
 import { createHash } from "crypto";
 import bcrypt from "bcryptjs";
 import {
-  createWrappedDEKForPassword,
+  rewrapDEKForNewPassword,
   encryptField,
 } from "../src/lib/crypto/envelope";
 import { encryptName } from "../src/lib/crypto/encrypted-columns";
@@ -49,6 +49,21 @@ const DEMO_USERNAME = "demo";
 const DEMO_PASSWORD = "finlynq-demo";
 const DEMO_USER_ID = "00000000-0000-0000-0000-00000000demo";
 const DEMO_DISPLAY_NAME = "Finlynq Demo";
+
+// FINLYNQ-281 — pin the demo account's DEK to a FIXED, deterministic value.
+//
+// Historically each nightly reseed generated a RANDOM DEK, re-encrypting every
+// demo row under a fresh key. Any long-lived session that had cached the
+// previous DEK — notably the public claude.ai MCP connector — then failed to
+// decrypt the newly-seeded rows with "unable to authenticate data" until it
+// reconnected (this masqueraded as a SEV-1 crypto outage; see FINLYNQ-281). A
+// stable DEK means the cached key keeps working across reseeds. Safe ONLY
+// because the demo data is public and non-sensitive — NEVER pin a real user's
+// DEK. The wrap (salt/iv/tag) is still regenerated each run; it merely unwraps
+// to this same DEK.
+const DEMO_DEK = createHash("sha256")
+  .update("finlynq-demo-account-fixed-dek-v1")
+  .digest();
 
 const databaseUrl: string = (() => {
   const url = process.env.DATABASE_URL ?? process.env.PF_DATABASE_URL;
@@ -346,12 +361,14 @@ async function main() {
 
     // 1. Upsert demo user (with envelope-encryption DEK).
     //
-    // Every reseed rotates the wrapped DEK — crucially, also rotating the DEK
-    // itself — because we're inserting freshly-encrypted ciphertext using
-    // whichever DEK we generate here. That means old rows wouldn't decrypt,
-    // but the wipe step below drops them first so there's no mismatch.
+    // FINLYNQ-281 — the demo DEK is now a FIXED constant (DEMO_DEK), NOT a fresh
+    // random key per reseed. Every reseed re-wraps the SAME DEK under a new
+    // salt/iv (so `dek_wrapped` still changes) but unwraps back to DEMO_DEK, so
+    // a session that cached the DEK before a reseed keeps decrypting the
+    // freshly-seeded rows. The wipe step below still drops the old rows first.
     const passwordHash = await bcrypt.hash(DEMO_PASSWORD, 12);
-    const { dek: demoDek, wrapped: demoWrap } = createWrappedDEKForPassword(DEMO_PASSWORD);
+    const demoDek = DEMO_DEK;
+    const demoWrap = rewrapDEKForNewPassword(demoDek, DEMO_PASSWORD);
     // ON CONFLICT now targets the primary key (id). The old `(email)` target
     // assumed a hard UNIQUE on the email column, but that constraint was
     // replaced by a partial unique index on lower(email) when usernames

--- a/src/app/(app)/admin/inbox/page.tsx
+++ b/src/app/(app)/admin/inbox/page.tsx
@@ -26,7 +26,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Inbox, Trash2, RefreshCw, ArrowUpFromLine, CheckCircle2 } from "lucide-react";
+import { Inbox, Trash2, RefreshCw, ArrowUpFromLine, CheckCircle2, Send } from "lucide-react";
 
 interface InboxRow {
   id: string;
@@ -59,6 +59,10 @@ export default function AdminInboxPage() {
   const [openId, setOpenId] = useState<string | null>(null);
   const [detail, setDetail] = useState<InboxDetail | null>(null);
   const [acting, setActing] = useState(false);
+  const [replyText, setReplyText] = useState("");
+  const [sending, setSending] = useState(false);
+  const [replyError, setReplyError] = useState<string | null>(null);
+  const [replySent, setReplySent] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -80,6 +84,9 @@ export default function AdminInboxPage() {
   const openDetail = useCallback(async (id: string) => {
     setOpenId(id);
     setDetail(null);
+    setReplyText("");
+    setReplyError(null);
+    setReplySent(false);
     try {
       const res = await fetch(`/api/admin/inbox/${id}`);
       const data = await res.json();
@@ -91,7 +98,37 @@ export default function AdminInboxPage() {
     }
   }, []);
 
-  const closeDetail = () => { setOpenId(null); setDetail(null); };
+  const closeDetail = () => {
+    setOpenId(null);
+    setDetail(null);
+    setReplyText("");
+    setReplyError(null);
+    setReplySent(false);
+  };
+
+  const sendReply = useCallback(async (id: string) => {
+    const body = replyText.trim();
+    if (!body) return;
+    setSending(true);
+    setReplyError(null);
+    try {
+      const res = await fetch(`/api/admin/inbox/${id}/reply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Failed to send reply");
+      setReplySent(true);
+      setReplyText("");
+      // Reflect the now-triaged state in the list without closing the panel.
+      load();
+    } catch (e) {
+      setReplyError(e instanceof Error ? e.message : "Failed to send reply");
+    } finally {
+      setSending(false);
+    }
+  }, [replyText, load]);
 
   const markTriaged = useCallback(async (id: string) => {
     setActing(true);
@@ -253,6 +290,43 @@ export default function AdminInboxPage() {
                     <p className="p-6 text-sm text-muted-foreground text-center">(no body content)</p>
                   )}
                 </div>
+
+                {detail.category === "mailbox" && (
+                  <div className="space-y-2 pt-1">
+                    <label className="text-xs font-medium text-muted-foreground">
+                      Reply to <span className="font-mono">{detail.fromAddress}</span>
+                      <span className="text-muted-foreground/70"> · sends from {detail.toAddress}</span>
+                    </label>
+                    <textarea
+                      value={replyText}
+                      onChange={(e) => {
+                        setReplyText(e.target.value);
+                        if (replySent) setReplySent(false);
+                      }}
+                      rows={5}
+                      maxLength={50000}
+                      placeholder={`Write your reply…`}
+                      disabled={sending}
+                      className="w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-60"
+                    />
+                    {replyError && <p className="text-xs text-rose-700">{replyError}</p>}
+                    {replySent && (
+                      <p className="text-xs text-emerald-700 flex items-center gap-1">
+                        <CheckCircle2 className="h-3.5 w-3.5" /> Reply sent.
+                      </p>
+                    )}
+                    <div className="flex items-center gap-2">
+                      <Button
+                        size="sm"
+                        onClick={() => sendReply(detail.id)}
+                        disabled={sending || !replyText.trim()}
+                      >
+                        <Send className={`h-4 w-4 mr-1.5 ${sending ? "animate-pulse" : ""}`} />
+                        {sending ? "Sending…" : "Send reply"}
+                      </Button>
+                    </div>
+                  </div>
+                )}
 
                 <div className="flex items-center gap-2 pt-1">
                   {!detail.triagedAt && (

--- a/src/app/(app)/import/pending/_components/bank-pane.tsx
+++ b/src/app/(app)/import/pending/_components/bank-pane.tsx
@@ -12,12 +12,14 @@
 import { Button } from "@/components/ui/button";
 import { Check, Flag, X as XIcon, Trash2 } from "lucide-react";
 import { DbPane, type DbTransactionRow } from "@/components/import/reconcile/db-pane";
+import { type PaneMatchStatus } from "@/components/import/reconcile/match-status";
 
 export function BankPane({
   dbRows,
   dbRowsLoading,
   onDbRowClick,
   highlightedBankIds,
+  matchStatus,
   linkMode,
   busyKey,
   deleteBankRow,
@@ -29,6 +31,7 @@ export function BankPane({
   dbRowsLoading: boolean;
   onDbRowClick: (bankId: string) => void;
   highlightedBankIds: ReadonlySet<string>;
+  matchStatus?: ReadonlyMap<string, PaneMatchStatus>;
   linkMode: { stagedRowId: string } | null;
   busyKey: string | null;
   deleteBankRow: (bankId: string, deleteLinkedTransactions: boolean | null) => void;
@@ -42,6 +45,7 @@ export function BankPane({
       loading={dbRowsLoading}
       onRowClick={onDbRowClick}
       highlightedBankIds={highlightedBankIds}
+      matchStatus={matchStatus}
       rowActions={(r) => {
         // In link-mode: show a Pick button on rows that aren't
         // already linked to a DIFFERENT staged row. The staged

--- a/src/app/(app)/import/pending/_components/staged-pane.tsx
+++ b/src/app/(app)/import/pending/_components/staged-pane.tsx
@@ -22,6 +22,7 @@ import {
   SuggestionsGroup,
   type SuggestionDisplay,
 } from "@/components/import/reconcile/suggestions-group";
+import { type PaneMatchStatus } from "@/components/import/reconcile/match-status";
 
 export function StagedPane({
   stagedImportId,
@@ -35,6 +36,7 @@ export function StagedPane({
   onRowUpdated,
   onStagedRowClick,
   highlightedStagedIds,
+  matchStatus,
   anchorsByDate,
   displaySuggestions,
   acceptSuggestion,
@@ -57,6 +59,7 @@ export function StagedPane({
   onRowUpdated: (updated: StagedEditableRow) => void;
   onStagedRowClick: (stagedId: string) => void;
   highlightedStagedIds: ReadonlySet<string>;
+  matchStatus?: ReadonlyMap<string, PaneMatchStatus>;
   anchorsByDate: Map<string, number>;
   displaySuggestions: SuggestionDisplay[];
   acceptSuggestion: (s: SuggestionDisplay) => void;
@@ -81,6 +84,7 @@ export function StagedPane({
       onRowUpdated={onRowUpdated}
       onRowClick={onStagedRowClick}
       highlightedStagedIds={highlightedStagedIds}
+      matchStatus={matchStatus}
       anchorsByDate={anchorsByDate}
       header={
         displaySuggestions.length > 0 && (

--- a/src/app/(app)/reports/page.tsx
+++ b/src/app/(app)/reports/page.tsx
@@ -1281,6 +1281,40 @@ function PeriodCell({ value, currency, colorClass }: { value: number | undefined
   );
 }
 
+/** Bottom totals row: per-period column sums + grand total, aligned to the table columns. */
+function TotalsRow({
+  label,
+  items,
+  visibleTs,
+  total,
+  currency,
+  colorClass,
+  leadingCol,
+}: {
+  label: string;
+  items: BreakdownItem[];
+  visibleTs: TimeseriesPoint[];
+  total: number;
+  currency: string;
+  colorClass: string;
+  leadingCol: boolean;
+}) {
+  return (
+    <TableRow className="border-t-2 bg-muted/40 font-semibold hover:bg-muted/40">
+      {leadingCol && <TableCell className="w-8 pr-0"></TableCell>}
+      <TableCell className="text-sm font-semibold">{label}</TableCell>
+      {visibleTs.map((pt) => {
+        const periodSum = items.reduce((s, item) => s + (item.periods[pt.period] ?? 0), 0);
+        return <PeriodCell key={pt.period} value={periodSum} currency={currency} colorClass={`${colorClass} font-semibold`} />;
+      })}
+      <TableCell className={`text-right font-mono text-sm font-bold ${colorClass}`}>
+        {formatCurrency(total, currency)}
+      </TableCell>
+      <TableCell className="text-right text-xs text-muted-foreground">100%</TableCell>
+    </TableRow>
+  );
+}
+
 /** Truncation notice rendered above the table when the series was capped. */
 function TruncationNotice({ visible, shown, total }: { visible: boolean; shown: number; total: number }) {
   if (!visible) return null;
@@ -1354,6 +1388,15 @@ function GroupedTable({
                 />
               );
             })}
+            <TotalsRow
+              label="Total"
+              items={groups.flatMap((g) => g.items)}
+              visibleTs={visibleTs}
+              total={total}
+              currency={currency}
+              colorClass={colorClass}
+              leadingCol
+            />
           </TableBody>
         </Table>
       </div>
@@ -1509,6 +1552,15 @@ function FlatTable({
                 </TableRow>
               );
             })}
+            <TotalsRow
+              label="Total"
+              items={items}
+              visibleTs={visibleTs}
+              total={total}
+              currency={currency}
+              colorClass={colorClass}
+              leadingCol={false}
+            />
           </TableBody>
         </Table>
       </div>

--- a/src/app/api/admin/inbox/[id]/reply/route.ts
+++ b/src/app/api/admin/inbox/[id]/reply/route.ts
@@ -1,0 +1,119 @@
+/**
+ * POST /api/admin/inbox/[id]/reply — reply to a contact-inbox email.
+ *
+ * Admin-only. Sends the maintainer's reply to the ORIGINAL sender
+ * (row.from_address) via the app's existing email transport (Resend), so the
+ * admin never has to open the Resend dashboard to respond.
+ *
+ * From-address: the reply is sent FROM the mailbox address the mail arrived on
+ * (row.to_address, e.g. info@finlynq.com) — but ONLY when that address is on the
+ * Resend-verified sending domain (derived from EMAIL_FROM); otherwise Resend
+ * would 403 the send, so we fall back to the default EMAIL_FROM sender.
+ * Reply-To is set to the same mailbox address so the recipient's reply threads
+ * back into this inbox (once inbound receiving is wired to the app webhook).
+ *
+ * On a successful send the row is marked triaged (mirrors the PATCH triage
+ * action). A send failure returns 502 and leaves the row untouched so the admin
+ * can retry.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { db, schema } from "@/db";
+import { eq } from "drizzle-orm";
+import { requireAdmin } from "@/lib/auth/require-admin";
+import { sendEmail, contactReplyEmail } from "@/lib/email";
+import { safeErrorMessage } from "@/lib/validate";
+
+export const dynamic = "force-dynamic";
+
+/** Loose RFC-ish address check — just enough to avoid handing garbage to Resend. */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** The verified sending domain, derived from EMAIL_FROM (default finlynq.com). */
+function verifiedSendingDomain(): string {
+  const from = process.env.EMAIL_FROM || "Finlynq <noreply@finlynq.com>";
+  const m = /<([^>]+)>/.exec(from);
+  const addr = (m ? m[1] : from).trim();
+  const domain = addr.split("@")[1];
+  return (domain || "finlynq.com").toLowerCase();
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAdmin(request);
+  if (!auth.authenticated) return auth.response;
+  const { id } = await params;
+  const { userId } = auth.context;
+
+  const parsed = (await request.json().catch(() => ({}))) as { body?: unknown };
+  const replyBody = typeof parsed.body === "string" ? parsed.body.trim() : "";
+  if (!replyBody) {
+    return NextResponse.json({ error: "Reply body is required" }, { status: 400 });
+  }
+  if (replyBody.length > 50_000) {
+    return NextResponse.json({ error: "Reply is too long" }, { status: 400 });
+  }
+
+  const row = await db
+    .select()
+    .from(schema.incomingEmails)
+    .where(eq(schema.incomingEmails.id, id))
+    .get();
+
+  if (!row) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const recipient = (row.fromAddress || "").trim();
+  if (!EMAIL_RE.test(recipient)) {
+    return NextResponse.json(
+      { error: "This email has no valid reply address" },
+      { status: 422 },
+    );
+  }
+
+  // Send FROM the mailbox address only if it's on the verified domain.
+  const mailbox = (row.toAddress || "").trim().toLowerCase();
+  const onVerifiedDomain =
+    EMAIL_RE.test(mailbox) && mailbox.endsWith(`@${verifiedSendingDomain()}`);
+  const from = onVerifiedDomain
+    ? `Finlynq <${mailbox}>`
+    : process.env.EMAIL_FROM || "Finlynq <noreply@finlynq.com>";
+  const replyTo = onVerifiedDomain ? mailbox : undefined;
+
+  const baseSubject = row.subject?.trim() || "(no subject)";
+  const subject = /^re:/i.test(baseSubject) ? baseSubject : `Re: ${baseSubject}`;
+
+  try {
+    await sendEmail(
+      contactReplyEmail({
+        to: recipient,
+        from,
+        replyTo,
+        subject,
+        replyBody,
+        original: {
+          fromAddress: recipient,
+          receivedAt: row.receivedAt ? String(row.receivedAt) : null,
+          bodyText: row.bodyText,
+        },
+      }),
+    );
+  } catch (e) {
+    console.error("[admin-inbox-reply] send failed", e);
+    return NextResponse.json(
+      { error: safeErrorMessage(e, "Failed to send reply") },
+      { status: 502 },
+    );
+  }
+
+  // Mark triaged on a successful send (admin has handled it).
+  await db
+    .update(schema.incomingEmails)
+    .set({ triagedAt: new Date(), triagedBy: userId })
+    .where(eq(schema.incomingEmails.id, id));
+
+  return NextResponse.json({ ok: true, sentTo: recipient, from });
+}

--- a/src/app/api/import/email-webhook/route.ts
+++ b/src/app/api/import/email-webhook/route.ts
@@ -43,6 +43,7 @@ import { deserializeTemplate, findBestTemplate, autoDetectColumnMapping } from "
 import { unwrapDEKForSecret, authLookupHash } from "@/lib/api-auth";
 import { invalidateUser as invalidateUserTxCache } from "@/lib/mcp/user-tx-cache";
 import { getInboundProvider } from "@/lib/email-import/providers";
+import { resendProvider } from "@/lib/email-import/providers/resend";
 import { ingestInboundEmail } from "@/lib/email-import/ingest";
 
 // Request-body cap on the JSON path. The DevManager push relay inlines
@@ -71,7 +72,18 @@ async function handleProviderInbound(request: NextRequest): Promise<NextResponse
     return NextResponse.json({ error: "Payload too large" }, { status: 413 });
   }
 
-  const provider = getInboundProvider();
+  // Content-negotiate the provider by transport signature rather than binding
+  // the single configured provider. The self-smtp DevManager relay carries an
+  // `x-webhook-secret`/HMAC and NO svix headers; Resend Inbound is svix-signed.
+  // So a svix-signed request is verified by the Resend provider even when the
+  // deployment's default provider is self-smtp — this is what lets info@ mail
+  // routed through Resend Inbound reach /admin/inbox without flipping the global
+  // INBOUND_EMAIL_PROVIDER (which would break the mail.finlynq.com import path).
+  // A request with no svix headers keeps the exact pre-existing behavior.
+  const hasSvix = !!(
+    request.headers.get("svix-signature") || request.headers.get("svix-id")
+  );
+  const provider = hasSvix ? resendProvider : getInboundProvider();
 
   // Read the raw body once — svix (Resend) needs the exact bytes for the HMAC.
   const rawBody = await request.text();

--- a/src/app/api/import/staging/upload/route.ts
+++ b/src/app/api/import/staging/upload/route.ts
@@ -395,6 +395,10 @@ export async function POST(request: NextRequest) {
       knobs: { skipHeaderRows, skipFooterRows, dateFormatOverride, defaultCurrency },
       boundAccountCurrency,
       userStatementBalance,
+      // fuzzyDedupWindowDays defaults to 3 inside writeStagedImport (the shared
+      // chokepoint) so every ingest path — manual/approve/auto uploads, the
+      // SimpleFIN feed, and the MCP upload_statement tool — gets the same
+      // payee-agnostic duplicate net without any caller having to opt in.
     });
 
     // approve/auto need a bound account; boundAccountMode is null when

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -12,6 +12,9 @@ import {
   computeAllAccountsUnrealizedPnL,
   summarizeUnrealizedPnL,
 } from "@/lib/unrealized-pnl";
+import { getAccountBalances } from "@/lib/queries";
+import { getHoldingsValueByAccount } from "@/lib/holdings-value";
+import { applyInvestmentMarketOverlay } from "../../../../mcp-server/investment-balance-overlay";
 
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request); if (!auth.authenticated) return auth.response;
@@ -169,29 +172,40 @@ export async function GET(request: NextRequest) {
 
   if (type === "balance-sheet") {
     // Stream D Phase 4 â€” plaintext name dropped.
-    const balances = await db
-      .select({
-        accountId: schema.accounts.id,
-        accountType: schema.accounts.type,
-        accountGroup: schema.accounts.group,
-        accountNameCt: schema.accounts.nameCt,
-        currency: schema.accounts.currency,
-        balance: sql<number>`COALESCE(SUM(${schema.transactions.amount}), 0)`,
-      })
-      .from(schema.accounts)
-      .leftJoin(schema.transactions, eq(schema.accounts.id, schema.transactions.accountId))
-      .where(eq(schema.accounts.userId, userId))
-      .groupBy(schema.accounts.id, schema.accounts.type, schema.accounts.group, schema.accounts.nameCt, schema.accounts.currency)
-      .orderBy(schema.accounts.type, schema.accounts.group)
-      .all();
+    //
+    // Account balances follow the load-bearing invariant "account with holdings
+    // = holdings.value": investment accounts are marked to MARKET via the SAME
+    // overlay the MCP balance tools + the reconcile summary use
+    // (applyInvestmentMarketOverlay, FINLYNQ-151/196), NEVER a naive
+    // SUM(transactions.amount) (which for an investment account is net
+    // contributions, not market value). This is a web-session route
+    // (requireAuth, DEK present) so the overlay can price holdings; a DEK-null
+    // caller degrades to the ledger balance per the overlay's own guard. Cash
+    // accounts keep their ledger balance. includeArchived preserves the prior
+    // account set (the old bespoke query had no archived filter).
+    const ledgerBalances = await getAccountBalances(userId, { includeArchived: true });
+    const overlay = await applyInvestmentMarketOverlay(
+      ledgerBalances.map((b) => ({
+        id: b.accountId,
+        currency: b.currency,
+        isInvestment: b.isInvestment === true,
+        ledgerBalance: Number(b.balance),
+      })),
+      dek,
+      () => getHoldingsValueByAccount(userId, dek),
+    );
+    const balanceByAccount = new Map(overlay.rows.map((r) => [r.id, r.balance]));
 
-    const converted = balances.map((b) => {
-      const { accountNameCt: _ct, ...rest } = b;
-      void _ct;
+    const converted = ledgerBalances.map((b) => {
+      const balance = balanceByAccount.get(b.accountId) ?? Number(b.balance);
       return {
-        ...rest,
+        accountId: b.accountId,
+        accountType: b.accountType,
+        accountGroup: b.accountGroup,
+        currency: b.currency,
+        balance,
         accountName: decryptName(b.accountNameCt, dek, null) ?? "",
-        convertedBalance: convertWithRateMap(b.balance, b.currency, rateMap),
+        convertedBalance: convertWithRateMap(balance, b.currency, rateMap),
         displayCurrency,
       };
     });

--- a/src/components/import/reconcile/db-pane.tsx
+++ b/src/components/import/reconcile/db-pane.tsx
@@ -32,6 +32,11 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { formatCurrency } from "@/lib/currency";
+import {
+  matchBorderClass,
+  MatchStatusBadge,
+  type PaneMatchStatus,
+} from "./match-status";
 
 export interface DbTransactionRow {
   /**
@@ -86,6 +91,7 @@ export function DbPane({
   header,
   onRowClick,
   highlightedBankIds,
+  matchStatus,
 }: {
   rows: DbTransactionRow[];
   loading: boolean;
@@ -96,6 +102,10 @@ export function DbPane({
   onRowClick?: (bankId: string) => void;
   /** Bank ids currently highlighted by a click-through. */
   highlightedBankIds?: ReadonlySet<string>;
+  /** Persistent cross-pane match status per bank id (computePanePairing).
+   *  'matched' = a file row covers it; 'only_ledger' = in-period, not in the
+   *  file. Absent (out-of-window / no batch) → no tint. */
+  matchStatus?: ReadonlyMap<string, PaneMatchStatus>;
 }) {
   if (loading) {
     return (
@@ -184,11 +194,12 @@ export function DbPane({
               const highlightClass = highlighted
                 ? "bg-sky-500/10 outline outline-2 outline-sky-500/40"
                 : "";
+              const ms = matchStatus?.get(r.id);
               const clickable = onRowClick != null;
               return (
                 <TableRow
                   key={r.id}
-                  className={`${dimmed} ${highlightClass} ${clickable ? "cursor-pointer" : ""}`}
+                  className={`${dimmed} ${matchBorderClass(ms)} ${highlightClass} ${clickable ? "cursor-pointer" : ""}`}
                   onClick={
                     clickable
                       ? (e) => {
@@ -214,6 +225,7 @@ export function DbPane({
                   </TableCell>
                   <TableCell className="text-xs">
                     <div className="flex items-center gap-1 flex-wrap">
+                      <MatchStatusBadge status={ms} />
                       {r.txType === "R" ? (
                         <Badge variant="outline" className="text-[10px]">
                           Transfer

--- a/src/components/import/reconcile/db-pane.tsx
+++ b/src/components/import/reconcile/db-pane.tsx
@@ -32,11 +32,7 @@ import {
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { formatCurrency } from "@/lib/currency";
-import {
-  matchBorderClass,
-  MatchStatusBadge,
-  type PaneMatchStatus,
-} from "./match-status";
+import { matchRowClass, type PaneMatchStatus } from "./match-status";
 
 export interface DbTransactionRow {
   /**
@@ -191,15 +187,17 @@ export function DbPane({
                 r.anchorBalance == null && !dayFirstSeenForLoaded.has(r.date);
               if (isFirstOfDayLoadedEmpty) dayFirstSeenForLoaded.add(r.date);
               const highlighted = highlightedBankIds?.has(r.id) ?? false;
+              // Ring (not a bg) so the click highlight layers cleanly over the
+              // persistent full-row match tint.
               const highlightClass = highlighted
-                ? "bg-sky-500/10 outline outline-2 outline-sky-500/40"
+                ? "ring-2 ring-inset ring-sky-500/60"
                 : "";
               const ms = matchStatus?.get(r.id);
               const clickable = onRowClick != null;
               return (
                 <TableRow
                   key={r.id}
-                  className={`${dimmed} ${matchBorderClass(ms)} ${highlightClass} ${clickable ? "cursor-pointer" : ""}`}
+                  className={`h-11 ${dimmed} ${matchRowClass(ms)} ${highlightClass} ${clickable ? "cursor-pointer" : ""}`}
                   onClick={
                     clickable
                       ? (e) => {
@@ -224,8 +222,7 @@ export function DbPane({
                     )}
                   </TableCell>
                   <TableCell className="text-xs">
-                    <div className="flex items-center gap-1 flex-wrap">
-                      <MatchStatusBadge status={ms} />
+                    <div className="flex items-center gap-1 flex-nowrap">
                       {r.txType === "R" ? (
                         <Badge variant="outline" className="text-[10px]">
                           Transfer

--- a/src/components/import/reconcile/file-pane.tsx
+++ b/src/components/import/reconcile/file-pane.tsx
@@ -32,6 +32,11 @@ import {
   type HoldingOption,
 } from "@/components/staging/staged-row-editor";
 import { RowBadge, type ReconcileState } from "./row-badge";
+import {
+  matchBorderClass,
+  MatchStatusBadge,
+  type PaneMatchStatus,
+} from "./match-status";
 
 const RowFragment = Fragment;
 
@@ -63,6 +68,10 @@ export interface FilePaneProps {
   onRowClick?: (stagedId: string) => void;
   /** Staged row ids currently highlighted by a click-through. */
   highlightedStagedIds?: ReadonlySet<string>;
+  /** Persistent cross-pane match status per staged id (computePanePairing).
+   *  'matched' = a bank row covers it; 'only_file' = new (no bank counterpart).
+   *  Absent → no tint. */
+  matchStatus?: ReadonlyMap<string, PaneMatchStatus>;
 }
 
 export function FilePane({
@@ -80,6 +89,7 @@ export function FilePane({
   anchorsByDate,
   onRowClick,
   highlightedStagedIds,
+  matchStatus,
 }: FilePaneProps) {
   if (rows.length === 0) {
     return (
@@ -98,9 +108,21 @@ export function FilePane({
   // the most recent transaction of that day).
   const balanceShownForDate = new Set<string>();
   const hasAnyAnchor = (anchorsByDate?.size ?? 0) > 0;
-  // Rows already pushed to the bank ledger (row_status='approved') stay
-  // visible but aren't re-sendable — exclude them from select-all.
-  const selectableRows = rows.filter((r) => r.rowStatus !== "approved");
+  // Select-all is the "default automatic path" — it should tick only the rows
+  // that still need loading. Exclude:
+  //   • row_status='approved'  — already pushed to the bank ledger
+  //   • reconcileState='linked' — already matched to an existing ledger tx
+  //   • reconcileState='skipped_duplicate' — an exact/fuzzy duplicate we already
+  //     have (the fuzzy net catches email-loaded charges under a drifted payee)
+  // Any of these can still be picked individually via its own row checkbox
+  // (linked → Unlink, skipped → Un-skip/force-load) — they're just kept out of
+  // the bulk select so the user can't re-load a duplicate by accident.
+  const selectableRows = rows.filter(
+    (r) =>
+      r.rowStatus !== "approved" &&
+      r.reconcileState !== "linked" &&
+      r.reconcileState !== "skipped_duplicate",
+  );
   // colSpan for the expanded editor row must cover every header column.
   // Columns: checkbox (1) + chevron (2) + Date (3) + Payee (4) + Type (5)
   //          + Amount (6) [+ Balance (7)] [+ Actions (last)]
@@ -172,11 +194,12 @@ export function FilePane({
               const highlightClass = highlighted
                 ? "bg-sky-500/10 outline outline-2 outline-sky-500/40"
                 : "";
+              const ms = matchStatus?.get(r.id);
               const clickable = onRowClick != null;
               return (
                 <RowFragment key={r.id}>
                   <TableRow
-                    className={`${dimmed} ${importedClass} ${highlightClass} ${clickable ? "cursor-pointer" : ""}`}
+                    className={`${dimmed} ${importedClass} ${matchBorderClass(ms)} ${highlightClass} ${clickable ? "cursor-pointer" : ""}`}
                     onClick={
                       clickable
                         ? (e) => {
@@ -228,6 +251,7 @@ export function FilePane({
                     </TableCell>
                     <TableCell className="text-xs">
                       <div className="flex items-center gap-1 flex-wrap">
+                        <MatchStatusBadge status={ms} />
                         {r.txType === "R" ? (
                           <Badge variant="outline" className="text-[10px]">
                             Transfer

--- a/src/components/import/reconcile/file-pane.tsx
+++ b/src/components/import/reconcile/file-pane.tsx
@@ -32,11 +32,7 @@ import {
   type HoldingOption,
 } from "@/components/staging/staged-row-editor";
 import { RowBadge, type ReconcileState } from "./row-badge";
-import {
-  matchBorderClass,
-  MatchStatusBadge,
-  type PaneMatchStatus,
-} from "./match-status";
+import { matchRowClass, type PaneMatchStatus } from "./match-status";
 
 const RowFragment = Fragment;
 
@@ -191,15 +187,17 @@ export function FilePane({
                 !balanceShownForDate.has(r.date);
               if (showBalance) balanceShownForDate.add(r.date);
               const highlighted = highlightedStagedIds?.has(r.id) ?? false;
+              // Ring (not a bg) so the click highlight layers cleanly over the
+              // persistent full-row match tint.
               const highlightClass = highlighted
-                ? "bg-sky-500/10 outline outline-2 outline-sky-500/40"
+                ? "ring-2 ring-inset ring-sky-500/60"
                 : "";
               const ms = matchStatus?.get(r.id);
               const clickable = onRowClick != null;
               return (
                 <RowFragment key={r.id}>
                   <TableRow
-                    className={`${dimmed} ${importedClass} ${matchBorderClass(ms)} ${highlightClass} ${clickable ? "cursor-pointer" : ""}`}
+                    className={`h-11 ${dimmed} ${importedClass} ${matchRowClass(ms)} ${highlightClass} ${clickable ? "cursor-pointer" : ""}`}
                     onClick={
                       clickable
                         ? (e) => {
@@ -250,8 +248,7 @@ export function FilePane({
                       )}
                     </TableCell>
                     <TableCell className="text-xs">
-                      <div className="flex items-center gap-1 flex-wrap">
-                        <MatchStatusBadge status={ms} />
+                      <div className="flex items-center gap-1 flex-nowrap">
                         {r.txType === "R" ? (
                           <Badge variant="outline" className="text-[10px]">
                             Transfer

--- a/src/components/import/reconcile/match-status.tsx
+++ b/src/components/import/reconcile/match-status.tsx
@@ -1,0 +1,78 @@
+/**
+ * Shared visual language for the persistent cross-pane reconciliation status
+ * (see {@link computePanePairing}). Both the FilePane (staged) and BankPane
+ * (bank ledger) import these so a "matched" / "only here" row reads with the
+ * SAME color on both sides and the eye can pair them across the gap.
+ *
+ *   matched      → emerald  (has a counterpart on the other side)
+ *   only_file    → amber    (staged row with no bank counterpart — new)
+ *   only_ledger  → slate    (bank row in the period with no file counterpart)
+ */
+
+import { Badge } from "@/components/ui/badge";
+
+export type PaneMatchStatus = "matched" | "only_file" | "only_ledger";
+
+/** Left-border tint for a row. Empty string when there's no status (neutral). */
+export function matchBorderClass(status: PaneMatchStatus | undefined): string {
+  switch (status) {
+    case "matched":
+      return "border-l-2 border-l-emerald-500/70";
+    case "only_file":
+      return "border-l-2 border-l-amber-500/70";
+    case "only_ledger":
+      return "border-l-2 border-l-slate-400/60";
+    default:
+      return "";
+  }
+}
+
+const BADGE_CONFIG: Record<PaneMatchStatus, { label: string; cls: string }> = {
+  matched: {
+    label: "Matched",
+    cls: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  },
+  only_file: {
+    label: "Only in file",
+    cls: "bg-amber-50 text-amber-700 border-amber-200",
+  },
+  only_ledger: {
+    label: "Only in ledger",
+    cls: "bg-slate-100 text-slate-600 border-slate-300",
+  },
+};
+
+/** Compact status pill rendered inside a row's Type cell. Null when no status. */
+export function MatchStatusBadge({
+  status,
+}: {
+  status: PaneMatchStatus | undefined;
+}) {
+  if (!status) return null;
+  const cfg = BADGE_CONFIG[status];
+  return (
+    <Badge variant="outline" className={`text-[10px] ${cfg.cls}`}>
+      {cfg.label}
+    </Badge>
+  );
+}
+
+/** Inline legend for the two-pane toolbar so the tint colors are self-explanatory. */
+export function MatchStatusLegend() {
+  return (
+    <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+      <span className="flex items-center gap-1">
+        <span className="inline-block h-2.5 w-2.5 rounded-sm bg-emerald-500/70" />
+        Matched
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block h-2.5 w-2.5 rounded-sm bg-amber-500/70" />
+        Only in file
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="inline-block h-2.5 w-2.5 rounded-sm bg-slate-400/60" />
+        Only in ledger
+      </span>
+    </div>
+  );
+}

--- a/src/components/import/reconcile/match-status.tsx
+++ b/src/components/import/reconcile/match-status.tsx
@@ -2,62 +2,38 @@
  * Shared visual language for the persistent cross-pane reconciliation status
  * (see {@link computePanePairing}). Both the FilePane (staged) and BankPane
  * (bank ledger) import these so a "matched" / "only here" row reads with the
- * SAME color on both sides and the eye can pair them across the gap.
+ * SAME full-row color on both sides and the eye can pair them across the gap.
  *
  *   matched      → emerald  (has a counterpart on the other side)
  *   only_file    → amber    (staged row with no bank counterpart — new)
  *   only_ledger  → slate    (bank row in the period with no file counterpart)
+ *
+ * The status is conveyed by a full-row background tint + the toolbar legend
+ * (no per-row text pill), which keeps rows to a single uniform line so both
+ * panes' rows align and more fit on screen.
  */
-
-import { Badge } from "@/components/ui/badge";
 
 export type PaneMatchStatus = "matched" | "only_file" | "only_ledger";
 
-/** Left-border tint for a row. Empty string when there's no status (neutral). */
-export function matchBorderClass(status: PaneMatchStatus | undefined): string {
+/**
+ * Full-row background tint for a row. Empty string when there's no status
+ * (neutral). Semi-transparent so it works in both light and dark themes and
+ * layers over the row's own hover/dim styling.
+ */
+export function matchRowClass(status: PaneMatchStatus | undefined): string {
   switch (status) {
     case "matched":
-      return "border-l-2 border-l-emerald-500/70";
+      return "bg-emerald-500/10";
     case "only_file":
-      return "border-l-2 border-l-amber-500/70";
+      return "bg-amber-500/10";
     case "only_ledger":
-      return "border-l-2 border-l-slate-400/60";
+      return "bg-slate-500/10";
     default:
       return "";
   }
 }
 
-const BADGE_CONFIG: Record<PaneMatchStatus, { label: string; cls: string }> = {
-  matched: {
-    label: "Matched",
-    cls: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  },
-  only_file: {
-    label: "Only in file",
-    cls: "bg-amber-50 text-amber-700 border-amber-200",
-  },
-  only_ledger: {
-    label: "Only in ledger",
-    cls: "bg-slate-100 text-slate-600 border-slate-300",
-  },
-};
-
-/** Compact status pill rendered inside a row's Type cell. Null when no status. */
-export function MatchStatusBadge({
-  status,
-}: {
-  status: PaneMatchStatus | undefined;
-}) {
-  if (!status) return null;
-  const cfg = BADGE_CONFIG[status];
-  return (
-    <Badge variant="outline" className={`text-[10px] ${cfg.cls}`}>
-      {cfg.label}
-    </Badge>
-  );
-}
-
-/** Inline legend for the two-pane toolbar so the tint colors are self-explanatory. */
+/** Inline legend for the two-pane toolbar so the row tints are self-explanatory. */
 export function MatchStatusLegend() {
   return (
     <div className="flex items-center gap-3 text-[11px] text-muted-foreground">

--- a/src/components/import/staged-review-surface.tsx
+++ b/src/components/import/staged-review-surface.tsx
@@ -51,6 +51,8 @@ import {
   sendableDelta,
 } from "@/lib/import/bank-ledger-projection";
 import { type DbTransactionRow } from "@/components/import/reconcile/db-pane";
+import { computePanePairing } from "@/lib/reconcile/pane-pairing";
+import { MatchStatusLegend } from "@/components/import/reconcile/match-status";
 import {
   type SuggestionDisplay,
 } from "@/components/import/reconcile/suggestions-group";
@@ -123,6 +125,9 @@ export function StagedReviewSurface({
   /** Anchor encoded as `staged:<id>` or `bank:<uuid>`. Null = no
    *  active highlight; second click on the same row clears it. */
   const [highlightAnchor, setHighlightAnchor] = useState<string | null>(null);
+  /** "Show only unmatched" — hides matched rows on BOTH panes so the user can
+   *  focus on what's new in the file / missing from it (R3). Component state. */
+  const [showOnlyUnmatched, setShowOnlyUnmatched] = useState(false);
 
   /** Per-row bank-transaction delete (2026-05-27). Mirrors /reconcile's
    *  flow: first fetch sends empty body; server returns 409 +
@@ -303,6 +308,43 @@ export function StagedReviewSurface({
       return !rn || rn === account.name;
     });
   }, [detail, accountId, accounts]);
+
+  // R3 — persistent cross-pane pairing. Derives, for every staged + bank row,
+  // whether it has a counterpart on the other side (matched / only-in-file /
+  // only-in-ledger) so both panes are tinted persistently (not just on click)
+  // and "Show only unmatched" can hide the matched noise. Computed from the
+  // FULL account-scoped staged set + full bank ledger (NOT the filtered display
+  // rows) so the toggle never changes the pairing itself.
+  const panePairing = useMemo(
+    () => computePanePairing(filteredStagedRows, dbRows),
+    [filteredStagedRows, dbRows],
+  );
+
+  // Rows actually rendered: when "Show only unmatched" is on, drop the matched
+  // rows on each side (staged → keep only-in-file; bank → keep only-in-ledger).
+  const visibleStagedRows = useMemo(() => {
+    if (!showOnlyUnmatched) return filteredStagedRows;
+    return filteredStagedRows.filter(
+      (r) => panePairing.stagedStatus.get(r.id) !== "matched",
+    );
+  }, [showOnlyUnmatched, filteredStagedRows, panePairing]);
+  const visibleBankRows = useMemo(() => {
+    if (!showOnlyUnmatched) return dbRows;
+    return dbRows.filter(
+      (r) => panePairing.bankStatus.get(r.id) === "only_ledger",
+    );
+  }, [showOnlyUnmatched, dbRows, panePairing]);
+  const unmatchedCounts = useMemo(() => {
+    let onlyFile = 0;
+    for (const v of panePairing.stagedStatus.values()) {
+      if (v === "only_file") onlyFile += 1;
+    }
+    let onlyLedger = 0;
+    for (const v of panePairing.bankStatus.values()) {
+      if (v === "only_ledger") onlyLedger += 1;
+    }
+    return { onlyFile, onlyLedger };
+  }, [panePairing]);
 
   // 2026-05-24 — parsed anchors → date map for the FilePane's per-day
   // Balance column. Plus the upload-form statement_balance lifted as a
@@ -1249,14 +1291,34 @@ export function StagedReviewSurface({
             setDetailLoading={setDetailLoading}
           />
         ) : detail ? (
-          <TwoPaneLayout
-            leftLabel="Bank ledger (continuous)"
+          <>
+            {/* R3 — persistent match legend + "show only unmatched" toggle. */}
+            <div className="flex flex-wrap items-center justify-between gap-2 px-1 pb-2">
+              <MatchStatusLegend />
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] text-muted-foreground">
+                  {unmatchedCounts.onlyFile} new · {unmatchedCounts.onlyLedger} only in ledger
+                </span>
+                <Button
+                  size="sm"
+                  variant={showOnlyUnmatched ? "default" : "outline"}
+                  onClick={() => setShowOnlyUnmatched((v) => !v)}
+                  className="h-7"
+                  title="Hide rows that already have a counterpart on the other side"
+                >
+                  {showOnlyUnmatched ? "Showing unmatched only" : "Show only unmatched"}
+                </Button>
+              </div>
+            </div>
+            <TwoPaneLayout
+              leftLabel="Bank ledger (continuous)"
             left={
               <BankPane
-                dbRows={dbRows}
+                dbRows={visibleBankRows}
                 dbRowsLoading={dbRowsLoading}
                 onDbRowClick={onDbRowClick}
                 highlightedBankIds={highlightedBankIds}
+                matchStatus={panePairing.bankStatus}
                 linkMode={linkMode}
                 busyKey={busyKey}
                 deleteBankRow={deleteBankRow}
@@ -1269,7 +1331,7 @@ export function StagedReviewSurface({
             right={
               <StagedPane
                 stagedImportId={detail.staged.id}
-                rows={filteredStagedRows}
+                rows={visibleStagedRows}
                 selected={selected}
                 expanded={expandedRows}
                 accounts={accounts}
@@ -1279,6 +1341,7 @@ export function StagedReviewSurface({
                 onRowUpdated={onRowUpdated}
                 onStagedRowClick={onStagedRowClick}
                 highlightedStagedIds={highlightedStagedIds}
+                matchStatus={panePairing.stagedStatus}
                 anchorsByDate={stagedAnchorsByDate}
                 displaySuggestions={displaySuggestions}
                 acceptSuggestion={acceptSuggestion}
@@ -1291,7 +1354,8 @@ export function StagedReviewSurface({
                 unlinkStagedRow={unlinkStagedRow}
               />
             }
-          />
+            />
+          </>
         ) : null}
       </div>
 

--- a/src/lib/email-import/fetch-resend-attachments.ts
+++ b/src/lib/email-import/fetch-resend-attachments.ts
@@ -48,6 +48,64 @@ interface AttachmentListResponse {
 
 const RESEND_API_BASE = "https://api.resend.com";
 
+/**
+ * Fetch the body (text/html) of a Resend Inbound email via the HTTP API.
+ *
+ * Resend's `email.received` webhook payload carries metadata only — NOT the
+ * message body (serverless body-size limits; see receiving docs). So for any
+ * inbound routed through Resend (e.g. info@ → /admin/inbox) we fetch the body
+ * separately from `GET /emails/receiving/{id}` → { text, html, ... }.
+ *
+ * Returns { text: null, html: null } (with a warn log) when RESEND_API_KEY is
+ * missing or any HTTP step fails, so the caller degrades to whatever the
+ * payload carried rather than throwing.
+ */
+export async function fetchResendReceivedBody(
+  resendEmailId: string,
+): Promise<{ text: string | null; html: string | null }> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.warn(
+      `[email-webhook] RESEND_API_KEY not set — cannot fetch body for ${resendEmailId}`,
+    );
+    return { text: null, html: null };
+  }
+
+  let resp: Response;
+  try {
+    resp = await fetch(
+      `${RESEND_API_BASE}/emails/receiving/${encodeURIComponent(resendEmailId)}`,
+      { headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+  } catch (e) {
+    console.warn(`[email-webhook] get-received-email network error for ${resendEmailId}:`, e);
+    return { text: null, html: null };
+  }
+
+  if (!resp.ok) {
+    console.warn(
+      `[email-webhook] get-received-email returned HTTP ${resp.status} for ${resendEmailId}`,
+    );
+    return { text: null, html: null };
+  }
+
+  try {
+    const body = (await resp.json()) as {
+      text?: unknown;
+      html?: unknown;
+      data?: { text?: unknown; html?: unknown };
+    };
+    const src = body.data && typeof body.data === "object" ? body.data : body;
+    return {
+      text: typeof src.text === "string" ? src.text : null,
+      html: typeof src.html === "string" ? src.html : null,
+    };
+  } catch (e) {
+    console.warn(`[email-webhook] get-received-email JSON parse error for ${resendEmailId}:`, e);
+    return { text: null, html: null };
+  }
+}
+
 export async function fetchResendAttachments(
   resendEmailId: string,
 ): Promise<ResendAttachment[]> {

--- a/src/lib/email-import/providers/resend.ts
+++ b/src/lib/email-import/providers/resend.ts
@@ -14,7 +14,7 @@ import {
   verifySvixSignature,
   SvixVerifyError,
 } from "@/lib/webhooks/svix";
-import { fetchResendAttachments } from "../fetch-resend-attachments";
+import { fetchResendAttachments, fetchResendReceivedBody } from "../fetch-resend-attachments";
 import type { ResendAttachment } from "../parse-attachments";
 import type {
   AuthResult,
@@ -55,10 +55,15 @@ class ResendProvider implements InboundEmailProvider {
   }
 
   async fetchContent(messageId: string): Promise<InboundContent> {
-    // Resend inlines body text/html in the webhook payload but NOT attachment
-    // bytes — only attachments need fetching.
-    const attachments = await fetchResendAttachments(messageId);
-    return { text: null, html: null, attachments };
+    // Resend's `email.received` webhook is metadata-only — NEITHER the body nor
+    // the attachment bytes are inlined. Fetch both from the HTTP API. (Called by
+    // `enrichInbound` only when the payload didn't already carry text/html —
+    // harmless if a future Resend payload does inline them.)
+    const [{ text, html }, attachments] = await Promise.all([
+      fetchResendReceivedBody(messageId),
+      fetchResendAttachments(messageId),
+    ]);
+    return { text, html, attachments };
   }
 
   async deleteReceived(): Promise<void> {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -17,6 +17,14 @@ export interface EmailMessage {
   subject: string;
   html: string;
   text?: string;
+  /**
+   * Optional sender override. Defaults to EMAIL_FROM. MUST be on a
+   * Resend-verified domain (finlynq.com) or Resend 403s the send — callers that
+   * set this (the admin contact-inbox reply) validate the domain first.
+   */
+  from?: string;
+  /** Optional Reply-To header. Used so a reply to our reply threads back to the mailbox address. */
+  replyTo?: string;
 }
 
 export interface EmailTransport {
@@ -71,11 +79,12 @@ function createSmtpTransport(): EmailTransport {
       });
 
       await transporter.sendMail({
-        from: process.env.EMAIL_FROM || "noreply@finlynq.com",
+        from: message.from || process.env.EMAIL_FROM || "noreply@finlynq.com",
         to: message.to,
         subject: message.subject,
         html: message.html,
         text: message.text,
+        ...(message.replyTo ? { replyTo: message.replyTo } : {}),
       });
     },
   };
@@ -101,11 +110,12 @@ function createResendTransport(): EmailTransport {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          from: process.env.EMAIL_FROM || "Finlynq <noreply@finlynq.com>",
+          from: message.from || process.env.EMAIL_FROM || "Finlynq <noreply@finlynq.com>",
           to: message.to,
           subject: message.subject,
           html: message.html,
           text: message.text,
+          ...(message.replyTo ? { reply_to: message.replyTo } : {}),
         }),
       });
       if (!res.ok) {
@@ -411,5 +421,73 @@ export function feedbackReplyNotificationEmail(opts: {
     subject: `[Finlynq feedback] reply on #${opts.feedbackId}`,
     html,
     text: `New reply on feedback #${opts.feedbackId} (${opts.feedbackType || "feedback"}) from ${opts.userLabel || opts.userId}:\n\n${opts.body}`,
+  };
+}
+
+/**
+ * Admin reply to a contact-inbox email (/admin/inbox). This is a person-to-
+ * person reply from the maintainer to an external sender, so it deliberately
+ * does NOT use the marketing `baseLayout` (dark header / footer) — it renders
+ * as a plain, professional email. The admin's reply body + the (optional)
+ * quoted original are user-derived → escaped. The caller sets `from` (the
+ * verified mailbox address, e.g. "Finlynq <info@finlynq.com>") + `replyTo`.
+ */
+export function contactReplyEmail(opts: {
+  to: string;
+  from: string;
+  replyTo?: string;
+  subject: string;
+  replyBody: string;
+  original?: {
+    fromAddress: string;
+    receivedAt?: string | null;
+    bodyText?: string | null;
+  };
+}): EmailMessage {
+  const safeReply = escapeHtml(opts.replyBody).replace(/\n/g, "<br>");
+
+  let quotedHtml = "";
+  let quotedText = "";
+  if (opts.original) {
+    const when = opts.original.receivedAt
+      ? new Date(opts.original.receivedAt).toLocaleString()
+      : "earlier";
+    const safeWhen = escapeHtml(when);
+    const safeFrom = escapeHtml(opts.original.fromAddress);
+    const origBody = (opts.original.bodyText || "").trim();
+    const safeOrigBody = escapeHtml(origBody).replace(/\n/g, "<br>");
+    quotedHtml = `
+      <div style="margin-top:24px;padding-left:12px;border-left:3px solid #e4e4e7;color:#71717a;font-size:13px;line-height:1.6">
+        <p style="margin:0 0 8px">On ${safeWhen}, ${safeFrom} wrote:</p>
+        ${safeOrigBody ? `<div style="white-space:pre-wrap">${safeOrigBody}</div>` : "<em>(no message body)</em>"}
+      </div>`;
+    quotedText = `\n\n---\nOn ${when}, ${opts.original.fromAddress} wrote:\n${
+      origBody
+        ? origBody
+            .split("\n")
+            .map((l) => `> ${l}`)
+            .join("\n")
+        : "> (no message body)"
+    }`;
+  }
+
+  const html = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>
+<body style="margin:0;padding:24px;background:#ffffff;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#18181b;font-size:14px;line-height:1.6">
+  <div style="max-width:600px;margin:0 auto">
+    <div style="white-space:pre-wrap">${safeReply}</div>
+    ${quotedHtml}
+  </div>
+</body>
+</html>`;
+
+  return {
+    to: opts.to,
+    from: opts.from,
+    ...(opts.replyTo ? { replyTo: opts.replyTo } : {}),
+    subject: opts.subject,
+    html,
+    text: `${opts.replyBody}${quotedText}`,
   };
 }

--- a/src/lib/holdings-value.ts
+++ b/src/lib/holdings-value.ts
@@ -435,6 +435,61 @@ export async function getHoldingsValueByAccount(
 }
 
 /**
+ * FINLYNQ-281 — decrypt-health probe for the market-valuation path.
+ *
+ * The market overlay cannot otherwise tell a VALID DEK from a present-but-WRONG
+ * one: a long-lived MCP session whose cached DEK went stale after the demo
+ * account's nightly DEK rotation, or a single corrupt ciphertext row. In that
+ * state `valueHoldingsAtDate` decrypts a holding's symbol to `null` and prices
+ * it at qty×1 (garbage — the `else if (h.symbol)` branch never matches), so
+ * `get_net_worth` returns a plausible-looking but WRONG `basis:"market"` total
+ * with no warning.
+ *
+ * This runs ONE tiny query (id + the two ciphertext columns — no pricing, FX,
+ * or joins) and counts holdings whose ciphertext is present (`v1:` prefix) but
+ * decrypts to `null` — the AES-GCM auth-tag failure signature (`decryptName`
+ * catches it and returns null; it never throws). The overlay uses a non-zero
+ * `failed` to fall back to ledger + an explicit note instead of emitting
+ * silently-wrong market money. Byte-neutral when decryption is healthy
+ * (`failed: 0` ⇒ the market path proceeds unchanged).
+ */
+export async function verifyHoldingDecryptHealth(
+  userId: string,
+  dek: Buffer | null,
+): Promise<{ failed: number; total: number }> {
+  // A null DEK is already handled by the overlay's dek==null → ledger + note
+  // branch; this probe only distinguishes a present-but-invalid DEK.
+  if (dek == null) return { failed: 0, total: 0 };
+  const rows = await db
+    .select({
+      id: schema.portfolioHoldings.id,
+      nameCt: schema.portfolioHoldings.nameCt,
+      symbolCt: schema.portfolioHoldings.symbolCt,
+    })
+    .from(schema.portfolioHoldings)
+    .where(eq(schema.portfolioHoldings.userId, userId));
+  if (rows.length === 0) return { failed: 0, total: 0 };
+  const decrypted = decryptNamedRows(rows, dek, {
+    nameCt: "name",
+    symbolCt: "symbol",
+  }) as Array<(typeof rows)[number] & { name: string | null; symbol: string | null }>;
+  // Only a real v1 ciphertext that decrypted to null counts as a failure —
+  // guards against false positives on empty/legacy/plaintext values.
+  const isCiphertext = (v: string | null | undefined): boolean =>
+    typeof v === "string" && v.startsWith("v1:");
+  let failed = 0;
+  for (const r of decrypted) {
+    if (
+      (isCiphertext(r.nameCt) && r.name == null) ||
+      (isCiphertext(r.symbolCt) && r.symbol == null)
+    ) {
+      failed++;
+    }
+  }
+  return { failed, total: rows.length };
+}
+
+/**
  * Per-HOLDING market value at `asOfDate` (FINLYNQ-129 stacked Performance view).
  * Optionally restricted to one account. The per-account sum of these rows equals
  * `getHoldingsValueByAccount`, so a stacked per-holding chart's outer edge ties

--- a/src/lib/import/stage-statement-file.ts
+++ b/src/lib/import/stage-statement-file.ts
@@ -69,6 +69,19 @@ import { findUnreasonableAmountError } from "@/lib/import-pipeline";
 /** 60 days — matches the route + stage-email-import.ts. */
 const STAGE_TTL_MS = 60 * 24 * 60 * 60 * 1000;
 
+/**
+ * Default fuzzy-dedup window (days) applied to EVERY ingest path. The exact
+ * import_hash is payee-sensitive, so a charge already loaded under a different
+ * descriptor (e.g. an email-connector alert "Spotify" vs the statement's
+ * "Spotify P43795D0D1", posted a day or two later) slips past it and would
+ * re-create a duplicate bank_transactions row. This payee-agnostic amount +
+ * date net catches those. Skipping a real transaction is recoverable (force-load
+ * from /import/pending); a duplicate is expensive to find and clean up — so the
+ * default leans toward over-skipping. A caller may widen it (connectors pass 3
+ * explicitly for the same reason); it is never silently disabled.
+ */
+const DEFAULT_FUZZY_DEDUP_WINDOW_DAYS = 3;
+
 /** "YYYY-MM-DD" → whole-day epoch number (UTC), or null if unparseable. */
 function isoToEpochDay(iso: string): number | null {
   const t = Date.parse(`${iso}T00:00:00Z`);
@@ -416,12 +429,18 @@ export interface WriteStagedImportContext {
    *  pass a provider tag (e.g. "simplefin") so the pending list labels them. */
   fileFormatOverride?: string | null;
   /**
-   * When set (live bank feeds), a still-`new` row is additionally marked
-   * `existing` (skipped by default) if the bound account already has a
-   * transaction OR bank-ledger row with the same amount within ±this many days
-   * — even under a different payee. This is the feed "auto-skip duplicates I
-   * already have" pass; it's re-derived every sync (no stored state), and a
-   * false match can still be force-loaded. Off (undefined) for file uploads.
+   * Fuzzy-dedup window (days). A still-`new` row is additionally marked
+   * `existing` (→ reconcile_state 'skipped_duplicate', excluded from the send by
+   * default) if the bound account already has a transaction OR bank-ledger row
+   * with the same amount within ±this many days — EVEN under a different payee.
+   * This is the payee-agnostic "auto-skip duplicates I already have" pass; it's
+   * re-derived every run (no stored state), and a false match can still be
+   * force-loaded from /import/pending.
+   *
+   * Defaults to {@link DEFAULT_FUZZY_DEDUP_WINDOW_DAYS} when omitted, so it runs
+   * on EVERY account-bound ingest (manual/approve/auto uploads, connectors, MCP)
+   * — the deliberate "never re-load a duplicate by mistake" default. Only skipped
+   * when the import isn't account-bound (cross-account CSV, accountId null).
    */
   fuzzyDedupWindowDays?: number;
 }
@@ -548,8 +567,11 @@ export async function writeStagedImport(
   // the SAME amount within ±window days. Re-derived every sync → a match stays
   // skipped with no stored state; a false positive can still be force-loaded.
   const fuzzySkip = new Set<number>();
-  if (ctx.fuzzyDedupWindowDays != null && accountId !== null) {
-    const windowDays = ctx.fuzzyDedupWindowDays;
+  // Defaults on for every account-bound ingest (see DEFAULT_FUZZY_DEDUP_WINDOW_DAYS);
+  // only cross-account CSVs (accountId null) skip it, since it's account-scoped.
+  const fuzzyWindowDays = ctx.fuzzyDedupWindowDays ?? DEFAULT_FUZZY_DEDUP_WINDOW_DAYS;
+  if (accountId !== null) {
+    const windowDays = fuzzyWindowDays;
     const candidates = shaped.filter(
       (r) => r.dedupStatus === "new" && r.accountId === accountId,
     );

--- a/src/lib/reconcile/pane-pairing.ts
+++ b/src/lib/reconcile/pane-pairing.ts
@@ -1,0 +1,148 @@
+/**
+ * Persistent cross-pane reconciliation pairing for the /import two-pane review.
+ *
+ * The FilePane (staged file rows) and BankPane (continuous bank ledger) sit
+ * side by side. This pure helper derives, for EVERY visible row, whether it has
+ * a counterpart on the other side — so both panes can be tinted persistently
+ * (not just on click) and the user can scan for "what's on one side but not the
+ * other". It also backs the "Show only unmatched" filter.
+ *
+ * Pairing rules (mirrors the dedup + click-highlight the surface already uses):
+ *   1. Explicit link — a staged row's linkedTransactionId matches a bank row's
+ *      linkedTransactionId ⇒ both `matched`.
+ *   2. A staged row in reconcileState 'linked' is `matched` even when its bank
+ *      counterpart isn't in view (it's linked to a system tx).
+ *   3. Fuzzy — a 'skipped_duplicate' staged row (a charge we already have,
+ *      possibly under a drifted payee) is paired to the nearest UNCLAIMED bank
+ *      row of the same amount within ±windowDays. It stays `matched` even when
+ *      no in-view bank row is found (it duplicates SOMETHING we hold).
+ *
+ * Bank rows are only classified WITHIN the staged date window (± window): older
+ * / newer ledger history isn't expected to appear in this statement, so it gets
+ * NO status (neutral) rather than a misleading "only in ledger".
+ *
+ * Pure + dependency-free so the client surface can call it in a memo and a unit
+ * test can exercise it without a DB or DEK.
+ */
+
+export interface PairingStagedRow {
+  id: string;
+  amount: number;
+  date: string; // YYYY-MM-DD
+  reconcileState?: "unmatched" | "auto_suggested" | "linked" | "skipped_duplicate";
+  linkedTransactionId?: number | null;
+}
+
+export interface PairingBankRow {
+  id: string;
+  amount: number;
+  date: string; // YYYY-MM-DD
+  linkedTransactionId: number | null;
+}
+
+export type StagedMatchStatus = "matched" | "only_file";
+export type BankMatchStatus = "matched" | "only_ledger";
+
+export interface PanePairing {
+  /** id → status for staged (file) rows. Every input staged row is present. */
+  stagedStatus: Map<string, StagedMatchStatus>;
+  /** id → status for bank rows. Out-of-window bank rows are ABSENT (neutral). */
+  bankStatus: Map<string, BankMatchStatus>;
+}
+
+/** Matches the DEFAULT_FUZZY_DEDUP_WINDOW_DAYS the staging dedup uses. */
+export const PANE_PAIRING_WINDOW_DAYS = 3;
+
+function toEpochDay(iso: string): number | null {
+  const t = Date.parse(`${iso}T00:00:00Z`);
+  return Number.isNaN(t) ? null : Math.floor(t / 86_400_000);
+}
+
+export function computePanePairing(
+  stagedRows: PairingStagedRow[],
+  bankRows: PairingBankRow[],
+  windowDays: number = PANE_PAIRING_WINDOW_DAYS,
+): PanePairing {
+  const stagedStatus = new Map<string, StagedMatchStatus>();
+  const bankStatus = new Map<string, BankMatchStatus>();
+  const claimedBank = new Set<string>();
+
+  // Staged date window — bank rows outside [min-window, max+window] are ledger
+  // history not expected in this statement, so they stay neutral (no status).
+  const stagedDays = stagedRows
+    .map((s) => toEpochDay(s.date))
+    .filter((d): d is number => d != null);
+  const hasWindow = stagedDays.length > 0;
+  const lo = hasWindow ? Math.min(...stagedDays) - windowDays : 0;
+  const hi = hasWindow ? Math.max(...stagedDays) + windowDays : 0;
+
+  // Index bank rows by linked tx id (explicit pairing) + by amount (fuzzy).
+  const bankByTxId = new Map<number, PairingBankRow[]>();
+  const bankByAmount = new Map<string, PairingBankRow[]>();
+  for (const b of bankRows) {
+    if (b.linkedTransactionId != null) {
+      const arr = bankByTxId.get(b.linkedTransactionId) ?? [];
+      arr.push(b);
+      bankByTxId.set(b.linkedTransactionId, arr);
+    }
+    const key = b.amount.toFixed(2);
+    const arr = bankByAmount.get(key) ?? [];
+    arr.push(b);
+    bankByAmount.set(key, arr);
+  }
+
+  for (const s of stagedRows) {
+    let matched = false;
+
+    // (1) explicit link by tx id.
+    if (s.linkedTransactionId != null) {
+      const peers = bankByTxId.get(s.linkedTransactionId);
+      if (peers && peers.length > 0) {
+        for (const b of peers) {
+          bankStatus.set(b.id, "matched");
+          claimedBank.add(b.id);
+        }
+        matched = true;
+      }
+    }
+
+    // (2) a 'linked' staged row is matched even without an in-view bank peer.
+    if (!matched && s.reconcileState === "linked") matched = true;
+
+    // (3) fuzzy pairing for a duplicate we already hold.
+    if (!matched && s.reconcileState === "skipped_duplicate") {
+      const sd = toEpochDay(s.date);
+      const candidates = bankByAmount.get(s.amount.toFixed(2)) ?? [];
+      let best: PairingBankRow | null = null;
+      let bestDelta = Infinity;
+      for (const b of candidates) {
+        if (claimedBank.has(b.id)) continue;
+        const bd = toEpochDay(b.date);
+        if (sd == null || bd == null) continue;
+        const delta = Math.abs(bd - sd);
+        if (delta <= windowDays && delta < bestDelta) {
+          best = b;
+          bestDelta = delta;
+        }
+      }
+      if (best) {
+        bankStatus.set(best.id, "matched");
+        claimedBank.add(best.id);
+      }
+      matched = true; // skipped_duplicate ⇒ "we already have this".
+    }
+
+    stagedStatus.set(s.id, matched ? "matched" : "only_file");
+  }
+
+  // Remaining in-window bank rows with no staged counterpart → only_ledger.
+  for (const b of bankRows) {
+    if (bankStatus.has(b.id)) continue;
+    if (!hasWindow) continue;
+    const bd = toEpochDay(b.date);
+    if (bd == null || bd < lo || bd > hi) continue;
+    bankStatus.set(b.id, "only_ledger");
+  }
+
+  return { stagedStatus, bankStatus };
+}

--- a/tests/api/mcp-investment-balance-overlay.test.ts
+++ b/tests/api/mcp-investment-balance-overlay.test.ts
@@ -28,8 +28,12 @@ process.env.PF_STAGING_KEY = process.env.PF_STAGING_KEY ?? "test-staging-key-32c
 // the qty×1 hazard never executes. The overlay's dek-null guard means this is
 // only consulted on the dek-present pass.
 const holdingsMap = new Map<number, { value: number; costBasis: number }>();
+// FINLYNQ-281 — the handlers now also call verifyHoldingDecryptHealth via the
+// overlay's `verifyDecrypt` probe; default to healthy so the market path (and
+// every pre-existing handler assertion) is unchanged.
 vi.mock("../../src/lib/holdings-value", () => ({
   getHoldingsValueByAccount: vi.fn(async () => holdingsMap),
+  verifyHoldingDecryptHealth: vi.fn(async () => ({ failed: 0, total: 0 })),
 }));
 
 // Mock FX so reporting conversion is the identity (every rate = 1). Lets the
@@ -113,6 +117,60 @@ describe("applyInvestmentMarketOverlay (pure)", () => {
     expect(res.marketApplied).toBe(false);
     expect(res.note).toBeUndefined();
     expect(res.rows[0]).toMatchObject({ balance: 42, balanceBasis: "ledger" });
+  });
+
+  // FINLYNQ-281 — a present-but-invalid DEK (stale MCP session cache after the
+  // demo DEK rotation, or a corrupt ciphertext row) must NOT produce a garbage
+  // `basis:"market"` total. The probe reports failures → fall back to ledger +
+  // note, and NEVER call the qty×1 pricing path.
+  it("decrypt failure (dek present): ledger + note + decryptionFailed, fetch NEVER called", async () => {
+    const fetchHoldings = vi.fn(async () => new Map([[2, { value: 15000, costBasis: 9000 }]]));
+    const verifyDecrypt = vi.fn(async () => ({ failed: 1, total: 3 }));
+    const res = await applyInvestmentMarketOverlay(
+      [
+        { id: 1, currency: "USD", isInvestment: false, ledgerBalance: 500 },
+        { id: 2, currency: "USD", isInvestment: true, ledgerBalance: 1234.56 },
+      ],
+      dek,
+      fetchHoldings,
+      verifyDecrypt,
+    );
+    expect(verifyDecrypt).toHaveBeenCalledTimes(1);
+    expect(fetchHoldings).not.toHaveBeenCalled(); // qty×1 garbage path skipped
+    expect(res.marketApplied).toBe(false);
+    expect(res.decryptionFailed).toBe(true);
+    expect(res.note).toBeTruthy();
+    // Investment row falls back to its ledger (net-contribution) balance.
+    expect(res.rows[1]).toMatchObject({ id: 2, balance: 1234.56, balanceBasis: "ledger" });
+    expect(res.rows[1].costBasis).toBeUndefined();
+  });
+
+  it("healthy decrypt (failed:0): market path proceeds unchanged", async () => {
+    const fetchHoldings = vi.fn(async () => new Map([[2, { value: 15000, costBasis: 9000 }]]));
+    const verifyDecrypt = vi.fn(async () => ({ failed: 0, total: 3 }));
+    const res = await applyInvestmentMarketOverlay(
+      [{ id: 2, currency: "USD", isInvestment: true, ledgerBalance: 0 }],
+      dek,
+      fetchHoldings,
+      verifyDecrypt,
+    );
+    expect(verifyDecrypt).toHaveBeenCalledTimes(1);
+    expect(fetchHoldings).toHaveBeenCalledTimes(1);
+    expect(res.marketApplied).toBe(true);
+    expect(res.decryptionFailed).toBeUndefined();
+    expect(res.rows[0]).toMatchObject({ id: 2, balance: 15000, balanceBasis: "market", costBasis: 9000 });
+  });
+
+  it("decrypt probe is skipped when omitted (back-compat 3-arg call still market)", async () => {
+    const fetchHoldings = vi.fn(async () => new Map([[2, { value: 15000, costBasis: 9000 }]]));
+    const res = await applyInvestmentMarketOverlay(
+      [{ id: 2, currency: "USD", isInvestment: true, ledgerBalance: 0 }],
+      dek,
+      fetchHoldings,
+    );
+    expect(fetchHoldings).toHaveBeenCalledTimes(1);
+    expect(res.marketApplied).toBe(true);
+    expect(res.decryptionFailed).toBeUndefined();
   });
 });
 

--- a/tests/pane-pairing.test.ts
+++ b/tests/pane-pairing.test.ts
@@ -1,0 +1,102 @@
+/**
+ * R3 — persistent cross-pane reconciliation pairing (computePanePairing).
+ *
+ * Pure, DB-free logic that tells the /import two-pane review, for every staged
+ * (file) row and bank-ledger row, whether it has a counterpart on the other
+ * side. Backs the persistent tint on both panes + the "Show only unmatched"
+ * filter. These cases lock the pairing rules the UI depends on.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  computePanePairing,
+  type PairingStagedRow,
+  type PairingBankRow,
+} from "@/lib/reconcile/pane-pairing";
+
+const staged = (o: Partial<PairingStagedRow> & { id: string }): PairingStagedRow => ({
+  amount: -10,
+  date: "2026-06-15",
+  reconcileState: "unmatched",
+  linkedTransactionId: null,
+  ...o,
+});
+const bank = (o: Partial<PairingBankRow> & { id: string }): PairingBankRow => ({
+  amount: -10,
+  date: "2026-06-15",
+  linkedTransactionId: null,
+  ...o,
+});
+
+describe("computePanePairing", () => {
+  it("pairs an explicit link (shared tx id) as matched on both sides", () => {
+    const { stagedStatus, bankStatus } = computePanePairing(
+      [staged({ id: "s1", reconcileState: "linked", linkedTransactionId: 42 })],
+      [bank({ id: "b1", linkedTransactionId: 42 })],
+    );
+    expect(stagedStatus.get("s1")).toBe("matched");
+    expect(bankStatus.get("b1")).toBe("matched");
+  });
+
+  it("fuzzy-pairs a skipped_duplicate to a same-amount bank row within the window", () => {
+    const { stagedStatus, bankStatus } = computePanePairing(
+      [staged({ id: "s1", reconcileState: "skipped_duplicate", amount: -14.34, date: "2026-06-13" })],
+      // Different payee/date is irrelevant — amount + within ±3 days is enough.
+      [bank({ id: "b1", amount: -14.34, date: "2026-06-15" })],
+    );
+    expect(stagedStatus.get("s1")).toBe("matched");
+    expect(bankStatus.get("b1")).toBe("matched");
+  });
+
+  it("keeps a skipped_duplicate matched even with no visible bank counterpart", () => {
+    const { stagedStatus, bankStatus } = computePanePairing(
+      [staged({ id: "s1", reconcileState: "skipped_duplicate", amount: -14.34 })],
+      [bank({ id: "b1", amount: -99.99 })], // wrong amount → no pair
+    );
+    expect(stagedStatus.get("s1")).toBe("matched"); // "we already have this"
+    // The unrelated bank row is in-window with no file peer → only_ledger.
+    expect(bankStatus.get("b1")).toBe("only_ledger");
+  });
+
+  it("marks a genuinely new staged row only_file", () => {
+    const { stagedStatus } = computePanePairing(
+      [staged({ id: "s1", reconcileState: "unmatched", amount: -20, date: "2026-06-20" })],
+      [],
+    );
+    expect(stagedStatus.get("s1")).toBe("only_file");
+  });
+
+  it("marks an in-window bank row with no staged peer only_ledger", () => {
+    const { bankStatus } = computePanePairing(
+      [staged({ id: "s1", amount: -10, date: "2026-06-15" })],
+      [bank({ id: "b1", amount: -77, date: "2026-06-16" })],
+    );
+    expect(bankStatus.get("b1")).toBe("only_ledger");
+  });
+
+  it("gives NO status to a bank row outside the staged date window", () => {
+    const { bankStatus } = computePanePairing(
+      [staged({ id: "s1", amount: -10, date: "2026-06-15" })],
+      [bank({ id: "old", amount: -10, date: "2026-01-01" })], // months earlier
+    );
+    expect(bankStatus.has("old")).toBe(false); // neutral, not "only_ledger"
+  });
+
+  it("does not double-claim one bank row for two same-amount dupes (greedy 1:1)", () => {
+    const { stagedStatus, bankStatus } = computePanePairing(
+      [
+        staged({ id: "s1", reconcileState: "skipped_duplicate", amount: -25, date: "2026-06-14" }),
+        staged({ id: "s2", reconcileState: "skipped_duplicate", amount: -25, date: "2026-06-15" }),
+      ],
+      [
+        bank({ id: "b1", amount: -25, date: "2026-06-14" }),
+        bank({ id: "b2", amount: -25, date: "2026-06-15" }),
+      ],
+    );
+    expect(stagedStatus.get("s1")).toBe("matched");
+    expect(stagedStatus.get("s2")).toBe("matched");
+    // Each dupe claimed a DISTINCT bank row — both matched, none left only_ledger.
+    expect(bankStatus.get("b1")).toBe("matched");
+    expect(bankStatus.get("b2")).toBe("matched");
+  });
+});


### PR DESCRIPTION
Ships the current dev delta to production (6 commits).

## Highlights
- **`/admin/inbox` reply-in-app** — reply to contact-inbox mail (info@/support@) from the app instead of opening Resend. New `POST /api/admin/inbox/[id]/reply` sends via the Resend transport FROM the mailbox address (Reply-To threads back), marks the row triaged. `EmailMessage` + both transports gained optional `from`/`replyTo`; new `contactReplyEmail` builder. Inbound webhook now content-negotiates provider by transport signature (svix → Resend even under self-smtp) and fetches the metadata-only Resend body. Verified end-to-end on dev.
- **FINLYNQ-281** — MCP fails loudly on undecryptable holdings (no phantom market value); fixed deterministic demo DEK.
- **Reports** — Balance Sheet values investment accounts at market.
- **Import** — default fuzzy dedup everywhere + persistent cross-pane match view + full-row match tint.
- **Income Statement** — per-column income/expense totals.

## Gates (run locally on the full dev tree)
- typecheck ✅ · eslint 0 errors ✅ · audit:invariants (16/16) ✅ · lint:tool-descriptions ✅ · vitest 1719 passed / 0 failed ✅

## Operator follow-up (post-merge)
To make new `info@` mail auto-land in `/admin/inbox`: create a Resend `email.received` webhook → `https://finlynq.com/api/import/email-webhook`, set `RESEND_WEBHOOK_SECRET`, restart `pf.service`. Confirm whether finlynq.com inbound is on Resend vs AWS SES first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)