### PR TITLE
hotfix: api_keys cleanup migration must not abort the deploy when not table owner

### DIFF
--- a/scripts/migrations/20260727b_drop_legacy_api_keys_table.sql
+++ b/scripts/migrations/20260727b_drop_legacy_api_keys_table.sql
@@ -25,13 +25,43 @@
 -- Defensive: only drops when empty. If an old self-hosted deployment somehow
 -- has rows, the migration leaves the table alone and warns rather than
 -- destroying data or blocking the deploy.
+--
+-- It must ALSO tolerate not owning the table. `api_keys` predates the tracked
+-- migration chain, so on any deployment where it was created by hand as a
+-- different role (prod: owner `postgres`, while migrations run as the app
+-- role) `DROP TABLE` fails with "must be owner of table api_keys" — SQLSTATE
+-- 42501. That aborts the migration runner and takes the whole deploy with it,
+-- which is precisely what the paragraph above says this migration must never
+-- do: it is opportunistic cleanup of a dead, empty table, not a load-bearing
+-- schema change. Ownership is checked up front and the drop is additionally
+-- wrapped so a privilege error downgrades to a warning. Leaving the table is
+-- harmless — the FK trap it describes needs at least one row, and no code path
+-- can create one. An operator finishes the job with:
+--     ALTER TABLE public.api_keys OWNER TO <app_role>;   -- then re-run, or
+--     DROP TABLE public.api_keys;                        -- as a superuser
+-- (Discovered by a failed prod deploy, 2026-07-27.)
 
 DO $$
 DECLARE
   n bigint;
+  owner_name text;
 BEGIN
   IF to_regclass('public.api_keys') IS NULL THEN
     RAISE NOTICE 'api_keys: already absent, nothing to do';
+    RETURN;
+  END IF;
+
+  SELECT tableowner INTO owner_name
+    FROM pg_tables WHERE schemaname = 'public' AND tablename = 'api_keys';
+  IF NOT pg_has_role(current_user, owner_name, 'USAGE') THEN
+    -- NB: records as applied, so it will not re-run. Deliberate: re-running
+    -- would fail identically until an operator intervenes, and the table is
+    -- inert either way.
+    RAISE WARNING
+      'api_keys: owned by % but migrating as % — NOT dropping. The table is '
+      'empty and unreachable from the app, so this is safe to leave. To finish: '
+      'ALTER TABLE public.api_keys OWNER TO %; or DROP TABLE it as a superuser.',
+      owner_name, current_user, current_user;
     RETURN;
   END IF;
 
@@ -46,6 +76,15 @@ BEGIN
     RETURN;
   END IF;
 
-  DROP TABLE public.api_keys;
-  RAISE NOTICE 'api_keys: dropped (was empty)';
+  -- Belt-and-braces: the ownership probe above should already have caught the
+  -- privilege case, but a DROP can still be refused (e.g. an event trigger, or
+  -- a role grant changing mid-deploy). Never let cleanup abort a release.
+  BEGIN
+    DROP TABLE public.api_keys;
+    RAISE NOTICE 'api_keys: dropped (was empty)';
+  EXCEPTION WHEN insufficient_privilege THEN
+    RAISE WARNING
+      'api_keys: insufficient privilege to drop as % — left in place (empty, '
+      'inert). Drop it manually as its owner or a superuser.', current_user;
+  END;
 END $$;

--- a/tests/migration-runner.test.ts
+++ b/tests/migration-runner.test.ts
@@ -48,18 +48,59 @@ describe("migration runner parity", () => {
     expect(bad).toEqual([]);
   });
 
