### PR TITLE
fix(mcp): align loan docs and subscription currency defaults

### DIFF
--- a/docs/mcp-schema-contract.md
+++ b/docs/mcp-schema-contract.md
@@ -1,0 +1,81 @@
+# Finlynq MCP schema and currency contract
+
+This document is the source-of-truth example for the HTTP MCP surface. Examples
+must match the runtime Zod schemas and the validation performed by the handler.
+
+## Loans
+
+Use `manage_loans` with `op: "add"` (or the compatibility alias `add_loan`).
+The required fields are:
+
+```json
+{
+  "op": "add",
+  "name": "Demo mortgage",
+  "type": "mortgage",
+  "principal": 18000,
+  "annual_rate": 6.99,
+  "term_months": 48,
+  "start_date": "2025-08-01"
+}
+```
+
+Field names are exact:
+
+- `annual_rate` is the accepted name; `interest_rate` is not accepted.
+- `start_date` is required and must be `YYYY-MM-DD`.
+- `principal` must be greater than zero.
+- The loan must provide either `term_months` or `payment_amount`; the
+  amortization validator also rejects non-amortizing combinations.
+- `payment_frequency` defaults to `monthly`.
+- `extra_payment` defaults to `0`.
+- `residual_value` is for leases and must be below principal.
+- `account_id` is preferred for an exact account link; `account` is the
+  name/alias resolver alternative and refuses unmatched or ambiguous names.
+
+`manage_loans` update validates the merged existing row, so changing only a
+payment or rate cannot create a non-amortizing loan.
+
+## Display/reporting currency
+
+The single user-facing currency is stored in the per-user setting:
+
+```text
+settings.key = "display_currency"
+```
+
+The HTTP API operation to change it is:
+
+```text
+PUT /api/settings/display-currency
+{"displayCurrency":"CHF"}
+```
+
+There is currently **no MCP operation** that changes this setting. Configure it
+through the web/API endpoint, then MCP reporting tools read it automatically.
+An explicit `reportingCurrency` argument still overrides the saved setting for
+one call. When the setting is absent or unreadable, the documented final
+fallback is `CAD`.
+
+## Subscriptions
+
+`manage_subscriptions(op: "add")` accepts an optional `currency`.
+
+- Explicit `currency` always wins.
+- When omitted, the subscription inherits `settings.display_currency`.
+- It does not inherit an account currency; a subscription may have no linked
+  account and the display setting is deterministic for both cases.
+- If `display_currency` is configured as `CHF`, an omitted currency is stored as
+  `CHF`; it is not silently stored as `CAD`.
+- If no display currency is configured, the final fallback is `CAD`.
+- Bulk subscription creation follows the same rule and resolves the default
+  once for the operation.
+
+Budget and report totals use the resolved reporting currency: explicit
+`reportingCurrency`, otherwise `settings.display_currency`, otherwise `CAD`.
+
+## Safety
+
+Examples contain synthetic values only. Never put credentials, tokens,
+user identifiers, ciphertext, database URLs, or live financial data in MCP
+help, schemas, tests, issues, commits, or pull requests.

