### PR TITLE
Two DTI numerator corrections found in prod validation

### DIFF
--- a/src/lib/financial-health.ts
+++ b/src/lib/financial-health.ts
@@ -287,14 +287,24 @@ export async function calculateFinancialHealth(
     sql`, `,
   );
 
-  // Realized payments into liability accounts NO loan points at. Positive
-  // amount on a liability = the balance moving back toward zero; `link_id IS
-  // NOT NULL` is what makes it a PAYMENT (its cash leg exists) rather than a
-  // refund or a write-off. Scoping to loan-less accounts is what stops a
-  // transfer into a loan account being counted twice — once scheduled, once
-  // realized. `opening_balance` / `balance_adjustment` are excluded here too:
-  // a positive opening balance on a liability is still a stated balance, not a
-  // payment (the GH #333 bug, mirrored on the other side of zero).
+  // Realized payments into liability accounts NO loan points at. A positive
+  // amount on a liability is the balance moving back toward zero. Scoping to
+  // loan-less accounts is what stops a transfer into a loan account being
+  // counted twice — once scheduled, once realized. `opening_balance` /
+  // `balance_adjustment` are excluded here too: a positive opening balance on a
+  // liability is still a stated balance, not a payment (the GH #333 bug,
+  // mirrored on the other side of zero).
+  //
+  // NO `link_id IS NOT NULL` REQUIREMENT — that was this rewrite's own bug,
+  // caught validating on prod 2026-08-23. Only `createTransferPair` stamps a
+  // link id; a card payment that arrived by IMPORT, or was typed as two
+  // independent rows, carries none. Requiring it dropped all six of the demo's
+  // $1,100 Visa payments ($6,600 against a $3,552 balance), reporting DTI as 0%
+  // and scoring that component a perfect 100 — understating debt, which is the
+  // flattering direction nobody reports. A refund or chargeback also lands here
+  // and also genuinely reduces what is owed, so counting it is not wrong; a
+  // write-off is rare enough not to justify re-introducing a filter that
+  // silently deletes real payments.
   const untrackedRows = asRows(await db.execute(sql`
     SELECT COALESCE(t.currency, a.currency) AS currency,
            SUM(t.amount) AS total
@@ -303,7 +313,6 @@ export async function calculateFinancialHealth(
     WHERE t.user_id = ${userId} AND t.date >= ${twelveStart}
       AND a.type = 'L'
       AND t.amount > 0
-      AND t.link_id IS NOT NULL
       AND (t.kind IS NULL OR t.kind NOT IN (${nonDebtServiceKinds}))
       AND NOT EXISTS (
         SELECT 1 FROM loans l

--- a/src/lib/financial-health.ts
+++ b/src/lib/financial-health.ts
@@ -295,6 +295,15 @@ export async function calculateFinancialHealth(
   // liability is still a stated balance, not a payment (the GH #333 bug,
   // mirrored on the other side of zero).
   //
+  // The loan exclusion is CORRELATED ON DATE, not just on account. A loan
+  // linked to an account only covers the window from its own `start_date`
+  // onward; payments made BEFORE it was opened have no schedule describing
+  // them and must still count. Measured on dev 2026-08-23: a loan created 16
+  // days earlier suppressed that card's entire 12-month history, turning $6,600
+  // of real payments into a $58 prorated sliver and reporting DTI as 0%. The
+  // scheduled path covers `date >= start_date`; the realized path covers the
+  // rest, so the two partition the window instead of one silently eating it.
+  //
   // NO `link_id IS NOT NULL` REQUIREMENT — that was this rewrite's own bug,
   // caught validating on prod 2026-08-23. Only `createTransferPair` stamps a
   // link id; a card payment that arrived by IMPORT, or was typed as two
@@ -317,6 +326,7 @@ export async function calculateFinancialHealth(
       AND NOT EXISTS (
         SELECT 1 FROM loans l
         WHERE l.user_id = ${userId} AND l.account_id = a.id
+          AND t.date >= l.start_date
       )
     GROUP BY COALESCE(t.currency, a.currency)
   `)) as Array<{ currency: string | null; total: number | string }>;

--- a/tests/financial-health-dti.test.ts
+++ b/tests/financial-health-dti.test.ts
@@ -91,6 +91,13 @@ describe("DTI numerator predicate (GH #333)", () => {
     expect(code).toContain("FROM loans l");
   });
 