+  /**
+   * Strip comments, then dollar-quoted bodies (`$$…$$`, `$tag$…$tag$`).
+   *
+   * The dollar-quote pass is what makes the transaction guard below correct
+   * rather than merely strict. Inside a `DO $$ … $$` body, BEGIN/END are
+   * PL/pgSQL *block* delimiters — they cannot commit or roll back the runner's
+   * transaction, so a nested `BEGIN … EXCEPTION … END;` (the standard way to
+   * make one statement non-fatal) is completely safe. Without this pass the
+   * guard flags that as an offender, which is a false positive that pushes
+   * authors toward removing legitimate error handling.
+   *
+   * Existing DO blocks slipped through only incidentally: they end `END $$;`,
+   * and the `$$` between END and `;` happens not to match the regex.
+   */
+  function stripCommentsAndDollarBodies(sql: string): string {
+    return sql
+      .replace(/--[^\n]*/g, "")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\$([A-Za-z_][A-Za-z0-9_]*)?\$[\s\S]*?\$\1\$/g, " ");
+  }
+
   it("no migration opens its own transaction", () => {
     // Both runners wrap file body + ledger INSERT in ONE transaction. An inner
     // COMMIT would close it early and decouple the bookkeeping from the DDL,
     // so a later failure would leave the migration recorded but half-applied.
     const offenders: string[] = [];
     for (const f of readdirSync(MIGRATIONS_DIR).filter((x) => x.endsWith(".sql"))) {
-      const sql = readFileSync(path.join(MIGRATIONS_DIR, f), "utf8")
-        .replace(/--[^\n]*/g, "")
-        .replace(/\/\*[\s\S]*?\*\//g, "");
+      const sql = stripCommentsAndDollarBodies(
+        readFileSync(path.join(MIGRATIONS_DIR, f), "utf8"),
+      );
       if (/^\s*(BEGIN|COMMIT|END)\s*;/im.test(sql)) offenders.push(f);
     }
     expect(offenders).toEqual([]);
+  });
+
+  it("still catches a migration that really does open its own transaction", () => {
+    // Guards the guard: the dollar-quote exemption above must not blunt the
+    // check for top-level transaction control, which is the thing that would
+    // actually decouple the ledger INSERT from the DDL.
+    const check = (sql: string) =>
+      /^\s*(BEGIN|COMMIT|END)\s*;/im.test(stripCommentsAndDollarBodies(sql));
+
+    expect(check("BEGIN;\nALTER TABLE t ADD COLUMN c int;\nCOMMIT;\n")).toBe(true);
+    expect(check("ALTER TABLE t ADD COLUMN c int;\nCOMMIT;\n")).toBe(true);
+    expect(check("-- BEGIN;\nALTER TABLE t ADD COLUMN c int;\n")).toBe(false);
+    // A nested PL/pgSQL block with exception handling is NOT transaction control.
+    expect(
+      check(
+        "DO $$\nBEGIN\n  BEGIN\n    DROP TABLE t;\n  EXCEPTION WHEN insufficient_privilege THEN\n    RAISE WARNING 'skipped';\n  END;\nEND $$;\n",
+      ),
+    ).toBe(false);
+    // ...but a real COMMIT after a DO block is still caught.
+    expect(check("DO $$\nBEGIN\n  PERFORM 1;\nEND $$;\nCOMMIT;\n")).toBe(true);
   });
 });
 


### PR DESCRIPTION
Unblocks the production deploy of release `c11d4ce`, which failed at:

```
ERROR:  must be owner of table api_keys
CONTEXT:  SQL statement "DROP TABLE public.api_keys"
```

## What happened

`api_keys` predates the tracked migration chain and was created by hand as `postgres`, while migrations run as the app role (`finlynq_prod`). `DROP TABLE` is denied with SQLSTATE 42501, which aborted the migration runner and took the whole release with it.

**No user impact:** the failure came before the build and restart steps, so prod kept serving the previous build throughout. `healthz` stayed 200. The pre-deploy encrypted backup was taken normally.

## Why this is a real bug, not just a prod quirk

The migration's own header states it must warn "rather than destroying data or blocking the deploy" — it is opportunistic cleanup of a dead, empty table. It already guarded *has rows* and *already absent*, but assumed the deploy role owned the table. Any self-hosted deployment whose `api_keys` is owned by a different role than its migration role would hit the same wall on this release.

## Fix

- `pg_has_role` check up front → warn and return instead of failing
- The `DROP` is additionally wrapped to downgrade `insufficient_privilege` to a warning

Leaving the table is harmless: the FK trap it describes needs at least one row, and no code path can create one (prod has 0).

## Verification

Ran the fixed block against prod's actual role/ownership pair inside a rolled-back transaction — as both `finlynq_prod` and `finlynq_dev` it emits the warning and returns cleanly instead of erroring. Prod was not modified.

## Migration state on prod after the failed run

| Migration | Status |
|---|---|
| `20260725_user_prompt_acks` | applied |
| `20260727b_drop_legacy_api_keys_table` | failed → not recorded, will retry |
| `20260727_cleanup_orphaned_user_rows` | not reached |
| `20260727c_portfolio_snapshots_native_currency` | not reached |

All three remaining migrations apply on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)