### PR TITLE
Loan currency: native + reporting basis, cross-currency payoff fix, and loan editing

### DIFF
--- a/docs/loans.md
+++ b/docs/loans.md
@@ -142,6 +142,28 @@ stamped with the old CAD table default, and the migration deliberately does not
 rewrite them, since "the user chose CAD" and "MCP never sent a currency" are
 indistinguishable after the fact.
 
+## Editing a loan (2026-08-05)
+
+`PUT /api/loans` has existed since v2 but nothing in the app called it, so a
+loan was create-or-delete only in the browser — including when its currency was
+wrong. The loan card now carries an **Edit** action.
+
+Create and edit share **one** `DialogContent` and **one** `buildPayload()`,
+switched solely by an `editingLoan` state flag: add a field to the form and it
+becomes editable in the same change. Keep it that way — a second dialog or a
+second payload shape is how the two modes drift apart.
+
+- The edit form seeds from the loan's **native** fields, never the converted
+  `*Display` companions; seeding from those would rewrite the principal in the
+  display currency on save.
+- Changing the currency **re-denominates** (re-labels the stored numbers) and
+  never converts, matching `manage_loans(op:update)`. An inline amber note
+  appears as soon as the picker changes, and saving routes through a
+  `ConfirmDialog` that spells out what will happen.
+- The save handler follows the standard contract: a `saving` re-entry guard
+  (`/api/loans` has no idempotency key), a `try/catch` around the request, and
+  `parseSaveError` on `!res.ok` with the dialog left open and input preserved.
+
 ## Deferred (Phase 4 — tracked on FINLYNQ-136)
 
 - Posting the principal/interest split into `transactions` (principal =

--- a/docs/loans.md
+++ b/docs/loans.md
@@ -104,6 +104,44 @@ posting starts writing transactions — nothing here blocks it.
   instead of throwing. Same for the **stdio** read tools (stdio writes still
   refuse per Stream D Phase 4).
 
+## Currency (2026-08-05)
+
+A loan is denominated in `loans.currency`, resolved on create as **explicit >
+linked account's currency > the user's display currency** via the shared pure
+`pickRecordCurrency` ([src/lib/fx/record-currency.ts](../src/lib/fx/record-currency.ts)).
+The column default is USD and exists only as a backstop.
+
+Every read surface is **dual basis**, matching accounts and transactions:
+
+- Amounts stay in the loan's **own** currency — that is what
+  `buildLoanSchedule` computed, and what the schedule/amortization/what-if
+  tables display.
+- Each row also carries an **additive current-rate companion** for totalling
+  across a mixed-currency book: `remainingBalanceDisplay` /
+  `monthlyEquivalentPaymentDisplay` (REST `GET /api/loans`, alongside
+  `displayCurrency`) and `remainingBalanceReporting` /
+  `monthlyEquivalentPaymentReporting` (MCP `manage_loans(op:list)`, alongside
+  `reportingCurrency`). **Only these may be summed** (FINLYNQ-123) — the
+  Total Debt / Monthly Payments tiles read them and caveat "converted at
+  today's rates" whenever a foreign-currency loan is present.
+
+`get_debt_payoff_plan` **converts balances and minimum payments into
+`reportingCurrency` before ranking**, on both transports. This is a
+correctness fix, not a labelling one: snowball orders by balance and the single
+`extra_payment` budget is pooled across every debt, so an unconverted foreign
+balance could outrank every other debt purely on magnitude and absorb the whole
+budget. `inputs.debts` echoes each loan's native currency and amount next to the
+converted figures; `extra_payment` is interpreted in `reportingCurrency`.
+Interest **rates are percentages and are never converted** — avalanche ordering
+was always sound.
+
+`manage_loans` add/update accept `currency`. On update it **re-denominates**
+the loan (reinterprets the stored numbers); it does not convert them. That is
+the repair path for loans created before the parameter existed — those were
+stamped with the old CAD table default, and the migration deliberately does not
+rewrite them, since "the user chose CAD" and "MCP never sent a currency" are
+indistinguishable after the fact.
+
 ## Deferred (Phase 4 — tracked on FINLYNQ-136)
 
 - Posting the principal/interest split into `transactions` (principal =

--- a/mcp-server/register-core-tools.ts
+++ b/mcp-server/register-core-tools.ts
@@ -24,6 +24,8 @@ import {
   validateCurrencyCode,
   validateFxDate,
   collapseLegSources,
+  getRateMap,
+  convertWithRateMap,
 } from "../src/lib/fx-service.js";
 import { SUPPORTED_CURRENCIES } from "../src/lib/fx/supported-currencies.js";
 import { resolveTxAmountsCore } from "../src/lib/currency-conversion.js";
@@ -2041,7 +2043,9 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
         data: {
           loanId: loan_id,
           // Stream D Phase 4: loanName omitted on stdio (cannot decrypt name_ct).
-          loanCurrency: loan.currency ?? "CAD",
+          // FINLYNQ-183/284: never a CAD literal — a loan with no explicit
+          // currency reads as the user's own reporting currency.
+          loanCurrency: String(loan.currency ?? reporting).toUpperCase(),
           reportingCurrency: reporting,
           asOfDate: cutoff,
           monthlyPayment: summary.monthlyPayment,
@@ -2070,7 +2074,7 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
   // ── get_debt_payoff_plan ──────────────────────────────────────────────────
   server.tool(
     "get_debt_payoff_plan",
-    "Compare avalanche vs snowball payoff across all user loans. Loan balances stay in each loan's own currency; reportingCurrency is surfaced as metadata.",
+    "Compare avalanche vs snowball payoff across all user loans. Balances and minimum payments are converted to reportingCurrency before ranking and before the shared extra_payment budget is applied; `inputs.debts` echoes each loan's native currency and amount. extra_payment is interpreted in reportingCurrency.",
     {
       strategy: z.enum(["avalanche", "snowball", "both"]).optional(),
       extra_payment: z.number().optional(),
@@ -2079,14 +2083,24 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
     async ({ strategy, extra_payment, reportingCurrency }) => {
       const reporting = await resolveReportingCurrencyStdio(sqlite, userId, reportingCurrency);
       const loans = await sqlite.prepare(
-        `SELECT id, principal, annual_rate, term_months, start_date, payment_amount, payment_frequency, extra_payment, residual_value FROM loans WHERE user_id = ?`
+        `SELECT id, principal, annual_rate, term_months, start_date, payment_amount, payment_frequency, extra_payment, residual_value, currency FROM loans WHERE user_id = ?`
       ).all(userId) as SqliteRow[];
       if (!loans.length) return txt({ success: true, data: { message: "No loans found", strategies: {} } });
+      // FINLYNQ-123: snowball ranks by balance and the extra_payment budget is
+      // pooled across every debt, so all balances must share one currency
+      // first. Mirrors the HTTP tool in mcp-server/tools/loans.ts.
+      const rateMap = await getRateMap(reporting, userId);
       const today = new Date().toISOString().split("T")[0];
       // Issue #213 — split out legacy bad rows so one bad start_date no
       // longer poisons the whole strategy computation.
       const excluded: Array<{ loanId: number; error: string; value: unknown }> = [];
       const debts: Debt[] = [];
+      // Native-currency echo alongside the converted figures the strategy uses.
+      const debtsNative: Array<{
+        id: number; currency: string;
+        nativeBalance: number; nativeMinPayment: number;
+        balance: number; minPayment: number;
+      }> = [];
       for (const l of loans) {
         if (parseYmdSafe(String(l.start_date)) === null) {
           excluded.push({ loanId: Number(l.id), error: "invalid start_date", value: l.start_date });
@@ -2113,20 +2127,35 @@ export function registerCoreTools(server: McpServer, sqlite: PgCompatDb, opts: C
         }
         const paid = summary.schedule.filter((r) => r.date <= today);
         const principalPaid = paid.reduce((s, r) => s + r.principal, 0);
-        const balance = Math.max(Number(l.principal) - principalPaid, 0);
-        const minPayment = Number(l.payment_amount ?? summary.monthlyPayment);
+        const nativeBalance = Math.round(Math.max(Number(l.principal) - principalPaid, 0) * 100) / 100;
+        const nativeMinPayment = Number(l.payment_amount ?? summary.monthlyPayment);
+        const loanCurrency = String(l.currency ?? reporting).toUpperCase();
+        const balance = Math.round(convertWithRateMap(nativeBalance, loanCurrency, rateMap) * 100) / 100;
+        const minPayment = Math.round(convertWithRateMap(nativeMinPayment, loanCurrency, rateMap) * 100) / 100;
         debts.push({
           id: Number(l.id),
           // Stream D Phase 4: stdio cannot decrypt loan name — surface id only.
           name: `Loan #${Number(l.id)}`,
-          balance: Math.round(balance * 100) / 100,
+          balance,
           rate: Number(l.annual_rate),
+          minPayment,
+        });
+        debtsNative.push({
+          id: Number(l.id),
+          currency: loanCurrency,
+          nativeBalance,
+          nativeMinPayment,
+          balance,
           minPayment,
         });
       }
       const strat = strategy ?? "both";
       const extra = extra_payment ?? 0;
-      const result: Record<string, unknown> = { inputs: { extraPayment: extra, debts }, reportingCurrency: reporting };
+      const result: Record<string, unknown> = {
+        inputs: { extraPayment: extra, extraPaymentCurrency: reporting, debts: debtsNative },
+        reportingCurrency: reporting,
+        amountsConvertedTo: reporting,
+      };
       if (excluded.length) result.excluded = excluded;
       if (strat === "avalanche" || strat === "both") result.avalanche = calculateDebtPayoff(debts, extra, "avalanche");
       if (strat === "snowball" || strat === "both") result.snowball = calculateDebtPayoff(debts, extra, "snowball");

--- a/mcp-server/tools/loans.ts
+++ b/mcp-server/tools/loans.ts
@@ -39,6 +39,11 @@ import {
   resolveReportingCurrency,
 } from "../reporting-currency";
 import {
+  getRateMap,
+  convertWithRateMap,
+} from "../../src/lib/fx-service";
+import { pickRecordCurrency } from "../../src/lib/fx/record-currency";
+import {
   ymdDate,
   parseYmdSafe,
 } from "../lib/date-validators";
@@ -63,7 +68,8 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
       const rawRows = await q(db, sql`
         SELECT l.id, l.name_ct, l.type, l.principal, l.annual_rate, l.term_months,
                l.start_date, l.payment_amount, l.payment_frequency, l.extra_payment,
-               l.residual_value, l.note, l.account_id, a.name_ct AS account_name_ct
+               l.residual_value, l.note, l.account_id, l.currency,
+               a.name_ct AS account_name_ct
         FROM loans l
         LEFT JOIN accounts a ON a.id = l.account_id
         WHERE l.user_id = ${userId}
@@ -92,10 +98,22 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
           acctBalances.set(Number(b.account_id), { balance: Number(b.balance), txCount: Number(b.tx_count) });
         }
       }
+      // FINLYNQ-123 dual basis: amounts stay in each loan's own currency and
+      // each row also carries a current-rate conversion, so an assistant can
+      // both quote a loan correctly and total a mixed-currency book.
+      const reporting = await resolveReportingCurrency(db, userId, null);
+      const rateMap = await getRateMap(reporting, userId);
       const today = new Date().toISOString().split("T")[0];
       const enriched = rows.map((r) => {
+        const loanCurrency = String(r.currency ?? reporting).toUpperCase();
+        const toReporting = (amount: number | null) =>
+          amount == null ? null : Math.round(convertWithRateMap(amount, loanCurrency, rateMap) * 100) / 100;
         const integrityRow = (error: string, value: unknown) => ({
           ...r,
+          currency: loanCurrency,
+          reportingCurrency: reporting,
+          remainingBalanceReporting: null,
+          monthlyEquivalentPaymentReporting: null,
           monthlyPayment: null,
           totalInterest: null,
           payoffDate: null,
@@ -177,6 +195,10 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
               : Math.round(principalPaid * 100) / 100,
           interestPaid: Math.round(interestPaid * 100) / 100,
           periodsRemaining,
+          currency: loanCurrency,
+          reportingCurrency: reporting,
+          remainingBalanceReporting: toReporting(remainingBalance),
+          monthlyEquivalentPaymentReporting: toReporting(summary.monthlyEquivalentPayment),
         };
       });
       return text({ success: true, data: enriched });
@@ -197,9 +219,10 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
     extra_payment?: number;
     residual_value?: number;
     min_payment?: number;
+    currency?: string;
     note?: string;
   }): Promise<ToolResult> {
-      const { name, type, principal, annual_rate, term_months, start_date, account, account_id, payment_amount, payment_frequency, extra_payment, residual_value, min_payment, note } = args;
+      const { name, type, principal, annual_rate, term_months, start_date, account, account_id, payment_amount, payment_frequency, extra_payment, residual_value, min_payment, currency, note } = args;
       // FINLYNQ-267: resolve the optional linked account via the shared envelope
       // — a mistyped/unmatched name is REFUSED (not silently unlinked) and a 2+
       // match returns an ambiguous list; `account_id` is the FK fast-path.
@@ -234,15 +257,31 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
         if (e instanceof LoanValidationError) return err(e.message);
         throw e;
       }
+      // Currency resolution (feedback #7): explicit > linked account > display.
+      // This INSERT used to omit the column entirely, so every MCP-created loan
+      // silently took the table default — which was CAD.
+      let accountCurrency: string | null = null;
+      if (accountId != null) {
+        const acctRow = await q(db, sql`
+          SELECT currency FROM accounts WHERE id = ${accountId} AND user_id = ${userId}
+        `);
+        accountCurrency = (acctRow[0]?.currency as string | undefined) ?? null;
+      }
+      const loanCurrency = pickRecordCurrency({
+        explicit: currency,
+        accountCurrency,
+        displayCurrency: await resolveReportingCurrency(db, userId, null),
+      });
       const n = dek ? encryptName(dek, name) : { ct: null, lookup: null };
       // Stream D Phase 4 — plaintext name dropped.
       const result = await q(db, sql`
-        INSERT INTO loans (user_id, type, account_id, principal, annual_rate, term_months, start_date, payment_amount, payment_frequency, extra_payment, residual_value, note, name_ct, name_lookup)
-        VALUES (${userId}, ${type}, ${accountId}, ${principal}, ${annual_rate}, ${term_months ?? null}, ${start_date}, ${pmt}, ${payment_frequency ?? "monthly"}, ${extra_payment ?? 0}, ${residual_value ?? null}, ${encNote(note)}, ${n.ct}, ${n.lookup})
+        INSERT INTO loans (user_id, type, account_id, currency, principal, annual_rate, term_months, start_date, payment_amount, payment_frequency, extra_payment, residual_value, note, name_ct, name_lookup)
+        VALUES (${userId}, ${type}, ${accountId}, ${loanCurrency}, ${principal}, ${annual_rate}, ${term_months ?? null}, ${start_date}, ${pmt}, ${payment_frequency ?? "monthly"}, ${extra_payment ?? 0}, ${residual_value ?? null}, ${encNote(note)}, ${n.ct}, ${n.lookup})
         RETURNING id
       `);
       const termDesc = term_months != null ? `over ${term_months} months` : `at ${pmt}/${payment_frequency ?? "monthly"} (payment-driven)`;
-      return text({ success: true, data: { id: result[0]?.id, message: `Loan "${name}" created — $${principal} at ${annual_rate}% ${termDesc}` } });
+      // Report the currency rather than a bare `$` — the amount is not USD.
+      return text({ success: true, data: { id: result[0]?.id, currency: loanCurrency, message: `Loan "${name}" created — ${principal} ${loanCurrency} at ${annual_rate}% ${termDesc}` } });
   }
 
   // ── op: update — lifted VERBATIM from update_loan ──────────────────────────
@@ -260,9 +299,10 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
     residual_value?: number;
     account?: string;
     account_id?: number;
+    currency?: string;
     note?: string;
   }): Promise<ToolResult> {
-      const { id, name, type, principal, annual_rate, term_months, start_date, payment_amount, payment_frequency, extra_payment, residual_value, account, account_id, note } = args;
+      const { id, name, type, principal, annual_rate, term_months, start_date, payment_amount, payment_frequency, extra_payment, residual_value, account, account_id, currency, note } = args;
       const existing = await q(db, sql`
         SELECT id, principal, annual_rate, term_months, start_date, payment_amount,
                payment_frequency, extra_payment, residual_value
@@ -333,6 +373,9 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
       if (extra_payment !== undefined) updates.push(sql`extra_payment = ${extra_payment}`);
       if (residual_value !== undefined) updates.push(sql`residual_value = ${residual_value}`);
       if (accountIdUpdate !== undefined) updates.push(sql`account_id = ${accountIdUpdate}`);
+      // Re-denominates the loan; it does NOT convert the stored amounts. This
+      // is the repair path for a loan created before the currency was settable.
+      if (currency !== undefined) updates.push(sql`currency = ${currency.toUpperCase()}`);
       if (note !== undefined) updates.push(sql`note = ${encNote(note)}`);
       if (!updates.length) return err("No fields to update");
 
@@ -365,7 +408,7 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
   registerManageTool(
     server,
     "manage_loans",
-    "Manage loans & debt: `op` selects add / update / delete / list. add: create a loan or lease (principal/rate + term_months OR payment_amount; residual_value for leases). update: change any loan field by id. delete: remove a loan by id. list: all loans with balance/rate/payment/payoff date/linked account. For amortization schedules or payoff strategies use get_loan_amortization / get_debt_payoff_plan.",
+    "Manage loans & debt: `op` selects add / update / delete / list. add: create a loan or lease (principal/rate + term_months OR payment_amount; residual_value for leases; `currency` defaults to the linked account's, else the user's display currency). update: change any loan field by id. delete: remove a loan by id. list: all loans with balance/rate/payment/payoff date/linked account — amounts are in each loan's own `currency`, with `*Reporting` companions converted to `reportingCurrency` for totalling across currencies. For amortization schedules or payoff strategies use get_loan_amortization / get_debt_payoff_plan.",
     z.discriminatedUnion("op", [
       z.object({
         op: z.literal("add"),
@@ -382,6 +425,7 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
         extra_payment: z.number().nonnegative().optional().describe("Extra principal per payment (must be >= 0; default 0)"),
         residual_value: z.number().nonnegative().optional().describe("Lease residual/buyout — the schedule amortizes down to this instead of 0 (must be < principal)"),
         min_payment: z.number().positive().optional().describe("Alias for payment_amount — minimum required payment (must be > 0)"),
+        currency: z.string().regex(/^[A-Za-z]{3,4}$/).optional().describe("ISO code the loan is denominated in, e.g. 'RUB'. Defaults to the linked account's currency, else the user's display currency — never a hardcoded default."),
         note: z.string().optional(),
       }),
       z.object({
@@ -399,6 +443,7 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
         residual_value: z.number().nonnegative().optional().describe("Lease residual/buyout — balance remaining at term end (must be < principal)"),
         account: z.string().optional().describe("Linked account — name or alias (fuzzy matched — mistyped/unmatched is REFUSED; 2+ → ambiguous). Pass empty string to clear. PREFER `account_id`."),
         account_id: z.number().int().positive().optional().describe("Linked-account FK fast-path — wins over the fuzzy `account` name."),
+        currency: z.string().regex(/^[A-Za-z]{3,4}$/).optional().describe("ISO code the loan is denominated in. Changes the currency the stored amounts are interpreted in — it does NOT convert them."),
         note: z.string().optional(),
       }),
       z.object({
@@ -479,7 +524,9 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
         data: {
           loanId: loan_id,
           loanName: loan.name,
-          loanCurrency: loan.currency ?? "CAD",
+          // FINLYNQ-183/284: never a CAD literal. A loan predating an explicit
+          // currency reads as the user's own reporting currency, not Canada's.
+          loanCurrency: String(loan.currency ?? reporting).toUpperCase(),
           reportingCurrency: reporting,
           asOfDate: cutoff,
           monthlyPayment: summary.monthlyPayment,
@@ -510,7 +557,7 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
   // ── get_debt_payoff_plan ──────────────────────────────────────────────────
   server.tool(
     "get_debt_payoff_plan",
-    "Compare debt payoff strategies (avalanche vs snowball) across all user loans with an optional extra monthly payment. Loan balances stay in each loan's own currency; the response includes the resolved reportingCurrency for cross-currency context.",
+    "Compare debt payoff strategies (avalanche vs snowball) across all user loans with an optional extra monthly payment. Balances and minimum payments are converted to reportingCurrency before ranking and before the shared extra_payment budget is applied, so a mixed-currency book is compared like for like; `inputs.debts` echoes each loan's native currency and amount alongside the converted figures. extra_payment is interpreted in reportingCurrency.",
     {
       strategy: z.enum(["avalanche", "snowball", "both"]).optional().describe("'avalanche' (highest rate first), 'snowball' (smallest balance first), or 'both' (default)"),
       extra_payment: z.number().optional().describe("Extra monthly payment to apply on top of minimums (default 0)"),
@@ -521,17 +568,31 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
       // Stream D Phase 4: l.name dropped — read l.name_ct only.
       const loansRaw = await q(db, sql`
         SELECT id, name_ct, principal, annual_rate, term_months, start_date,
-               payment_amount, payment_frequency, extra_payment, residual_value
+               payment_amount, payment_frequency, extra_payment, residual_value,
+               currency
         FROM loans WHERE user_id = ${userId}
       `);
       if (!loansRaw.length) return text({ success: true, data: { message: "No loans found", strategies: {} } });
       const loans = decryptNameish(loansRaw, dek);
+      // FINLYNQ-123: this tool RANKS loans against each other (snowball orders
+      // by balance) and pools one `extra_payment` budget across all of them, so
+      // every balance and minimum must be in ONE currency first. Without this
+      // an ₽8.1M loan outranked every USD debt by ~80x and consumed the whole
+      // extra budget — the strategy itself came out wrong, not just its labels.
+      const rateMap = await getRateMap(reporting, userId);
       const today = new Date().toISOString().split("T")[0];
       // Issue #213 — split out legacy bad rows so one bad start_date no
       // longer poisons the whole strategy computation. The bad rows still
       // surface to the caller (`excluded`) so they can be fixed.
       const excluded: Array<{ loanId: number; error: string; value: unknown }> = [];
       const debts: Debt[] = [];
+      // Native-currency echo so the caller can see what each figure was before
+      // conversion — the converted `debts` array is what drives the strategy.
+      const debtsNative: Array<{
+        id: number; name: string; currency: string;
+        nativeBalance: number; nativeMinPayment: number;
+        balance: number; minPayment: number;
+      }> = [];
       for (const l of loans) {
         if (parseYmdSafe(String(l.start_date)) === null) {
           excluded.push({ loanId: Number(l.id), error: "invalid start_date", value: l.start_date });
@@ -558,19 +619,39 @@ export function registerLoansTools(server: McpServer, ctx: PgToolContext) {
         }
         const paid = summary.schedule.filter((r) => r.date <= today);
         const principalPaid = paid.reduce((s, r) => s + r.principal, 0);
-        const balance = Math.max(Number(l.principal) - principalPaid, 0);
-        const minPayment = Number(l.payment_amount ?? summary.monthlyPayment);
+        const nativeBalance = Math.round(Math.max(Number(l.principal) - principalPaid, 0) * 100) / 100;
+        const nativeMinPayment = Number(l.payment_amount ?? summary.monthlyPayment);
+        const loanCurrency = String(l.currency ?? reporting).toUpperCase();
+        const balance = Math.round(convertWithRateMap(nativeBalance, loanCurrency, rateMap) * 100) / 100;
+        const minPayment = Math.round(convertWithRateMap(nativeMinPayment, loanCurrency, rateMap) * 100) / 100;
         debts.push({
           id: Number(l.id),
           name: String(l.name),
-          balance: Math.round(balance * 100) / 100,
+          // Rate is a percentage — comparable across currencies as-is, so the
+          // avalanche ordering was always sound; only snowball/pooling broke.
+          balance,
           rate: Number(l.annual_rate),
+          minPayment,
+        });
+        debtsNative.push({
+          id: Number(l.id),
+          name: String(l.name),
+          currency: loanCurrency,
+          nativeBalance,
+          nativeMinPayment,
+          balance,
           minPayment,
         });
       }
       const strat = strategy ?? "both";
       const extra = extra_payment ?? 0;
-      const result: Record<string, unknown> = { inputs: { extraPayment: extra, debts }, reportingCurrency: reporting };
+      const result: Record<string, unknown> = {
+        // `extraPayment` is the caller's pooled budget and is interpreted in
+        // the reporting currency, same as every converted balance below.
+        inputs: { extraPayment: extra, extraPaymentCurrency: reporting, debts: debtsNative },
+        reportingCurrency: reporting,
+        amountsConvertedTo: reporting,
+      };
       if (excluded.length) result.excluded = excluded;
       if (strat === "avalanche" || strat === "both") {
         result.avalanche = calculateDebtPayoff(debts, extra, "avalanche");

--- a/scripts/migrations/20260805_loans_currency_default_usd.sql
+++ b/scripts/migrations/20260805_loans_currency_default_usd.sql
@@ -1,0 +1,31 @@
+-- Loans: default `currency` to USD instead of CAD.
+--
+-- `loans.currency` has existed since Loans v2 (FINLYNQ-136) and the REST
+-- create/update path has always persisted it, but nothing else did:
+--
+--   * MCP `manage_loans(op:add)` omitted the column from its INSERT entirely,
+--     so every loan created through an AI assistant silently took this
+--     default.
+--   * The web `/loans` page never read the column back, formatting every
+--     amount in the user's display currency instead.
+--
+-- The second half is a UI fix (same commit). This migration closes the first:
+-- a CAD default contradicts the app-wide "default display currency = USD"
+-- convention (FINLYNQ-183) and the MCP resolver's own USD terminal fallback
+-- (FINLYNQ-284, `resolveReportingCurrency`). It is the same class of bug as
+-- the `?? "CAD"` literal that stamped auto-detected subscriptions CAD for a
+-- user holding only MXN/USD (feedback #7).
+--
+-- EXISTING ROWS ARE DELIBERATELY NOT REWRITTEN. A loan already stamped 'CAD'
+-- may genuinely be a CAD loan; we cannot distinguish "the user chose CAD"
+-- from "MCP never sent a currency and the default filled in". Guessing would
+-- silently restate someone's debt. Loans are still dev-mode-gated
+-- (`requireDevMode` 404s the route, `DevModeGuard` redirects the page), so the
+-- affected population is small and can correct a loan in the UI, which now
+-- shows the currency it is actually stored in.
+--
+-- After this, the default is only ever a backstop: all three write paths
+-- (REST POST, REST PUT, MCP manage_loans add/update) resolve the currency
+-- explicitly as explicit > linked account's currency > display currency.
+
+ALTER TABLE loans ALTER COLUMN currency SET DEFAULT 'USD';

--- a/src/app/(app)/loans/page.tsx
+++ b/src/app/(app)/loans/page.tsx
@@ -33,6 +33,13 @@ type Loan = {
   remainingBalance: number; balanceSource: "account" | "projection" | null;
   principalPaid: number; interestPaid: number; periodsRemaining: number;
   accountName: string | null;
+  // FINLYNQ-123 dual basis. Every amount above is in `currency` (the loan's
+  // own). The `*Display` companions are the server's current-rate conversion
+  // into `displayCurrency` and are the ONLY figures safe to sum across loans.
+  currency: string;
+  displayCurrency: string;
+  remainingBalanceDisplay: number | null;
+  monthlyEquivalentPaymentDisplay: number | null;
 };
 type AmortRow = { period: number; date: string; payment: number; principal: number; interest: number; balance: number };
 type AccrualRow = { month: string; interest: number };
@@ -61,7 +68,7 @@ function equivalentTermMonths(loan: Loan): number {
   return Math.max(1, Math.round((loan.periodsRemaining / perYear) * 12));
 }
 type WhatIf = { extraPayment: number; monthsSaved: number; interestSaved: number; newPayoffDate: string; totalInterest: number };
-type Account = { id: number; name: string };
+type Account = { id: number; name: string; currency?: string | null };
 
 const LOAN_TYPE_COLORS: Record<string, string> = {
   mortgage: "border-l-indigo-500",
@@ -231,9 +238,16 @@ function LoansPageContent() {
 
   const deletingLoan = loans.find((l) => l.id === deleteId) ?? null;
 
-  const totalDebt = loans.reduce((s, l) => s + (l.remainingBalance ?? 0), 0);
+  // FINLYNQ-123: totals sum the server's converted figures, NOT the native
+  // ones. Adding a ₽8,116,000 balance to a USD book and labelling the result
+  // "$" is an ~80x overstatement. `*Display` is null only for a row the server
+  // couldn't schedule (dataIntegrity), which contributes nothing either way.
+  const totalDebt = loans.reduce((s, l) => s + (l.remainingBalanceDisplay ?? 0), 0);
   // Monthly-equivalent so weekly/quarterly/annual loans sum comparably.
-  const totalMonthly = loans.reduce((s, l) => s + (l.monthlyEquivalentPayment ?? l.monthlyPayment ?? 0), 0);
+  const totalMonthly = loans.reduce((s, l) => s + (l.monthlyEquivalentPaymentDisplay ?? 0), 0);
+  // Whether any loan is booked in something other than the display currency —
+  // drives the "converted at today's rate" caveat on the two total tiles.
+  const hasForeignLoan = loans.some((l) => l.currency && l.currency !== displayCurrency);
 
   if (loading) return <LoansSkeleton />;
   if (loadError) return <ErrorState title="Couldn't load loans" message="We couldn't load your loans. Please try again." onRetry={() => { setLoading(true); load(); }} />;
@@ -245,7 +259,12 @@ function LoansPageContent() {
           <h1 className="text-2xl font-bold">Loans & Debt</h1>
           <p className="text-sm text-muted-foreground mt-1">Track balances, amortization schedules, and payoff strategies</p>
         </div>
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        {/* `displayCurrency` starts at the USD default and only resolves once
+            /api/auth/session lands, so the useState initializer above captures
+            USD for everyone. Re-seed on open — otherwise a RUB user is shown
+            USD preselected and the form SENDS it, persisting the wrong
+            currency rather than merely displaying one. */}
+        <Dialog open={dialogOpen} onOpenChange={(open) => { if (open) setForm((f) => ({ ...f, currency: displayCurrency })); setDialogOpen(open); }}>
           <DialogTrigger render={<Button id="add-loan-btn" />}><Plus className="h-4 w-4 mr-1" /> Add Loan</DialogTrigger>
           <DialogContent>
             <DialogHeader><DialogTitle>Add Loan</DialogTitle></DialogHeader>
@@ -328,7 +347,13 @@ function LoansPageContent() {
               <div><Label>Linked Account</Label>
                 <Combobox
                   value={form.accountId}
-                  onValueChange={(v) => setForm({ ...form, accountId: v })}
+                  // Mirror the server's precedence (explicit > linked account >
+                  // display currency): picking an account moves the currency
+                  // with it, so the form can't imply one and store another.
+                  onValueChange={(v) => {
+                    const acct = accounts.find((a) => String(a.id) === v);
+                    setForm((f) => ({ ...f, accountId: v, currency: acct?.currency || f.currency }));
+                  }}
                   items={sortAccount(
                     accounts.map((a): ComboboxItemShape => ({ value: String(a.id), label: a.name })),
                     (a) => Number(a.value),
@@ -357,7 +382,10 @@ function LoansPageContent() {
               <CardTitle className="text-sm text-muted-foreground">Total Debt</CardTitle>
             </div>
           </CardHeader>
-          <CardContent><p className="text-2xl font-bold text-rose-600">{formatCurrency(totalDebt, displayCurrency)}</p></CardContent>
+          <CardContent>
+            <p className="text-2xl font-bold text-rose-600">{formatCurrency(totalDebt, displayCurrency)}</p>
+            {hasForeignLoan && <p className="text-xs text-muted-foreground mt-1">converted at today&apos;s rates</p>}
+          </CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-2">
@@ -368,7 +396,10 @@ function LoansPageContent() {
               <CardTitle className="text-sm text-muted-foreground">Monthly Payments</CardTitle>
             </div>
           </CardHeader>
-          <CardContent><p className="text-2xl font-bold">{formatCurrency(totalMonthly, displayCurrency)}</p></CardContent>
+          <CardContent>
+            <p className="text-2xl font-bold">{formatCurrency(totalMonthly, displayCurrency)}</p>
+            {hasForeignLoan && <p className="text-xs text-muted-foreground mt-1">converted at today&apos;s rates</p>}
+          </CardContent>
         </Card>
         <Card>
           <CardHeader className="pb-2">
@@ -405,6 +436,9 @@ function LoansPageContent() {
                 <div className="flex items-center gap-2">
                   <CardTitle>{loan.name}</CardTitle>
                   <Badge variant="secondary" className={badgeClass}>{loan.type}</Badge>
+                  {loan.currency !== displayCurrency && (
+                    <Badge variant="outline" className="font-mono text-xs">{loan.currency}</Badge>
+                  )}
                 </div>
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" onClick={() => viewAmortization(loan)}>View Schedule</Button>
@@ -416,21 +450,24 @@ function LoansPageContent() {
               <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">
                 <div>
                   <p className="text-xs text-muted-foreground">Remaining{loan.balanceSource === "account" && <span className="ml-1 text-emerald-600" title={`Live balance from ${loan.accountName ?? "linked account"}`}>· from account</span>}</p>
-                  <p className="font-mono font-bold text-rose-600">{formatCurrency(loan.remainingBalance, displayCurrency)}</p>
+                  <p className="font-mono font-bold text-rose-600">{formatCurrency(loan.remainingBalance, loan.currency)}</p>
+                  {loan.currency !== displayCurrency && loan.remainingBalanceDisplay != null && (
+                    <p className="text-xs text-muted-foreground font-mono">≈ {formatCurrency(loan.remainingBalanceDisplay, displayCurrency)}</p>
+                  )}
                 </div>
-                <div><p className="text-xs text-muted-foreground">{FREQUENCY_LABELS[loan.paymentFrequency] ?? "Payment"}</p><p className="font-mono">{formatCurrency(loan.paymentPerPeriod ?? loan.monthlyPayment, displayCurrency)}</p></div>
+                <div><p className="text-xs text-muted-foreground">{FREQUENCY_LABELS[loan.paymentFrequency] ?? "Payment"}</p><p className="font-mono">{formatCurrency(loan.paymentPerPeriod ?? loan.monthlyPayment, loan.currency)}</p></div>
                 <div><p className="text-xs text-muted-foreground">Rate</p><p className="font-mono">{loan.annualRate}%</p></div>
-                <div><p className="text-xs text-muted-foreground">Total Interest</p><p className="font-mono">{formatCurrency(loan.totalInterest, displayCurrency)}</p></div>
+                <div><p className="text-xs text-muted-foreground">Total Interest</p><p className="font-mono">{formatCurrency(loan.totalInterest, loan.currency)}</p></div>
                 <div>
                   <p className="text-xs text-muted-foreground">{loan.type === "lease" ? "Term end" : "Payoff"}</p>
                   <p className="font-mono">{loan.payoffDate}</p>
                   {loan.type === "lease" && loan.residualValue != null && loan.residualValue > 0 && (
-                    <p className="text-xs text-muted-foreground">residual {formatCurrency(loan.residualValue, displayCurrency)}</p>
+                    <p className="text-xs text-muted-foreground">residual {formatCurrency(loan.residualValue, loan.currency)}</p>
                   )}
                 </div>
               </div>
               <div className="space-y-1">
-                <div className="flex justify-between text-xs"><span>Principal paid: {formatCurrency(loan.principalPaid, displayCurrency)}</span><span>{Math.round(paidPct)}%</span></div>
+                <div className="flex justify-between text-xs"><span>Principal paid: {formatCurrency(loan.principalPaid, loan.currency)}</span><span>{Math.round(paidPct)}%</span></div>
                 <CspSafeBar
                   percent={paidPct}
                   className="bg-rose-200"
@@ -446,7 +483,9 @@ function LoansPageContent() {
       {/* Amortization detail modal */}
       {selectedLoan && amort && (
         <Card>
-          <CardHeader><CardTitle>Amortization: {selectedLoan.name}</CardTitle></CardHeader>
+          {/* Every figure in this panel comes from the schedule the server
+              computed in the loan's OWN currency — never the display one. */}
+          <CardHeader><CardTitle>Amortization: {selectedLoan.name} <span className="text-sm font-normal text-muted-foreground font-mono">({selectedLoan.currency})</span></CardTitle></CardHeader>
           <CardContent>
             <Tabs defaultValue="chart">
               <TabsList><TabsTrigger value="chart">Chart</TabsTrigger><TabsTrigger value="table">Table</TabsTrigger><TabsTrigger value="monthly">Monthly Interest</TabsTrigger><TabsTrigger value="whatif">What-If</TabsTrigger></TabsList>
@@ -471,7 +510,7 @@ function LoansPageContent() {
                     <TableHeader><TableRow><TableHead>#</TableHead><TableHead>Date</TableHead><TableHead>Payment</TableHead><TableHead>Principal</TableHead><TableHead>Interest</TableHead><TableHead>Balance</TableHead></TableRow></TableHeader>
                     <TableBody>
                       {amort.schedule.map((r) => (
-                        <TableRow key={r.period}><TableCell>{r.period}</TableCell><TableCell>{r.date}</TableCell><TableCell>{formatCurrency(r.payment, displayCurrency)}</TableCell><TableCell className="text-emerald-600">{formatCurrency(r.principal, displayCurrency)}</TableCell><TableCell className="text-rose-600">{formatCurrency(r.interest, displayCurrency)}</TableCell><TableCell className="font-mono">{formatCurrency(r.balance, displayCurrency)}</TableCell></TableRow>
+                        <TableRow key={r.period}><TableCell>{r.period}</TableCell><TableCell>{r.date}</TableCell><TableCell>{formatCurrency(r.payment, selectedLoan.currency)}</TableCell><TableCell className="text-emerald-600">{formatCurrency(r.principal, selectedLoan.currency)}</TableCell><TableCell className="text-rose-600">{formatCurrency(r.interest, selectedLoan.currency)}</TableCell><TableCell className="font-mono">{formatCurrency(r.balance, selectedLoan.currency)}</TableCell></TableRow>
                       ))}
                     </TableBody>
                   </Table>
@@ -484,19 +523,19 @@ function LoansPageContent() {
                     <TableHeader><TableRow><TableHead>Month</TableHead><TableHead>Interest Accrued</TableHead></TableRow></TableHeader>
                     <TableBody>
                       {(amort.monthlyAccrual ?? []).map((m) => (
-                        <TableRow key={m.month}><TableCell className="font-mono">{m.month}</TableCell><TableCell className="text-rose-600 font-mono">{formatCurrency(m.interest, displayCurrency)}</TableCell></TableRow>
+                        <TableRow key={m.month}><TableCell className="font-mono">{m.month}</TableCell><TableCell className="text-rose-600 font-mono">{formatCurrency(m.interest, selectedLoan.currency)}</TableCell></TableRow>
                       ))}
                     </TableBody>
                   </Table>
                 </div>
               </TabsContent>
               <TabsContent value="whatif">
-                <p className="text-sm text-muted-foreground mb-4">What if you added extra monthly payments?</p>
+                <p className="text-sm text-muted-foreground mb-4">What if you added extra monthly payments? Amounts are in {selectedLoan.currency}.</p>
                 <Table>
                   <TableHeader><TableRow><TableHead>Extra/Month</TableHead><TableHead>Months Saved</TableHead><TableHead>Interest Saved</TableHead><TableHead>New Payoff</TableHead></TableRow></TableHeader>
                   <TableBody>
                     {whatIf.map((w) => (
-                      <TableRow key={w.extraPayment}><TableCell className="font-mono">{formatCurrency(w.extraPayment, displayCurrency)}</TableCell><TableCell className="text-emerald-600 font-bold">{w.monthsSaved} months</TableCell><TableCell className="text-emerald-600 font-bold">{formatCurrency(w.interestSaved, displayCurrency)}</TableCell><TableCell>{w.newPayoffDate}</TableCell></TableRow>
+                      <TableRow key={w.extraPayment}><TableCell className="font-mono">{formatCurrency(w.extraPayment, selectedLoan.currency)}</TableCell><TableCell className="text-emerald-600 font-bold">{w.monthsSaved} months</TableCell><TableCell className="text-emerald-600 font-bold">{formatCurrency(w.interestSaved, selectedLoan.currency)}</TableCell><TableCell>{w.newPayoffDate}</TableCell></TableRow>
                     ))}
                   </TableBody>
                 </Table>

--- a/src/app/(app)/loans/page.tsx
+++ b/src/app/(app)/loans/page.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Combobox, type ComboboxItemShape } from "@/components/ui/combobox";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useDropdownOrder } from "@/components/dropdown-order-provider";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -18,10 +18,11 @@ import { formatCurrency } from "@/lib/currency";
 import { useDisplayCurrency } from "@/components/currency-provider";
 import { useActiveCurrencies } from "@/lib/hooks/useActiveCurrencies";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, BarChart, Bar, Legend } from "recharts";
-import { Plus, Trash2, Landmark, CreditCard, FileText, Calendar } from "lucide-react";
+import { Plus, Pencil, Trash2, Landmark, CreditCard, FileText, Calendar } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { ErrorState } from "@/components/error-state";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { parseSaveError } from "@/lib/save-error";
 import { CspSafeBar } from "@/components/csp-safe-bar";
 
 type Loan = {
@@ -33,6 +34,7 @@ type Loan = {
   remainingBalance: number; balanceSource: "account" | "projection" | null;
   principalPaid: number; interestPaid: number; periodsRemaining: number;
   accountName: string | null;
+  accountId: number | null;
   // FINLYNQ-123 dual basis. Every amount above is in `currency` (the loan's
   // own). The `*Display` companions are the server's current-rate conversion
   // into `displayCurrency` and are the ONLY figures safe to sum across loans.
@@ -152,6 +154,14 @@ function LoansPageContent() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
+  // ONE dialog serves create and edit. `editingLoan` is the only mode switch,
+  // so any field added to the form below is automatically editable too — the
+  // whole reason this isn't a second copy of the layout.
+  const [editingLoan, setEditingLoan] = useState<Loan | null>(null);
+  const [saving, setSaving] = useState(false);
+  // A currency change on an existing loan RE-DENOMINATES it (reinterprets the
+  // stored numbers); it does not convert them. Held here pending confirmation.
+  const [pendingRedenominate, setPendingRedenominate] = useState<{ from: string; to: string } | null>(null);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [deleting, setDeleting] = useState(false);
   const [selectedLoan, setSelectedLoan] = useState<Loan | null>(null);
@@ -179,6 +189,41 @@ function LoansPageContent() {
   }
 
   const isFormValid = form.name.trim() !== "" && form.principal !== "" && parseFloat(form.principal) > 0 && form.annualRate !== "" && parseFloat(form.annualRate) >= 0 && parseFloat(form.annualRate) <= 100 && (form.termMonths !== "" ? parseInt(form.termMonths) > 0 : form.paymentAmount !== "" && parseFloat(form.paymentAmount) > 0) && form.startDate !== "";
+
+  const BLANK_FORM = {
+    name: "", type: "mortgage", principal: "", currency: displayCurrency, annualRate: "",
+    termMonths: "", startDate: "", paymentAmount: "", paymentFrequency: "monthly",
+    extraPayment: "0", residualValue: "", accountId: "",
+  };
+
+  function openCreate() {
+    setEditingLoan(null);
+    setErrors({});
+    setForm({ ...BLANK_FORM, currency: displayCurrency });
+    setDialogOpen(true);
+  }
+
+  function openEdit(loan: Loan) {
+    setEditingLoan(loan);
+    setErrors({});
+    // Seed from the loan's NATIVE fields — never the converted companions, or
+    // saving would silently rewrite the principal in the display currency.
+    setForm({
+      name: loan.name ?? "",
+      type: loan.type,
+      principal: String(loan.principal),
+      currency: loan.currency,
+      annualRate: String(loan.annualRate),
+      termMonths: loan.termMonths == null ? "" : String(loan.termMonths),
+      startDate: loan.startDate,
+      paymentAmount: loan.paymentAmount == null ? "" : String(loan.paymentAmount),
+      paymentFrequency: loan.paymentFrequency,
+      extraPayment: String(loan.extraPayment ?? 0),
+      residualValue: loan.residualValue == null ? "" : String(loan.residualValue),
+      accountId: loan.accountId == null ? "" : String(loan.accountId),
+    });
+    setDialogOpen(true);
+  }
 
   const load = useCallback(() => {
     setLoadError(false);
@@ -208,20 +253,71 @@ function LoansPageContent() {
     setWhatIf(Array.isArray(whatIfRes) ? whatIfRes : []);
   }
 
+  // ONE payload shape for both verbs, so a field added to the form reaches
+  // create and edit together rather than silently working in only one.
+  function buildPayload() {
+    return {
+      name: form.name,
+      type: form.type,
+      principal: parseFloat(form.principal),
+      currency: form.currency || displayCurrency,
+      annualRate: parseFloat(form.annualRate),
+      termMonths: form.termMonths ? parseInt(form.termMonths) : null,
+      startDate: form.startDate,
+      paymentAmount: form.paymentAmount ? parseFloat(form.paymentAmount) : null,
+      paymentFrequency: form.paymentFrequency,
+      extraPayment: parseFloat(form.extraPayment) || 0,
+      residualValue: form.type === "lease" && form.residualValue ? parseFloat(form.residualValue) : null,
+      accountId: form.accountId ? parseInt(form.accountId) : null,
+    };
+  }
+
+  async function doSave() {
+    // `saving` gates re-entry — /api/loans has no idempotency key, so a
+    // double-submit would book the loan twice.
+    if (saving) return;
+    setSaving(true);
+    setPendingRedenominate(null);
+    const editing = editingLoan;
+    try {
+      const res = await fetch("/api/loans", {
+        method: editing ? "PUT" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(editing ? { id: editing.id, ...buildPayload() } : buildPayload()),
+      });
+      if (!res.ok) {
+        // e.g. payment below the period interest, or 423 with no DEK. Keep the
+        // dialog OPEN and the input intact.
+        const message = await parseSaveError(res, editing ? "Failed to save loan" : "Failed to create loan");
+        setErrors((prev) => ({ ...prev, form: message }));
+        return;
+      }
+      setDialogOpen(false);
+      setEditingLoan(null);
+      setForm({ ...BLANK_FORM, currency: displayCurrency });
+      setErrors({});
+      load();
+    } catch {
+      // A thrown fetch (offline, DNS, aborted) would otherwise leave the
+      // dialog sitting there looking like nothing happened.
+      setErrors((prev) => ({ ...prev, form: "Couldn't reach the server. Check your connection and try again." }));
+    } finally {
+      setSaving(false);
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!validateForm()) return;
-    const res = await fetch("/api/loans", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ name: form.name, type: form.type, principal: parseFloat(form.principal), currency: form.currency || displayCurrency, annualRate: parseFloat(form.annualRate), termMonths: form.termMonths ? parseInt(form.termMonths) : null, startDate: form.startDate, paymentAmount: form.paymentAmount ? parseFloat(form.paymentAmount) : null, paymentFrequency: form.paymentFrequency, extraPayment: parseFloat(form.extraPayment) || 0, residualValue: form.type === "lease" && form.residualValue ? parseFloat(form.residualValue) : null, accountId: form.accountId ? parseInt(form.accountId) : null }) });
-    if (!res.ok) {
-      // e.g. payment below the period interest — surface the server's message.
-      const body = await res.json().catch(() => null);
-      setErrors({ ...errors, form: body?.error ?? "Failed to create loan" });
+    if (saving || !validateForm()) return;
+    const from = editingLoan?.currency;
+    const to = form.currency || displayCurrency;
+    // Changing the currency of an EXISTING loan reinterprets its stored
+    // numbers rather than converting them — confirm before that lands.
+    if (editingLoan && from && from !== to) {
+      setPendingRedenominate({ from, to });
       return;
     }
-    setDialogOpen(false);
-    setForm({ name: "", type: "mortgage", principal: "", currency: displayCurrency, annualRate: "", termMonths: "", startDate: "", paymentAmount: "", paymentFrequency: "monthly", extraPayment: "0", residualValue: "", accountId: "" });
-    setErrors({});
-    load();
+    await doSave();
   }
 
   async function handleDelete() {
@@ -259,15 +355,16 @@ function LoansPageContent() {
           <h1 className="text-2xl font-bold">Loans & Debt</h1>
           <p className="text-sm text-muted-foreground mt-1">Track balances, amortization schedules, and payoff strategies</p>
         </div>
-        {/* `displayCurrency` starts at the USD default and only resolves once
-            /api/auth/session lands, so the useState initializer above captures
-            USD for everyone. Re-seed on open — otherwise a RUB user is shown
-            USD preselected and the form SENDS it, persisting the wrong
-            currency rather than merely displaying one. */}
-        <Dialog open={dialogOpen} onOpenChange={(open) => { if (open) setForm((f) => ({ ...f, currency: displayCurrency })); setDialogOpen(open); }}>
-          <DialogTrigger render={<Button id="add-loan-btn" />}><Plus className="h-4 w-4 mr-1" /> Add Loan</DialogTrigger>
+        {/* Opening is routed through openCreate/openEdit rather than a
+            DialogTrigger, so the form is seeded before the dialog paints.
+            `displayCurrency` starts at the USD default and only resolves once
+            /api/auth/session lands, so seeding at open (not at useState) is
+            what stops a RUB user being shown USD preselected — the form SENDS
+            that value, persisting the wrong currency rather than displaying it. */}
+        <Button id="add-loan-btn" onClick={openCreate}><Plus className="h-4 w-4 mr-1" /> Add Loan</Button>
+        <Dialog open={dialogOpen} onOpenChange={(open) => { setDialogOpen(open); if (!open) setEditingLoan(null); }}>
           <DialogContent>
-            <DialogHeader><DialogTitle>Add Loan</DialogTitle></DialogHeader>
+            <DialogHeader><DialogTitle>{editingLoan ? "Edit Loan" : "Add Loan"}</DialogTitle></DialogHeader>
             <form onSubmit={handleSubmit} className="space-y-3">
               <div className="grid grid-cols-2 gap-3">
                 <div>
@@ -365,8 +462,15 @@ function LoansPageContent() {
                   className="w-full"
                 />
               </div>
+              {editingLoan && form.currency !== editingLoan.currency && (
+                <p className="text-xs text-amber-600 dark:text-amber-500">
+                  Changing the currency re-labels the amounts above as {form.currency}. It does not convert them.
+                </p>
+              )}
               {errors.form && <p className="text-xs text-destructive">{errors.form}</p>}
-              <Button type="submit" className="w-full" disabled={!isFormValid}>Add Loan</Button>
+              <Button type="submit" className="w-full" disabled={!isFormValid || saving}>
+                {saving ? "Saving…" : editingLoan ? "Save changes" : "Add Loan"}
+              </Button>
             </form>
           </DialogContent>
         </Dialog>
@@ -442,6 +546,7 @@ function LoansPageContent() {
                 </div>
                 <div className="flex gap-2">
                   <Button variant="outline" size="sm" onClick={() => viewAmortization(loan)}>View Schedule</Button>
+                  <Button variant="ghost" size="icon" className="h-8 w-8" aria-label={`Edit loan ${loan.name}`} onClick={() => openEdit(loan)}><Pencil className="h-4 w-4" /></Button>
                   <Button variant="ghost" size="icon" className="h-8 w-8 text-destructive" aria-label={`Delete loan ${loan.name}`} onClick={() => setDeleteId(loan.id)}><Trash2 className="h-4 w-4" /></Button>
                 </div>
               </div>
@@ -544,6 +649,27 @@ function LoansPageContent() {
           </CardContent>
         </Card>
       )}
+
+      {/* Re-denomination is not a conversion: the stored numbers stay put and
+          only their currency label changes. That is the right primitive for
+          repairing a loan booked in the wrong currency, but it silently
+          restates the debt if the user expected a conversion. */}
+      <ConfirmDialog
+        open={pendingRedenominate !== null}
+        onOpenChange={(open) => { if (!open) setPendingRedenominate(null); }}
+        title="Change loan currency?"
+        description={
+          <>
+            This re-labels the loan from <strong>{pendingRedenominate?.from}</strong> to{" "}
+            <strong>{pendingRedenominate?.to}</strong>. The amounts are <strong>not</strong> converted —
+            a principal of {form.principal || "0"} stays {form.principal || "0"}, now read as{" "}
+            {pendingRedenominate?.to}.
+          </>
+        }
+        confirmLabel="Change currency"
+        busy={saving}
+        onConfirm={doSave}
+      />
 
       <ConfirmDialog
         open={deleteId !== null}

--- a/src/app/api/loans/route.ts
+++ b/src/app/api/loans/route.ts
@@ -16,6 +16,8 @@ import { validateBody, safeErrorMessage, logApiError } from "@/lib/validate";
 import { buildNameFields, decryptNamedRows, encryptOptional, decryptOptional } from "@/lib/crypto/encrypted-columns";
 import { verifyOwnership, OwnershipError } from "@/lib/verify-ownership";
 import { todayISO } from "@/lib/utils/date";
+import { getDisplayCurrency, getRateMap, convertWithRateMap } from "@/lib/fx-service";
+import { pickRecordCurrency } from "@/lib/fx/record-currency";
 // Issue #213 — shared YYYY-MM-DD validator (regex + leap-year/Feb-30 round-trip).
 import { ymdDate, parseYmdSafe } from "../../../../mcp-server/lib/date-validators";
 
@@ -120,6 +122,20 @@ export async function GET(request: NextRequest) {
   const acctBalances = await getLinkedAccountBalances(userId, linkedIds);
   const today = todayISO();
 
+  // FINLYNQ-123 dual basis: every amount below stays in the LOAN's own
+  // currency (that's what the schedule was computed in), and each row also
+  // carries a current-rate conversion into the display currency so the page
+  // can total across a mixed-currency book. Summing the native figures under
+  // one label — which is what the page used to do — reports an ₽8.1M mortgage
+  // as $8.1M.
+  const displayCurrency = await getDisplayCurrency(
+    userId,
+    request.nextUrl.searchParams.get("currency"),
+  );
+  const rateMap = await getRateMap(displayCurrency, userId);
+  const toDisplay = (amount: number | null, from: string | null) =>
+    amount == null ? null : convertWithRateMap(amount, from ?? displayCurrency, rateMap);
+
   // Add amortization summary for each loan
   const withSummary = loans.map((loan) => {
     const integrityRow = (error: string, value: unknown) => ({
@@ -132,6 +148,9 @@ export async function GET(request: NextRequest) {
       interestPaid: null,
       periodsRemaining: null,
       balanceSource: null,
+      displayCurrency,
+      remainingBalanceDisplay: null,
+      monthlyEquivalentPaymentDisplay: null,
       dataIntegrity: { error, value },
     });
     // Issue #213 — guard against legacy bad start_date so the whole list
@@ -212,6 +231,14 @@ export async function GET(request: NextRequest) {
           : Math.round(principalPaid * 100) / 100,
       interestPaid: Math.round(interestPaid * 100) / 100,
       periodsRemaining,
+      // Additive reporting-currency companions — the native fields above are
+      // untouched, so nothing that already read this response changes.
+      displayCurrency,
+      remainingBalanceDisplay: toDisplay(remainingBalance, loan.currency),
+      monthlyEquivalentPaymentDisplay: toDisplay(
+        summary.monthlyEquivalentPayment,
+        loan.currency,
+      ),
     };
   });
 
@@ -279,13 +306,30 @@ export async function POST(request: NextRequest) {
       extraPayment: d.extraPayment ?? 0,
       residualValue: d.residualValue,
     });
+    // Currency resolution (feedback #7): explicit > linked account > display.
+    // Falling through to the column default is what let MCP-created loans land
+    // as CAD; the web form always sends one, but the REST API is public.
+    let accountCurrency: string | null = null;
+    if (d.accountId != null) {
+      const acct = await db
+        .select({ currency: schema.accounts.currency })
+        .from(schema.accounts)
+        .where(and(eq(schema.accounts.id, d.accountId), eq(schema.accounts.userId, userId)))
+        .get();
+      accountCurrency = acct?.currency ?? null;
+    }
+    const currency = pickRecordCurrency({
+      explicit: d.currency,
+      accountCurrency,
+      displayCurrency: await getDisplayCurrency(userId),
+    });
     const enc = buildNameFields(dek, { name: d.name });
     // Stream D Phase 4 — plaintext name dropped.
     const loan = await db.insert(schema.loans).values({
       userId,
       type: d.type,
       accountId: d.accountId || null,
-      ...(d.currency ? { currency: d.currency.toUpperCase() } : {}),
+      currency,
       principal: d.principal,
       annualRate: d.annualRate,
       termMonths: d.termMonths ?? null,

--- a/src/app/api/settings/active-currencies/route.ts
+++ b/src/app/api/settings/active-currencies/route.ts
@@ -71,6 +71,20 @@ async function deriveFromData(userId: string): Promise<string[]> {
   const set = new Set<string>();
   for (const r of accountRows) if (r.currency) set.add(r.currency.toUpperCase());
   for (const r of txRows) if (r.currency) set.add(r.currency.toUpperCase());
+  // Records that carry their OWN currency count as "in use" too (2026-08-05).
+  // Accounts and transactions alone missed money the user genuinely holds in a
+  // currency: a RUB loan (or goal/subscription/budget) for someone with no RUB
+  // account left RUB out of every dropdown, so they could not create another
+  // one from the web — the form's `ensure` only force-includes the value a
+  // record ALREADY has. Same omission as `getActiveCurrencies` in fx-service.
+  for (const table of [schema.loans, schema.goals, schema.subscriptions, schema.budgets]) {
+    const rows = await db
+      .select({ currency: table.currency })
+      .from(table)
+      .where(eq(table.userId, userId))
+      .groupBy(table.currency);
+    for (const r of rows) if (r.currency) set.add(r.currency.toUpperCase());
+  }
   return Array.from(set);
 }
 

--- a/src/db/schema-pg.ts
+++ b/src/db/schema-pg.ts
@@ -356,7 +356,11 @@ export const loans = pgTable("loans", {
   // dropped. Reads via `name_ct` + DEK; exact-match queries via `name_lookup`.
   type: text("type").notNull(),
   accountId: integer("account_id").references(() => accounts.id),
-  currency: text("currency").notNull().default("CAD"),
+  // FINLYNQ-183/284: USD, not CAD. Every write path resolves the currency
+  // explicitly (explicit > linked account > display currency); this default is
+  // only a backstop, and a CAD one silently stamped CAD onto loans created
+  // through MCP, which never sent the column at all.
+  currency: text("currency").notNull().default("USD"),
   principal: doublePrecision("principal").notNull(),
   annualRate: doublePrecision("annual_rate").notNull(),
   // FINLYNQ-136 (Loans v2): nullable — payment-driven loans solve for the

--- a/src/lib/fx-service.ts
+++ b/src/lib/fx-service.ts
@@ -629,7 +629,30 @@ export async function getActiveCurrencies(): Promise<string[]> {
     .groupBy(schema.transactions.currency);
   const txnCurrencies = txnCurrencyRows.map((r) => r.currency);
 
-  return Array.from(new Set([...accountCurrencies, ...txnCurrencies]));
+  // Records that carry their OWN currency must be here too (2026-08-05).
+  // This set is what `getRateMap` iterates, and `convertWithRateMap` falls back
+  // to `rate ?? 1` for anything missing — so a currency absent from this list
+  // converts SILENTLY 1:1 rather than failing. A RUB loan for a user with no
+  // RUB account therefore totalled at ~80x its real value, which is the same
+  // rate=1 trap called out for retired currencies. loans/goals/subscriptions/
+  // budgets are all converted through this map (loans page, spotlight,
+  // dashboard), and none of them were represented.
+  const recordCurrencies: string[] = [];
+  for (const table of [schema.loans, schema.goals, schema.subscriptions, schema.budgets]) {
+    const rows = await db
+      .select({ currency: table.currency })
+      .from(table)
+      .groupBy(table.currency);
+    recordCurrencies.push(...rows.map((r) => r.currency));
+  }
+
+  return Array.from(
+    new Set(
+      [...accountCurrencies, ...txnCurrencies, ...recordCurrencies]
+        .filter((c): c is string => typeof c === "string" && c.trim() !== "")
+        .map((c) => c.trim().toUpperCase()),
+    ),
+  );
 }
 
 export async function getActiveCurrencyPairs(displayCurrency: string): Promise<Array<{ from: string; to: string }>> {

--- a/src/lib/fx/record-currency.ts
+++ b/src/lib/fx/record-currency.ts
@@ -1,0 +1,44 @@
+/**
+ * The currency a NEW record is stored in.
+ *
+ * A record's currency is never a hardcoded default (feedback #7). The rule is
+ * always the same three-step precedence:
+ *
+ *   explicit > owning account's currency > the user's display currency
+ *
+ * It has been re-derived inline at every write site, and every time one of
+ * them skipped a step it persisted the wrong currency rather than merely
+ * rendering it wrong: `POST /api/subscriptions` and both MCP subscription
+ * create paths stamped CAD onto users holding only MXN/USD, and MCP
+ * `manage_loans(op:add)` omitted the column entirely so the DB default filled
+ * in. Only the PRECEDENCE lives here — each caller still fetches the account
+ * row and the display currency itself, because the web routes read through
+ * Drizzle and the MCP tools read through raw `sql`/pg-compat.
+ *
+ * Pure and dependency-free so both surfaces (and their tests) can share it.
+ */
+
+/** Normalize to an ISO-ish uppercase code, or null when there's nothing usable. */
+function normalize(code: string | null | undefined): string | null {
+  const c = (code ?? "").trim().toUpperCase();
+  return c ? c : null;
+}
+
+export function pickRecordCurrency(opts: {
+  /** Currency the caller passed explicitly (form field, tool argument). */
+  explicit?: string | null;
+  /** Currency of the account the record hangs off, when there is one. */
+  accountCurrency?: string | null;
+  /** The user's resolved display currency — the terminal fallback. */
+  displayCurrency: string;
+}): string {
+  return (
+    normalize(opts.explicit) ??
+    normalize(opts.accountCurrency) ??
+    // `displayCurrency` is itself resolved (getDisplayCurrency / the MCP
+    // resolveReportingCurrency), both of which already terminate at USD
+    // (FINLYNQ-183/284). USD here is belt-and-braces for an empty string.
+    normalize(opts.displayCurrency) ??
+    "USD"
+  );
+}

--- a/tests/api/loans.test.ts
+++ b/tests/api/loans.test.ts
@@ -53,6 +53,18 @@ vi.mock("drizzle-orm", () => ({
   eq: vi.fn(), sql: vi.fn(), and: vi.fn(), desc: vi.fn(), asc: vi.fn(), inArray: vi.fn(),
 }));
 
+// The route resolves the display currency and a rate map so each loan can
+// carry a reporting-currency companion alongside its native amounts
+// (FINLYNQ-123). `getDisplayCurrency` reads `schema.settings`, which the `@/db`
+// stub above doesn't model — mock the whole FX surface instead. RUB is priced
+// deliberately far from 1 so a missed conversion can't pass by coincidence.
+vi.mock("@/lib/fx-service", () => ({
+  getDisplayCurrency: vi.fn(async () => "USD"),
+  getRateMap: vi.fn(async () => new Map([["USD", 1], ["RUB", 0.011]])),
+  convertWithRateMap: (amount: number, from: string, map: Map<string, number>) =>
+    amount * (map.get((from ?? "").trim().toUpperCase()) ?? 1),
+}));
+
 // B4 — verifyOwnership runs a real DB query; bypass here since these
 // tests don't seed accounts. authz-ownership.test.ts covers cross-tenant.
 vi.mock("@/lib/verify-ownership", () => ({
@@ -78,7 +90,7 @@ describe("API /api/loans", () => {
   describe("GET", () => {
     it("returns loans with amortization summary", async () => {
       mockDbChain.all!.mockReturnValueOnce([
-        { id: 1, name: "Mortgage", type: "mortgage", principal: 300000, annualRate: 5, termMonths: 360, startDate: "2020-01-01", extraPayment: 0, paymentFrequency: "monthly", accountId: null, accountName: null, paymentAmount: null, note: "" },
+        { id: 1, name: "Mortgage", type: "mortgage", principal: 300000, annualRate: 5, termMonths: 360, startDate: "2020-01-01", extraPayment: 0, paymentFrequency: "monthly", accountId: null, accountName: null, paymentAmount: null, note: "", currency: "RUB" },
       ]);
       mockGenerateAmortization.mockReturnValue({
         monthlyPayment: 1610.46,
@@ -93,9 +105,20 @@ describe("API /api/loans", () => {
       const res = await GET(req);
       const { status, data } = await parseResponse(res);
       expect(status).toBe(200);
-      const loans = data as { monthlyPayment: number; totalInterest: number }[];
+      const loans = data as {
+        monthlyPayment: number; totalInterest: number;
+        currency: string; displayCurrency: string;
+        remainingBalance: number; remainingBalanceDisplay: number;
+      }[];
       expect(loans[0].monthlyPayment).toBe(1610.46);
       expect(loans[0].totalInterest).toBe(279765.6);
+      // Native amounts stay in the loan's own currency; the companion is the
+      // converted one. Before this fix the row carried no currency at all and
+      // the page rendered all of it as the display currency.
+      expect(loans[0].currency).toBe("RUB");
+      expect(loans[0].displayCurrency).toBe("USD");
+      expect(loans[0].remainingBalance).toBeCloseTo(299639.54, 2);
+      expect(loans[0].remainingBalanceDisplay).toBeCloseTo(299639.54 * 0.011, 2);
     });
   });
 

--- a/tests/loan-currency.test.ts
+++ b/tests/loan-currency.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Loan currency: precedence rule + a static wiring gate over the surfaces
+ * that have to honour it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `loans.currency` existed and the REST create path persisted it from day one
+ * (FINLYNQ-136). Everything else quietly dropped it:
+ *
+ *   * MCP `manage_loans(op:add)` omitted the column from its INSERT, so every
+ *     loan created through an assistant took the table default — which was CAD.
+ *   * `manage_loans(op:list)` and `get_debt_payoff_plan` never SELECTed it.
+ *   * The web `/loans` page formatted every amount in the DISPLAY currency, so
+ *     a ₽8,116,000 mortgage rendered as $8,116,000, and totalled native amounts
+ *     across currencies under a single symbol.
+ *
+ * The payoff planner is the one where the numbers, not just the labels, came
+ * out wrong: snowball ORDERS by balance and the `extra_payment` budget is
+ * POOLED across every debt, so an unconverted RUB balance outranked every USD
+ * debt by ~80x and absorbed the whole budget.
+ *
+ * The precedence tests below are pure. The wiring assertions are pure source
+ * reads: they cannot prove runtime behaviour, but they catch the regression
+ * this codebase has actually shipped before — a rule that exists and is
+ * correct while some call site quietly fails to use it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import path from "path";
+import { pickRecordCurrency } from "../src/lib/fx/record-currency";
+import { calculateDebtPayoff, type Debt } from "../src/lib/loan-calculator";
+
+const ROOT = path.resolve(__dirname, "..");
+const HTTP_LOANS = readFileSync(path.join(ROOT, "mcp-server/tools/loans.ts"), "utf8");
+const STDIO_TOOLS = readFileSync(path.join(ROOT, "mcp-server/register-core-tools.ts"), "utf8");
+const REST_LOANS = readFileSync(path.join(ROOT, "src/app/api/loans/route.ts"), "utf8");
+const LOANS_PAGE = readFileSync(path.join(ROOT, "src/app/(app)/loans/page.tsx"), "utf8");
+const SCHEMA = readFileSync(path.join(ROOT, "src/db/schema-pg.ts"), "utf8");
+
+/**
+ * Strip comments — the files below document the very literals some assertions
+ * forbid ("CAD"), so a raw substring match would trip on the prose explaining
+ * why it is gone.
+ */
+function codeOnly(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+describe("pickRecordCurrency — explicit > account > display", () => {
+  it("prefers an explicit code over everything else", () => {
+    expect(
+      pickRecordCurrency({ explicit: "RUB", accountCurrency: "USD", displayCurrency: "EUR" }),
+    ).toBe("RUB");
+  });
+
+  it("falls back to the owning account's currency", () => {
+    expect(
+      pickRecordCurrency({ accountCurrency: "RUB", displayCurrency: "USD" }),
+    ).toBe("RUB");
+  });
+
+  it("falls back to the display currency last", () => {
+    expect(pickRecordCurrency({ displayCurrency: "RUB" })).toBe("RUB");
+  });
+
+  it("normalizes case and whitespace", () => {
+    expect(pickRecordCurrency({ explicit: " rub ", displayCurrency: "USD" })).toBe("RUB");
+  });
+
+  it("treats blank strings as absent rather than as a choice", () => {
+    // An empty form field must not beat the account's real currency.
+    expect(
+      pickRecordCurrency({ explicit: "", accountCurrency: "RUB", displayCurrency: "USD" }),
+    ).toBe("RUB");
+    expect(
+      pickRecordCurrency({ explicit: "   ", accountCurrency: "", displayCurrency: "USD" }),
+    ).toBe("USD");
+  });
+
+  it("never returns CAD unless CAD was actually asked for", () => {
+    expect(pickRecordCurrency({ displayCurrency: "" })).toBe("USD");
+    expect(pickRecordCurrency({ explicit: "CAD", displayCurrency: "USD" })).toBe("CAD");
+  });
+});
+
+describe("debt payoff is only meaningful in one currency", () => {
+  // Pins the behaviour the conversion protects, using the real calculator.
+  // 500,000 RUB ≈ $5,500 at ~0.011 — genuinely the SECOND smallest debt here,
+  // but the largest number on the page. Snowball pays smallest-balance first,
+  // so the unconverted figure sends it to the back of the queue.
+  const RUB_TO_USD = 0.011;
+  const native: Debt[] = [
+    { id: 1, name: "RUB loan", balance: 500_000, rate: 6.25, minPayment: 9_000 },
+    { id: 2, name: "USD card", balance: 4_000, rate: 22.0, minPayment: 150 },
+    { id: 3, name: "USD auto", balance: 18_000, rate: 5.0, minPayment: 400 },
+  ];
+  const converted: Debt[] = native.map((d) =>
+    d.id === 1
+      ? { ...d, balance: d.balance * RUB_TO_USD, minPayment: d.minPayment * RUB_TO_USD }
+      : d,
+  );
+
+  it("snowball order changes once balances share a currency", () => {
+    const nativeOrder = calculateDebtPayoff(native, 500, "snowball").order.map((o) => o.name);
+    const convertedOrder = calculateDebtPayoff(converted, 500, "snowball").order.map((o) => o.name);
+    // Unconverted, the RUB loan goes last purely because its NUMBER is biggest
+    // — an ~80x distortion, not a financial judgement.
+    expect(nativeOrder).toEqual(["USD card", "USD auto", "RUB loan"]);
+    // Converted, it takes its real place: second smallest.
+    expect(convertedOrder).toEqual(["USD card", "RUB loan", "USD auto"]);
+  });
+
+  it("avalanche ranks on rate, which is currency-independent", () => {
+    // Rates are percentages, so ordering was always sound — documenting this
+    // keeps a future refactor from "fixing" it by converting the rate.
+    const order = calculateDebtPayoff(converted, 0, "avalanche").order.map((o) => o.name);
+    expect(order[0]).toBe("USD card");
+  });
+});
+
+describe("wiring: every loan surface carries the currency", () => {
+  it("the loans table defaults to USD, not CAD", () => {
+    const loansBlock = SCHEMA.slice(SCHEMA.indexOf('pgTable("loans"'));
+    const currencyLine = codeOnly(loansBlock).split("\n").find((l) => l.includes('currency: text('));
+    expect(currencyLine).toBeDefined();
+    expect(currencyLine).toContain('default("USD")');
+  });
+
+  it("MCP add_loan persists a resolved currency instead of the column default", () => {
+    expect(HTTP_LOANS).toContain("pickRecordCurrency");
+    // The INSERT must name the column; omitting it is the original bug.
+    const insert = HTTP_LOANS.slice(HTTP_LOANS.indexOf("INSERT INTO loans"));
+    expect(insert.slice(0, 400)).toContain("currency");
+  });
+
+  it("both debt-payoff planners SELECT currency and convert before ranking", () => {
+    for (const [label, src] of [["http", HTTP_LOANS], ["stdio", STDIO_TOOLS]] as const) {
+      const start = src.indexOf("get_debt_payoff_plan");
+      expect(start, `${label}: tool not found`).toBeGreaterThan(-1);
+      const body = src.slice(start);
+      const handler = body.slice(0, body.indexOf("get_fx_rate") > -1 ? body.indexOf("get_fx_rate") : 8000);
+      expect(handler, `${label}: SELECT must include currency`).toContain("currency");
+      expect(handler, `${label}: balances must be converted`).toContain("convertWithRateMap");
+      expect(handler, `${label}: needs a rate map`).toContain("getRateMap");
+    }
+  });
+
+  it("no loan surface falls back to a CAD literal", () => {
+    for (const [label, src] of [
+      ["mcp http loans", HTTP_LOANS],
+      ["rest /api/loans", REST_LOANS],
+      ["loans page", LOANS_PAGE],
+    ] as const) {
+      expect(codeOnly(src), `${label} still has a CAD literal`).not.toMatch(/["']CAD["']/);
+    }
+  });
+
+  it("the loans page formats per-loan amounts in the loan's own currency", () => {
+    const code = codeOnly(LOANS_PAGE);
+    // Totals are the ONLY thing allowed to use displayCurrency for money, and
+    // they must read the server-converted companions to do it.
+    expect(code).toContain("remainingBalanceDisplay");
+    expect(code).toContain("monthlyEquivalentPaymentDisplay");
+    expect(code).toContain("formatCurrency(loan.remainingBalance, loan.currency)");
+    // The old bug, verbatim: native balance rendered in the display currency.
+    expect(code).not.toContain("formatCurrency(loan.remainingBalance, displayCurrency)");
+    expect(code).not.toContain("formatCurrency(loan.totalInterest, displayCurrency)");
+  });
+
+  it("REST GET emits the reporting-currency companions", () => {
+    expect(REST_LOANS).toContain("remainingBalanceDisplay");
+    expect(REST_LOANS).toContain("monthlyEquivalentPaymentDisplay");
+    expect(REST_LOANS).toContain("getRateMap");
+  });
+});

--- a/tests/loan-currency.test.ts
+++ b/tests/loan-currency.test.ts
@@ -168,6 +168,26 @@ describe("wiring: every loan surface carries the currency", () => {
     expect(code).not.toContain("formatCurrency(loan.totalInterest, displayCurrency)");
   });
 
+  it("the page can edit a loan, through the SAME dialog as create", () => {
+    const code = codeOnly(LOANS_PAGE);
+    // PUT /api/loans existed from the start but nothing called it — a loan was
+    // create-or-delete only in the browser, so a wrong currency was visible
+    // and unfixable.
+    expect(code).toContain('method: editing ? "PUT" : "POST"');
+    expect(code).toContain("openEdit");
+    // One dialog, one payload builder, keyed off a single `editingLoan` flag:
+    // that is what makes a newly added field editable without extra work. Two
+    // DialogContent blocks (or a second payload shape) would break that.
+    expect(code.match(/<DialogContent>/g) ?? []).toHaveLength(1);
+    expect(code.match(/function buildPayload\(/g) ?? []).toHaveLength(1);
+    // Edit must seed from the NATIVE fields — seeding from the converted
+    // companions would rewrite the principal in the display currency on save.
+    expect(code).toContain("principal: String(loan.principal)");
+    expect(code).not.toContain("String(loan.remainingBalanceDisplay)");
+    // Re-denomination is confirmed, not silent.
+    expect(code).toContain("pendingRedenominate");
+  });
+
   it("REST GET emits the reporting-currency companions", () => {
     expect(REST_LOANS).toContain("remainingBalanceDisplay");
     expect(REST_LOANS).toContain("monthlyEquivalentPaymentDisplay");


### PR DESCRIPTION
Reported via in-app feedback 2026-08-05: a loan created in RUB displayed as USD.

## What was wrong

`loans.currency` and the REST create path have existed since Loans v2, but nothing else honoured them:

- MCP `manage_loans(op:add)` omitted the column from its INSERT, so every assistant-created loan took the table default — CAD.
- `manage_loans(op:list)` and `get_debt_payoff_plan` never SELECTed it.
- The `/loans` page formatted every amount with `displayCurrency`, so a RUB 8,116,000 mortgage rendered as $8,116,000 and the Total Debt tile summed native amounts across currencies under one symbol.

The reporter's diagnosis ("currency is not persisted") was wrong, but the symptom and the impact estimate were right.

## Changes

- **Dual basis everywhere**, matching accounts and transactions: amounts stay in the loan's own currency, with an additive current-rate companion that is the only figure totals may sum (FINLYNQ-123).
- **`get_debt_payoff_plan` converts before ranking, on both transports.** This is a correctness fix, not a labelling one — snowball orders by balance and the single `extra_payment` budget is pooled across every debt, so an unconverted foreign balance outranked every other debt on magnitude alone and absorbed the whole budget. Rates stay unconverted; avalanche was always sound.
- **Precedence extracted** to the pure `pickRecordCurrency` (explicit > linked account > display currency), shared by REST and MCP.
- **Column default CAD → USD** (FINLYNQ-183/284) via a tracked migration. Existing CAD-stamped rows are deliberately not rewritten — "the user chose CAD" and "MCP never sent one" are indistinguishable after the fact; `manage_loans(op:update)` and the new edit dialog are the repair path.
- **Loan editing in the web UI.** `PUT /api/loans` existed since v2 with no caller, so a loan was create-or-delete only in the browser. Create and edit share one `DialogContent` and one `buildPayload()`, switched by an `editingLoan` flag. Currency changes re-denominate rather than convert, behind a `ConfirmDialog`.

## Blast radius beyond loans

Two files affect all users:

- `src/lib/fx-service.ts` — `getActiveCurrencies` derived the FX rate map from accounts and transactions only, and `convertWithRateMap` falls back to `rate ?? 1`. A currency held solely via a loan, goal, subscription or budget therefore converted **silently 1:1**. Spotlight already converts budgets, subscriptions and goals through this map, so they carried the identical latent defect.
- `src/app/api/settings/active-currencies/route.ts` — same omission left those currencies unselectable in every dropdown.

Both now include the four record tables. The added scans are small tables alongside the existing `transactions` GROUP BY.

## Verification on dev

Loans remain behind `DevModeGuard`.

- Snowball ordering came out Card $3,432 → RUB Small $5,636 → Auto $15,696 → Mortgage $98,017. Natively the RUB small loan sorts third on magnitude alone.
- Total Debt reconciled exactly at $122,782.59; pre-fix that tile would have read ~$8,378,268.
- The demo account has no RUB account, so the rate resolving at all confirms the `getActiveCurrencies` fix is live.
- Edit verified end to end: seeds from native fields, save persists, currency change blocks on confirm, Cancel leaves the loan untouched.
- Migration applied and confirmed (`column_default = 'USD'::text`).

Gates: typecheck, 1999 tests, lint at baseline, tool-descriptions, all 16 invariants, production build.