--- a/mcp-server/tools/subscriptions.ts
+++ b/mcp-server/tools/subscriptions.ts
@@ -110,6 +110,11 @@ export function registerSubscriptionsTools(server: McpServer, ctx: PgToolContext
     notes?: string;
   }): Promise<ToolResult> {
       const { name, amount, cadence, next_billing_date, currency, category, category_id, account, account_id, notes } = args;
+      // An omitted subscription currency follows the user's display/reporting
+      // currency. The resolver falls back to CAD only when no display currency
+      // has been configured, so a CHF-configured user never gets an implicit
+      // CAD subscription.
+      const resolvedCurrency = await resolveReportingCurrency(db, userId, currency);
       // Stream D Phase 4: subscriptions.name plaintext column dropped — uniqueness
       // gate now relies on name_lookup HMAC. No DEK ⇒ no lookup ⇒ refuse cleanly.
       if (!dek) return err("Cannot create subscription without an unlocked DEK (Stream D Phase 4).");
@@ -145,10 +150,10 @@ export function registerSubscriptionsTools(server: McpServer, ctx: PgToolContext
       // Stream D Phase 4 — plaintext name dropped.
       const result = await q(db, sql`
         INSERT INTO subscriptions (user_id, amount, currency, frequency, category_id, account_id, next_date, status, notes, name_ct, name_lookup)
-        VALUES (${userId}, ${amount}, ${currency ?? "CAD"}, ${cadence}, ${categoryId}, ${accountId}, ${next_billing_date}, 'active', ${notes != null ? encNote(notes) : null}, ${n.ct}, ${n.lookup})
+        VALUES (${userId}, ${amount}, ${resolvedCurrency}, ${cadence}, ${categoryId}, ${accountId}, ${next_billing_date}, 'active', ${notes != null ? encNote(notes) : null}, ${n.ct}, ${n.lookup})
         RETURNING id
       `);
-      return text({ success: true, data: { id: Number(result[0]?.id), message: `Subscription "${name}" created — ${currency ?? "CAD"} ${amount} ${cadence}, next ${next_billing_date}` } });
+      return text({ success: true, data: { id: Number(result[0]?.id), message: `Subscription "${name}" created — ${resolvedCurrency} ${amount} ${cadence}, next ${next_billing_date}` } });
   }
 
   // ── op: update — lifted VERBATIM from update_subscription ──────────────────
@@ -520,6 +525,7 @@ export function registerSubscriptionsTools(server: McpServer, ctx: PgToolContext
 
       let created = 0;
       const skipped: string[] = [];
+      const resolvedCurrency = await resolveReportingCurrency(db, userId, undefined);
       for (const c of candidates) {
         // Stream D Phase 4 — plaintext name dropped; lookup-only dedup +
         // encrypted insert. DEK is required.
@@ -533,7 +539,7 @@ export function registerSubscriptionsTools(server: McpServer, ctx: PgToolContext
         const enc = encryptName(dek, c.payee);
         await db.execute(sql`
           INSERT INTO subscriptions (user_id, amount, currency, frequency, category_id, account_id, next_date, status, notes, name_ct, name_lookup)
-          VALUES (${userId}, ${c.amount}, 'CAD', ${c.cadence}, ${c.category_id ?? null}, NULL, ${next}, 'active', 'Auto-detected by MCP', ${enc.ct}, ${enc.lookup})
+          VALUES (${userId}, ${c.amount}, ${resolvedCurrency}, ${c.cadence}, ${c.category_id ?? null}, NULL, ${next}, 'active', 'Auto-detected by MCP', ${enc.ct}, ${enc.lookup})
         `);
         created++;
       }
@@ -553,7 +559,7 @@ export function registerSubscriptionsTools(server: McpServer, ctx: PgToolContext
         amount: z.number().positive().optional().describe("Amount per billing cycle (must be > 0). For a single add."),
         cadence: z.enum(["weekly", "monthly", "quarterly", "annual", "yearly"]).optional().describe("Billing frequency. For a single add."),
         next_billing_date: ymdDate.optional().describe("Next billing date (YYYY-MM-DD). For a single add."),
-        currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code (default CAD). Issue #206: full SUPPORTED_CURRENCIES list."),
+        currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code. If omitted, inherits settings.display_currency; fallback is CAD when no display currency is configured."),
         category: z.string().optional().describe("Category name (fuzzy matched — mistyped/unmatched is REFUSED, never silently unlinked). Single add."),
         category_id: z.number().int().positive().optional().describe("Category FK fast-path — wins over the fuzzy `category` name. Single add."),
         account: z.string().optional().describe("Account name or alias (fuzzy matched against name; exact match on alias — mistyped/unmatched is REFUSED). Single add."),
@@ -639,7 +645,7 @@ export function registerSubscriptionsTools(server: McpServer, ctx: PgToolContext
       amount: z.number().positive().describe("Amount per billing cycle (must be > 0)"),
       cadence: z.enum(["weekly", "monthly", "quarterly", "annual", "yearly"]).describe("Billing frequency"),
       next_billing_date: ymdDate.describe("Next billing date (YYYY-MM-DD)"),
-      currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code (default CAD). Issue #206: full SUPPORTED_CURRENCIES list."),
+      currency: supportedCurrencyEnum.optional().describe("ISO 4217 currency code. If omitted, inherits settings.display_currency; fallback is CAD when no display currency is configured."),
       category: z.string().optional().describe("Category name (fuzzy matched — mistyped/unmatched is REFUSED)"),
       category_id: z.number().int().positive().optional().describe("Category FK fast-path — wins over the fuzzy `category` name."),
       account: z.string().optional().describe("Account name or alias (fuzzy matched against name; exact match on alias — mistyped/unmatched is REFUSED)"),

--- a/tests/mcp/schema-sync.test.ts
+++ b/tests/mcp/schema-sync.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { resolveReportingCurrency } from "../../mcp-server/reporting-currency";
+import { buildLoanSchedule, LoanValidationError } from "@/lib/loan-calculator";
+
+describe("FINLYNQ-132 schema and currency contract", () => {
+  it("inherits CHF from settings when subscription currency is omitted", async () => {
+    const execute = vi.fn(async () => ({ rows: [{ value: "CHF" }] }));
+    const currency = await resolveReportingCurrency({ execute }, "user-1", undefined);
+
+    expect(currency).toBe("CHF");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an explicit subscription/reporting currency authoritative", async () => {
+    const execute = vi.fn();
+    const currency = await resolveReportingCurrency({ execute }, "user-1", "CHF");
+
+    expect(currency).toBe("CHF");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("falls back to CAD only when display currency is unavailable", async () => {
+    const execute = vi.fn(async () => ({ rows: [] }));
+    const currency = await resolveReportingCurrency({ execute }, "user-1", undefined);
+
+    expect(currency).toBe("CAD");
+  });
+
+  it("rejects a loan without term_months or payment_amount", () => {
+    expect(() =>
+      buildLoanSchedule({
+        principal: 18000,
+        annualRate: 6.99,
+        termMonths: null,
+        startDate: "2025-08-01",
+        paymentAmount: null,
+      }),
+    ).toThrow(LoanValidationError);
+  });
+
+  it("keeps the authoritative examples aligned with runtime names", () => {
+    const doc = readFileSync(resolve(__dirname, "../../docs/mcp-schema-contract.md"), "utf8");
+
+    expect(doc).toContain('"annual_rate": 6.99');
+    expect(doc).toContain('"start_date": "2025-08-01"');
+    expect(doc).toContain("interest_rate");
+    expect(doc).toContain("PUT /api/settings/display-currency");
+    expect(doc).toContain("inherits `settings.display_currency`");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes documentation/runtime drift in the Finlynq MCP surface and removes the implicit CAD subscription default.

### Loans
- Documents the exact required `manage_loans(op="add")` fields: `name`, `type`, `principal`, `annual_rate`, `start_date`, plus `term_months` or `payment_amount`.
- Documents the canonical `annual_rate` name (not `interest_rate`) and the merged-row amortization validation.

### Display/reporting currency
- Documents that the per-user `settings.display_currency` setting drives reporting defaults.
- Documents `PUT /api/settings/display-currency` as the current configuration path and explicitly records that no MCP setting-change operation exists.
- Documents the final CAD fallback only when no display setting is available.

### Subscriptions
- `manage_subscriptions(op="add")` now resolves omitted currency from `settings.display_currency`.
- Bulk subscription creation uses the same resolved default instead of hardcoding CAD.
- Tool descriptions now state the runtime behavior.

### Tests
- Added regression coverage for CHF inheritance, explicit currency precedence, CAD fallback, loan validation, and the authoritative help examples.

Related: FINLYNQ-132