+  it("correlates the loan exclusion ON DATE so pre-loan payments still count", () => {
+    // A loan covers the window from its own start_date onward. Excluding the
+    // account outright let a loan created 16 days ago erase that card's whole
+    // 12-month payment history ($6,600 -> $58 on dev, DTI reported as 0%).
+    expect(code).toContain("AND t.date >= l.start_date");
+  });
+
   it("does NOT require a link_id on realized payments", () => {
     // Shipped requiring one, and prod validation showed why that was wrong:
     // only `createTransferPair` stamps a link id, so imported and

--- a/tests/financial-health-dti.test.ts
+++ b/tests/financial-health-dti.test.ts
@@ -91,10 +91,13 @@ describe("DTI numerator predicate (GH #333)", () => {
     expect(code).toContain("FROM loans l");
   });
 
-  it("requires a link_id on realized payments", () => {
-    // The cash leg is what makes a positive row on a liability a PAYMENT
-    // rather than a refund or a write-off.
-    expect(code).toContain("t.link_id IS NOT NULL");
+  it("does NOT require a link_id on realized payments", () => {
+    // Shipped requiring one, and prod validation showed why that was wrong:
+    // only `createTransferPair` stamps a link id, so imported and
+    // hand-entered card payments carry none. Requiring it dropped $6,600 of
+    // real Visa payments and reported DTI as 0% — understating debt, the
+    // direction nobody complains about. Must not come back.
+    expect(code).not.toContain("t.link_id IS NOT NULL");
   });
 
   it("drops the 1.2x anomaly backstop it no longer needs", () => {

--- a/tests/lib/financial-health.test.ts
+++ b/tests/lib/financial-health.test.ts
@@ -93,7 +93,7 @@ function buildDb(
       }
       // Order matters: the untracked-payments query CONTAINS a `FROM loans`
       // sub-select, so it must be matched before the standalone loans query.
-      if (repr.includes("t.link_id IS NOT NULL")) {
+      if (repr.includes("FROM loans l")) {
         if (capture) capture.untrackedSql = repr;
         return { rows: dispatch.untrackedPayments ?? [] };
       }
@@ -334,7 +334,11 @@ describe("calculateFinancialHealth — load-bearing branches", () => {
     // The realized-payment query must scope to liabilities NO loan points at,
     // or a transfer into a loan account is counted twice.
     expect(capture.untrackedSql).toContain("NOT EXISTS");
-    expect(capture.untrackedSql).toContain("t.link_id IS NOT NULL");
+    // No link_id requirement: only createTransferPair stamps one, so imported
+    // and hand-entered card payments carry none. Requiring it reported DTI as
+    // 0% against a real card balance (caught on prod 2026-08-23).
+    expect(capture.untrackedSql).not.toContain("t.link_id IS NOT NULL");
+    expect(capture.untrackedSql).toContain("t.amount > 0");
 
     // ~300mo @ 3.2% on 838,194 ≈ 4,060/mo ≈ 48.7K/yr.
     expect(r.totals.totalDebtPayments12m.amount).toBeGreaterThan(40000);


### PR DESCRIPTION
Follow-up to #336. Both are corrections to the DTI rewrite that shipped in it, found by validating against real data rather than by a failing test.

## 1. Don't require a `link_id` on realized debt payments

The realized half of the numerator required `t.link_id IS NOT NULL`, on the reasoning that the cash leg is what makes a positive row on a liability a payment.

Only `createTransferPair` stamps a link id. A card payment that arrived by **import**, or was typed as two independent rows, carries none — so the clause silently dropped real payments. On the prod demo that meant all six $1,100 Visa payments ($6,600 against a $3,552 balance) vanished, reporting DTI as **0%** and scoring that component a perfect 100.

That understates debt, which is the direction nobody reports.

## 2. Correlate the loan exclusion on date

The realized half excluded any liability account a loan pointed at, regardless of when that loan started. A loan only covers the window from its own `start_date` onward; payments made before it was opened have no schedule describing them and were dropped outright.

Measured on dev: a loan created **16 days** earlier suppressed that card's entire 12-month history — $6,600 of real payments became a $58 prorated sliver, DTI 0%.

Now correlated on `t.date >= l.start_date`, so the scheduled and realized paths partition the window instead of one eating the other.

## Verified on dev

Numerator $6,739.51 = $6,600 realized (pre-loan card payments) + $139.51 scheduled (two loans, prorated by months elapsed). Against $38,517 income → **17%**, `reliable: false`, caveat rendered.

Both regressions are pinned by gates that forbid the old clauses returning. The behavioural test's SQL capture was re-keyed off `FROM loans l` — it had matched on the removed clause, so it was silently capturing nothing.

tsc clean · lint 0 errors · invariants 16/16 · 2059 tests passing. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)