### PR TITLE
Merge dev → main: admin live-activity counts

### DIFF
--- a/src/app/(app)/admin/page.tsx
+++ b/src/app/(app)/admin/page.tsx
@@ -73,6 +73,10 @@ interface UsageStats {
   activeUsersLast7Days: number;
   activeUsersLast30Days: number;
   loginsLast24Hours?: number;
+  // FINLYNQ — near-real-time "active now" from last_active_at (web + MCP + API key).
+  activeUsersLast15Min?: number;
+  activeUsersLast60Min?: number;
+  activeUsersLast24Hours?: number;
   recentLogins?: LoginActivityRow[];
 }
 
@@ -441,6 +445,56 @@ export default function AdminPage() {
             color="bg-amber-500/15 text-amber-600"
           />
         </div>
+      )}
+
+      {/* Live activity — near-real-time "who's using it right now" from
+          last_active_at (web + MCP + API key). The 15-min window is the
+          deploy-safety glance: ~0 means a restart disrupts nobody. */}
+      {stats && (
+        <motion.div variants={itemVariants}>
+          <div className="flex items-center gap-2 mb-3">
+            <span className="relative flex h-2 w-2">
+              {(stats.activeUsersLast15Min ?? 0) > 0 && (
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+              )}
+              <span
+                className={`relative inline-flex h-2 w-2 rounded-full ${
+                  (stats.activeUsersLast15Min ?? 0) > 0
+                    ? "bg-emerald-500"
+                    : "bg-zinc-300"
+                }`}
+              />
+            </span>
+            <h2 className="text-sm font-semibold text-muted-foreground">
+              Live activity
+            </h2>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <StatCard
+              label="Active now (15 min)"
+              value={stats.activeUsersLast15Min ?? 0}
+              icon={Activity}
+              color="bg-emerald-500/15 text-emerald-600"
+            />
+            <StatCard
+              label="Active (last hour)"
+              value={stats.activeUsersLast60Min ?? 0}
+              icon={Activity}
+              color="bg-teal-500/15 text-teal-600"
+            />
+            <StatCard
+              label="Active (last 24h)"
+              value={stats.activeUsersLast24Hours ?? 0}
+              icon={Activity}
+              color="bg-sky-500/15 text-sky-600"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground mt-2">
+            Counts users with any authenticated request (web, MCP, or API key)
+            in the window. Best glance before a deploy: the restart rotates JWTs
+            and forces a re-login.
+          </p>
+        </motion.div>
       )}
 
       {/* Plan Breakdown */}

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -7,7 +7,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDialect } from "@/db";
 import { requireAdmin } from "@/lib/auth/require-admin";
-import { getUsageStats, listUsers } from "@/lib/auth/queries";
+import { getUsageStats, listUsers, getActiveUserCounts } from "@/lib/auth/queries";
 
 export async function GET(request: NextRequest) {
   if (getDialect() !== "postgres") {
@@ -21,6 +21,10 @@ export async function GET(request: NextRequest) {
   if (!auth.authenticated) return auth.response;
 
   const stats = await getUsageStats();
+
+  // Near-real-time active-user counts (last_active_at — captures web + MCP +
+  // API-key activity, unlike the login-based windows below).
+  const activeCounts = await getActiveUserCounts();
 
   // Compute registrations in last 7 and 30 days
   const allUsers = await listUsers({ limit: 10000 });
@@ -92,6 +96,9 @@ export async function GET(request: NextRequest) {
     activeUsersLast7Days: activeLast7,
     activeUsersLast30Days: activeLast30,
     loginsLast24Hours: loginsLast24h,
+    activeUsersLast15Min: activeCounts.activeLast15Min,
+    activeUsersLast60Min: activeCounts.activeLast60Min,
+    activeUsersLast24Hours: activeCounts.activeLast24Hours,
     recentLogins,
   });
 }

--- a/src/lib/auth/queries.ts
+++ b/src/lib/auth/queries.ts
@@ -10,6 +10,7 @@ import { db } from "@/db";
 import type { DrizzleDb } from "@/db";
 import * as pgSchema from "@/db/schema-pg";
 import { eq, count, sql, inArray, and, isNull } from "drizzle-orm";
+import { normalizeDbRows } from "@/lib/db-utils";
 import crypto from "crypto";
 
 /** Returns the PostgreSQL schema tables */
@@ -720,5 +721,46 @@ export async function getUsageStats() {
     totalUsers: userRows[0]?.total ?? 0,
     totalTransactions: txRows[0]?.total ?? 0,
     totalAccounts: acctRows[0]?.total ?? 0,
+  };
+}
+
+/** Rolling "active now" counts derived from `users.last_active_at`. */
+export interface ActiveUserCounts {
+  /** Users with an authenticated request in the last 15 minutes. */
+  activeLast15Min: number;
+  /** Users with an authenticated request in the last 60 minutes. */
+  activeLast60Min: number;
+  /** Users with an authenticated request in the last 24 hours. */
+  activeLast24Hours: number;
+}
+
+/**
+ * Near-real-time active-user counts across three rolling windows, from
+ * `users.last_active_at` — which is bumped on ANY authenticated access (web
+ * session, OAuth/MCP token, or `pf_` API key), throttled to one write per
+ * 15-min window (see `lib/auth/last-active.ts`). Unlike `last_login_at` this
+ * captures MCP-only and API-key-only users, so it reflects real activity — the
+ * signal an operator wants before restarting/deploying.
+ *
+ * One round-trip: three `COUNT(*) FILTER` aggregates over a single scan.
+ */
+export async function getActiveUserCounts(): Promise<ActiveUserCounts> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result = await (db as any).execute(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE last_active_at > NOW() - interval '15 minutes') AS active_15m,
+      COUNT(*) FILTER (WHERE last_active_at > NOW() - interval '60 minutes') AS active_60m,
+      COUNT(*) FILTER (WHERE last_active_at > NOW() - interval '24 hours')   AS active_24h
+    FROM users
+  `);
+  const row = normalizeDbRows<{
+    active_15m: number | string;
+    active_60m: number | string;
+    active_24h: number | string;
+  }>(result)[0];
+  return {
+    activeLast15Min: Number(row?.active_15m ?? 0),
+    activeLast60Min: Number(row?.active_60m ?? 0),
+    activeLast24Hours: Number(row?.active_24h ?? 0),
   };
 }


### PR DESCRIPTION
## Summary
- Add near-real-time active-user counts (15 min / 60 min / 24h) to the `/admin` dashboard via `getActiveUserCounts()` — a single `COUNT(*) FILTER` scan over `users.last_active_at`, capturing web + MCP + API-key activity as a deploy-safety glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)